### PR TITLE
Add sandbox enforcement and launch mode to clash

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,27 @@
 # clash
 
-A permission enforcement tool for [Claude Code](https://docs.anthropic.com/en/docs/claude-code). Clash intercepts tool usage and enforces permission policies (Allow/Deny/Ask) based on your configuration.
+A permission enforcement tool for [Claude Code](https://docs.anthropic.com/en/docs/claude-code). Clash intercepts tool usage and enforces permission policies (Allow/Deny/Ask) based on your configuration, with optional kernel-enforced sandboxing for runtime restrictions.
 
 ## Features
 
 - **Permission enforcement** - Control which tools Claude Code can use automatically
 - **Hierarchical settings** - Configure permissions at system, project, or user level
+- **Policy engine** - Expressive (entity, verb, noun) rules with deny > ask > allow precedence
+- **Kernel-enforced sandbox** - Runtime filesystem and network restrictions via Landlock + seccomp (Linux) or Seatbelt (macOS)
 - **Plugin mode** - Run as a Claude Code plugin for seamless integration
-- **CLI mode** - Standalone commands for managing settings and permissions
+- **CLI mode** - Launch Claude Code with managed hooks, migrate legacy permissions, and test sandbox policies
+- **Legacy migration** - Convert existing Claude Code permission rules to the new policy format
 
 ## Installation
 
 ### As a Claude Code plugin (recommended)
 
 ```bash
-# Build the project
-cargo build --release
+# Build the plugin (copies binary + plugin manifest to /tmp/clash-dev/)
+just build-plugin
 
 # Use with Claude Code
-claude --plugin-dir /path/to/clash-plugin
+claude --plugin-dir /tmp/clash-dev/clash-plugin/
 ```
 
 ### As a standalone CLI
@@ -27,11 +30,33 @@ claude --plugin-dir /path/to/clash-plugin
 cargo install --path clash
 ```
 
+### Development mode
+
+```bash
+# Build plugin and launch Claude Code with it
+just dev
+```
+
 ## Usage
+
+### Launch mode (recommended)
+
+The `launch` command starts Claude Code with clash managing all hooks and sandbox enforcement:
+
+```bash
+# Launch with default settings
+clash launch
+
+# Launch with a custom policy file
+clash launch --policy ./policy.yaml
+
+# Pass additional arguments to Claude Code
+clash launch -- --debug
+```
 
 ### Plugin mode
 
-When running as a plugin, clash automatically intercepts tool usage and checks permissions:
+When running as a plugin, clash automatically intercepts tool usage via hooks:
 
 ```bash
 claude --plugin-dir /path/to/clash-plugin
@@ -40,18 +65,29 @@ claude --plugin-dir /path/to/clash-plugin
 ### CLI commands
 
 ```bash
-# Check installation status
-clash status
+# Launch Claude Code with clash managing hooks and sandbox
+clash launch [--policy <path>] [-- <claude-args>...]
 
-# Enter a subshell with clash hooks temporarily installed
-clash enter
+# Hook commands (called by Claude Code, not typically invoked directly)
+clash hook pre-tool-use       # Evaluate permissions before tool execution
+clash hook post-tool-use      # Post-execution informational hook
+clash hook permission-request # Auto-approve/deny permission requests
+clash hook notification       # Handle notifications
 
-# Legacy: Install/uninstall hooks (deprecated, use plugin mode)
-clash install
-clash uninstall
+# Sandbox commands
+clash sandbox exec --policy '<json>' --cwd /path -- <command>  # Run command in sandbox
+clash sandbox test --policy '<json>' --cwd /path -- <command>  # Test sandbox interactively
+clash sandbox check                                             # Check platform support
+
+# Migrate legacy permissions to policy format
+clash migrate              # Write policy.yaml to ~/.clash/policy.yaml
+clash migrate --dry-run    # Preview generated policy on stdout
+clash migrate --default deny  # Set default effect (ask, deny, allow)
 ```
 
 ## Configuration
+
+### Legacy permissions (Claude Code settings)
 
 Configure permissions in your Claude Code settings files:
 
@@ -78,20 +114,75 @@ Example permission configuration:
 }
 ```
 
-### Permission patterns
+**Permission patterns:**
 
 - `Tool` - Match any usage of a tool
 - `Tool(prefix:*)` - Match tool usage where the argument starts with prefix
 - `Tool(exact)` - Match exact argument
 
+### Policy engine
+
+The policy engine provides expressive (entity, verb, noun) rules for fine-grained control. Use `clash migrate` to convert legacy permissions to this format.
+
+**Evaluation:** All matching statements are collected, then precedence applies: **deny > ask > allow**. If no statement matches, the configurable default effect is used.
+
+Example policy (YAML):
+
+```yaml
+default: ask
+
+rules:
+  - allow execute git *
+  - allow execute cargo *
+  - deny read .env
+  - deny execute rm -rf *
+```
+
+**Entities:** `*`, `user`, `agent`, `agent:claude`, `service:github-mcp`, etc.
+
+**Verbs:** `read`, `write`, `edit`, `execute`, `delegate`
+
+**Nouns:** File paths, command strings, globs (with `*` and `**`)
+
+**Negation:** `!` inverts entity and noun matching:
+- `deny(!user, read, ~/config/*)` - only users can read config
+- `deny(agent:*, write, !~/code/proj/**)` - agents can't write outside project
+
+### Sandbox policy
+
+The sandbox enforces kernel-level restrictions on processes spawned by Claude Code. Restrictions are inherited by child processes and cannot be removed at runtime.
+
+**Platform backends:**
+- **Linux**: Landlock LSM (filesystem) + seccomp-BPF (syscall filtering)
+- **macOS**: Seatbelt sandbox profiles (SBPL)
+
+Example sandbox policy:
+
+```yaml
+sandbox:
+  default: read + execute
+  network: deny
+  rules:
+    - allow read + write + create + delete in $CWD
+    - deny write + delete + create in $CWD/.git
+    - deny read in $CWD/.env
+```
+
+**Capabilities:** `read`, `write`, `create`, `delete`, `execute` (combined with `+`)
+
+**Path variables:** `$CWD`, `$HOME`, `$TMPDIR`
+
+**Network:** `deny` (default, blocks network access) or `allow`
+
 ## Project structure
 
 ```
 clash/
-├── clash/              # Main CLI binary
-├── clash-plugin/       # Claude Code plugin
-├── claude_settings/    # Settings library (also usable standalone)
-└── clester/            # End-to-end testing tool
+├── clash/              # Main CLI binary (hooks, sandbox, launch, migrate)
+├── clash-plugin/       # Claude Code plugin (hooks.json + skills)
+├── claude_settings/    # Settings library (permissions, policy engine, sandbox types)
+├── clester/            # End-to-end testing tool
+└── plans/              # Design documents and research
 ```
 
 ## Library usage


### PR DESCRIPTION
## Summary

This PR significantly expands clash's capabilities by introducing kernel-enforced sandboxing, a new launch mode for managing Claude Code execution, and a policy engine for fine-grained permission control. The README is updated to reflect these new features and provide comprehensive documentation.

## Key Changes

- **Sandbox enforcement**: Added kernel-level runtime restrictions via Landlock + seccomp (Linux) and Seatbelt (macOS) to enforce filesystem and network policies
- **Launch mode**: New `clash launch` command that starts Claude Code with clash managing all hooks and sandbox enforcement, replacing the need for manual hook installation
- **Policy engine**: Introduced expressive (entity, verb, noun) rule format with deny > ask > allow precedence for fine-grained permission control
- **Legacy migration**: Added `clash migrate` command to convert existing Claude Code permission rules to the new policy format
- **Sandbox commands**: New CLI commands for sandbox testing and policy validation (`sandbox exec`, `sandbox test`, `sandbox check`)
- **Hook commands**: Clarified hook interface with explicit commands (`hook pre-tool-use`, `hook post-tool-use`, etc.) called by Claude Code
- **Build improvements**: Added `just build-plugin` and `just dev` commands for streamlined development workflow

## Notable Implementation Details

- Sandbox policies support path variables (`$CWD`, `$HOME`, `$TMPDIR`) and glob patterns with `*` and `**` wildcards
- Negation syntax (`!`) allows inverted matching for both entities and nouns
- Platform-specific backends abstract away OS differences (Landlock/seccomp vs Seatbelt)
- Policy evaluation collects all matching statements before applying precedence rules
- Legacy permissions are automatically converted to the new policy format with configurable defaults
- Plugin mode continues to work alongside the new launch mode for backward compatibility

https://claude.ai/code/session_01HxDWA6XUW8xXE4tNSoajnk