### PR TITLE
Add subtractive capability expressions and `all` keyword

### DIFF
--- a/clash/src/default_policy.yaml
+++ b/clash/src/default_policy.yaml
@@ -26,17 +26,17 @@ profiles:
     rules:
       allow * *: 
         fs:
-          read + write + execute + create + delete: subpath(.)
+          all: subpath(.)
   claude-internal:
     rules:
       allow * *: 
         fs:
-          read + write + execute + create + delete: subpath(~/.claude)
+          all: subpath(~/.claude)
   tmp:
     rules:
       allow * *:
         fs:
-          read + write + execute + create + delete: regex(^(/private)?/tmp) | regex(^(/private)?/var/folders/)
+          all: regex(^(/private)?/tmp) | regex(^(/private)?/var/folders/)
   
   sensitive:
     rules:

--- a/docs/policy-grammar.md
+++ b/docs/policy-grammar.md
@@ -221,11 +221,21 @@ An identifier resolves first as a named profile (composite), then as a named con
 Used in new-format `fs:` keys for capability-scoped filesystem constraints.
 
 ```ebnf
-cap_expr        = cap_name ("+" cap_name)*
-cap_name        = "read" | "write" | "create" | "delete" | "execute"
+cap_expr        = cap_term (('+' | '-') cap_term)*
+cap_term        = "read" | "write" | "create" | "delete" | "execute"
+                | "all" | "full"
 ```
 
-Example: `read + write` matches the `READ | WRITE` capability bitfield.
+The `+` operator adds capabilities, the `-` operator removes them. Removals take precedence over additions (consistent with deny-overrides-allow semantics). `all` and `full` are shorthand for all five capabilities.
+
+Examples:
+
+| Expression | Result |
+|-----------|--------|
+| `read + write` | READ \| WRITE |
+| `all` | READ \| WRITE \| CREATE \| DELETE \| EXECUTE |
+| `all - write` | READ \| CREATE \| DELETE \| EXECUTE |
+| `all - write - delete` | READ \| CREATE \| EXECUTE |
 
 ---
 

--- a/docs/policy-semantics.md
+++ b/docs/policy-semantics.md
@@ -198,11 +198,12 @@ fs:
 
 Each entry maps a capability set to a filter expression. For bash commands, these become sandbox rules. For non-bash verbs, they act as permission guards (the verb is mapped to a capability and checked against matching entries).
 
-The shorthand `full` can be used in place of `read + write + create + delete + execute`:
+The shorthand `all` (or `full`) can be used in place of `read + write + create + delete + execute`, and the `-` operator can remove individual capabilities:
 
 ```yaml
 fs:
-  full: subpath(.)    # All capabilities under CWD
+  all: subpath(.)              # All capabilities under CWD
+  all - write: subpath(/etc)   # Everything except write under /etc
 ```
 
 ---


### PR DESCRIPTION
## Summary
This PR enhances the capability expression syntax to support subtractive operations and introduces `all` as a shorthand for all capabilities. This allows more concise and intuitive permission specifications in sandbox policies.

## Key Changes

- **New `all` keyword**: Added `all` (alongside existing `full`) as a shorthand for all five capabilities (read, write, create, delete, execute)
- **Subtractive syntax**: Implemented support for the `-` operator to remove capabilities from a set, e.g., `all - write` or `all - write - delete`
- **Precedence semantics**: Removals take precedence over additions (consistent with deny-overrides-allow semantics), so `all - write + write` results in all capabilities except write
- **Refactored parser**: Split `Cap::parse()` into a main parser handling operators and a `parse_single()` helper for individual capability names
- **Updated default policy**: Simplified filesystem capability rules from verbose `read + write + execute + create + delete` to concise `all` in three profiles (default, claude-internal, tmp)
- **Enhanced documentation**: Updated grammar and semantics docs with examples and a reference table showing various capability expressions

## Implementation Details

The parser now:
1. Tracks separate `add` and `sub` bitsets for additive and subtractive operations
2. Iterates through the expression character-by-character to identify operators (`+` and `-`)
3. Applies the formula `result = add & !sub` to compute the final capability set
4. Returns an error if the result is empty (prevents invalid expressions like `all - all`)
5. Handles expressions with or without spaces (e.g., both `all - write` and `all-write` work)

## Testing
Added comprehensive test coverage for:
- The `all` keyword
- Subtractive operations (single and multiple)
- Edge cases (empty results, no-op subtractions)
- Expressions without spaces

https://claude.ai/code/session_017kYwr7QNY4NdXWiDMh712T