### PR TITLE
Add session start hook and permission mode guidance

### DIFF
--- a/clash-plugin/hooks/hooks.json
+++ b/clash-plugin/hooks/hooks.json
@@ -43,6 +43,16 @@
           }
         ]
       }
+    ],
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/bin/clash hook session-start"
+          }
+        ]
+      }
     ]
   }
 }

--- a/clash/src/handlers.rs
+++ b/clash/src/handlers.rs
@@ -104,6 +104,21 @@ pub fn resolve_via_zulip_or_continue(
 pub fn handle_session_start(input: &SessionStartHookInput) -> anyhow::Result<HookOutput> {
     let mut lines: Vec<String> = Vec::new();
 
+    // 0. Check permission mode and recommend --dangerously-skip-permissions
+    let skip_permissions = input
+        .permission_mode
+        .as_deref()
+        .is_some_and(|m| m.contains("dangerously-skip-permissions"));
+
+    if !skip_permissions {
+        lines.push(
+            "NOTE: Clash is managing permissions for this session. \
+             For the best experience, run Claude Code with --dangerously-skip-permissions \
+             to let Clash be the sole permission handler and avoid double prompting."
+                .into(),
+        );
+    }
+
     // 1. Check policy file
     let policy_contents = match ClashSettings::policy_file() {
         Ok(policy_path) if policy_path.exists() => match std::fs::read_to_string(&policy_path) {
@@ -312,6 +327,37 @@ mod tests {
         assert!(
             ctx.contains("model: claude-sonnet-4-20250514"),
             "got: {ctx}"
+        );
+    }
+
+    #[test]
+    fn test_session_start_recommends_skip_permissions_in_default_mode() {
+        let input = default_session_start_input(); // permission_mode = "default"
+        let output = handle_session_start(&input).unwrap();
+        let context = match &output.hook_specific_output {
+            Some(HookSpecificOutput::SessionStart(s)) => s.additional_context.as_deref(),
+            _ => panic!("expected SessionStart output"),
+        };
+        let ctx = context.expect("should have context");
+        assert!(
+            ctx.contains("--dangerously-skip-permissions"),
+            "should recommend --dangerously-skip-permissions when not in skip mode, got: {ctx}"
+        );
+    }
+
+    #[test]
+    fn test_session_start_no_recommendation_when_skip_permissions() {
+        let mut input = default_session_start_input();
+        input.permission_mode = Some("dangerously-skip-permissions".into());
+        let output = handle_session_start(&input).unwrap();
+        let context = match &output.hook_specific_output {
+            Some(HookSpecificOutput::SessionStart(s)) => s.additional_context.as_deref(),
+            _ => panic!("expected SessionStart output"),
+        };
+        let ctx = context.expect("should have context");
+        assert!(
+            !ctx.contains("NOTE: Clash is managing permissions"),
+            "should NOT recommend --dangerously-skip-permissions when already in skip mode, got: {ctx}"
         );
     }
 }


### PR DESCRIPTION
## Summary
This PR adds a new SessionStart hook to the Clash plugin that provides users with guidance about permission handling when Claude Code is initialized. The hook recommends using the `--dangerously-skip-permissions` flag to avoid double prompting when Clash is managing permissions.

## Changes
- **hooks.json**: Registered a new `SessionStart` hook that triggers the `clash hook session-start` command when a session begins
- **handlers.rs**: Implemented `handle_session_start()` logic that:
  - Checks if the session is running in `--dangerously-skip-permissions` mode
  - Displays a helpful note recommending this flag when not already enabled, to inform users they can streamline the permission workflow
  - Continues with existing policy file validation and other session initialization checks
- **tests**: Added two test cases to verify:
  - The recommendation is shown in default permission mode
  - The recommendation is suppressed when already using `--dangerously-skip-permissions`

## Implementation Details
The permission mode check uses a simple string containment test on the `permission_mode` field. The recommendation is added to the session start output's `additional_context` field, making it visible to users without blocking session initialization.

https://claude.ai/code/session_01U7wQs4qoFXLiafX3SCBXqC