### PR TITLE
Implement 6 Linear tickets: EMP-57/58, EMP-54, EMP-49, EMP-55, EMP-45, EMP-44

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ fs:
   read + write: subpath(~/.ssh)       # Allow read+write under ~/.ssh
 ```
 
-Capabilities: `read`, `write`, `create`, `delete`, `execute` (combined with `+`)
+Capabilities: `read`, `write`, `create`, `delete`, `execute` (combined with `+`), or `full` as shorthand for all five
 
 **`network`** — `deny` or `allow` (controls network access in the sandbox)
 

--- a/clash-plugin/skills/describe/SKILL.md
+++ b/clash-plugin/skills/describe/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: describe
+description: Describe the active clash policy in human-readable terms
+---
+Read the active policy file:
+
+```bash
+cat ~/.clash/policy.yaml
+```
+
+Then parse and explain the policy in human-readable terms. Cover each of the following:
+
+1. **Default behavior** — What is the default permission behavior (`allow`, `deny`, or `ask`)? What profile is active?
+2. **Profiles** — Which profiles are defined and what does each one include? Show the inheritance chain if profiles use `include:`.
+3. **Rules** — For each rule in the active profile (and inherited profiles), explain:
+   - What effect it has (`allow`, `deny`, or `ask`)
+   - What verb and noun pattern it matches
+   - What inline constraints are in place (filesystem restrictions, network, pipe, redirect, argument constraints)
+4. **Filesystem constraints** — Summarize which paths have which capabilities (`read`, `write`, `create`, `delete`, `execute`, or `full`), and what sandbox restrictions apply to bash commands.
+5. **Effective security posture** — Summarize in plain English what the policy allows and blocks. For example: "This policy allows all file operations within the working directory, blocks git push and destructive git operations, and requires approval for everything else."
+6. **Potential issues** — Note any gaps, overly permissive rules, or misconfigurations. For example: missing deny rules for sensitive paths, overly broad wildcards, or redundant rules.

--- a/clash-plugin/skills/dogfood/SKILL.md
+++ b/clash-plugin/skills/dogfood/SKILL.md
@@ -29,5 +29,3 @@ After running the command, explain to the user:
    - Add `deny bash git checkout main:` / `deny bash git switch main:` to prevent switching to main
    - Add project-specific deny rules for commands they want blocked
    - Adjust the filesystem access profiles for their workflow
-6. Run `clash launch` to start Claude Code with clash enforcing the policy
-7. For local development run `just dev` to rebuild the clash plugin and start a new Claude Code session with that plugin enabled.

--- a/clash/src/handlers.rs
+++ b/clash/src/handlers.rs
@@ -145,12 +145,18 @@ pub fn handle_session_start(input: &SessionStartHookInput) -> anyhow::Result<Hoo
                         ));
                     }
                     Err(e) => {
-                        lines.push(format!("ISSUE: policy.yaml compile error: {}", e));
+                        lines.push(format!(
+                            "ISSUE: policy.yaml compile error: {}. All actions will default to 'ask'.",
+                            e
+                        ));
                     }
                 }
             }
             Err(e) => {
-                lines.push(format!("ISSUE: policy.yaml parse error: {}", e));
+                lines.push(format!(
+                    "ISSUE: policy.yaml parse error: {}. All actions will default to 'ask'.",
+                    e
+                ));
             }
         }
 

--- a/clash/src/policy/sandbox_types.rs
+++ b/clash/src/policy/sandbox_types.rs
@@ -38,6 +38,7 @@ impl Cap {
                 "create" => caps |= Cap::CREATE,
                 "delete" => caps |= Cap::DELETE,
                 "execute" => caps |= Cap::EXECUTE,
+                "full" => caps |= Cap::all(),
                 other => return Err(format!("unknown capability: '{}'", other)),
             }
         }
@@ -249,6 +250,8 @@ mod tests {
             Cap::parse("read + write + create + delete + execute").unwrap(),
             Cap::all()
         );
+        assert_eq!(Cap::parse("full").unwrap(), Cap::all());
+        assert_eq!(Cap::parse("full + read").unwrap(), Cap::all()); // redundant but valid
         assert!(Cap::parse("unknown").is_err());
         assert!(Cap::parse("").is_err());
     }

--- a/clash/src/sandbox/macos.rs
+++ b/clash/src/sandbox/macos.rs
@@ -145,7 +145,14 @@ fn emit_caps_for_path(profile: &mut String, path: &str, caps: Cap, path_match: P
     } else {
         // Without WRITE, emit only the specific sub-operations requested.
         if caps.contains(Cap::CREATE) {
+            // CREATE needs file-write-create plus data/xattr/mode operations
+            // because tools like `cp` must write content and metadata to
+            // newly created files (not just the creation syscall).
             profile.push_str(&format!("(allow file-write-create {})\n", filter));
+            profile.push_str(&format!("(allow file-write-data {})\n", filter));
+            profile.push_str(&format!("(allow file-write-xattr {})\n", filter));
+            profile.push_str(&format!("(allow file-write-mode {})\n", filter));
+            profile.push_str(&format!("(allow file-write-flags {})\n", filter));
         }
         if caps.contains(Cap::DELETE) {
             profile.push_str(&format!("(allow file-write-unlink {})\n", filter));
@@ -169,6 +176,10 @@ fn emit_deny_for_path(profile: &mut String, path: &str, caps: Cap, path_match: P
     } else {
         if caps.contains(Cap::CREATE) {
             profile.push_str(&format!("(deny file-write-create {})\n", filter));
+            profile.push_str(&format!("(deny file-write-data {})\n", filter));
+            profile.push_str(&format!("(deny file-write-xattr {})\n", filter));
+            profile.push_str(&format!("(deny file-write-mode {})\n", filter));
+            profile.push_str(&format!("(deny file-write-flags {})\n", filter));
         }
         if caps.contains(Cap::DELETE) {
             profile.push_str(&format!("(deny file-write-unlink {})\n", filter));

--- a/docs/policy-semantics.md
+++ b/docs/policy-semantics.md
@@ -198,6 +198,13 @@ fs:
 
 Each entry maps a capability set to a filter expression. For bash commands, these become sandbox rules. For non-bash verbs, they act as permission guards (the verb is mapped to a capability and checked against matching entries).
 
+The shorthand `full` can be used in place of `read + write + create + delete + execute`:
+
+```yaml
+fs:
+  full: subpath(.)    # All capabilities under CWD
+```
+
 ---
 
 ## Profile Inheritance


### PR DESCRIPTION
- EMP-57+58: Remove outdated `clash launch` and `just dev` instructions
  from dogfood skill
- EMP-54: Add `full` shorthand for all filesystem capabilities
  (read + write + create + delete + execute) in Cap::parse()
- EMP-49: Add /clash:describe skill to explain the active policy in
  human-readable terms
- EMP-55: Surface policy parse/compile errors to users in both
  session-start context and per-tool-invocation ask reasons
- EMP-45: Add render_human() to DecisionTrace for clear English
  explanations of rule matching, replacing technical trace format in
  user-facing additional_context
- EMP-44: Fix macOS sandbox xattr failure on cp by emitting
  file-write-data, file-write-xattr, file-write-mode, and
  file-write-flags operations when CREATE capability is granted

https://claude.ai/code/session_01UhcD8cax9wxTgg6s2nsgzy