### PR TITLE
Add --bypass-permissions flag to init command for Claude Code integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,9 @@ clash sandbox test --policy '<json>' --cwd /path -- <command>  # Test sandbox in
 clash sandbox check                                             # Check platform support
 
 # Migrate legacy permissions to policy format
+# Initialize with bypass permissions (recommended for Clash-managed sessions)
+clash init --bypass-permissions
+
 clash migrate              # Write policy.yaml to ~/.clash/policy.yaml
 clash migrate --dry-run    # Preview generated policy on stdout
 clash migrate --default deny  # Set default effect (ask, deny, allow)

--- a/clash/src/main.rs
+++ b/clash/src/main.rs
@@ -181,6 +181,11 @@ enum Commands {
         /// Overwrite an existing policy.yaml file
         #[arg(long)]
         force: bool,
+
+        /// Set bypassPermissions in user-level Claude Code settings so Clash is
+        /// the sole permission handler (avoids double-prompting)
+        #[arg(long)]
+        bypass_permissions: bool,
     },
 
     /// File a bug report to the clash issue tracker
@@ -261,7 +266,10 @@ fn main() -> Result<()> {
             Commands::Launch { policy, args } => run_launch(policy, args),
             Commands::Migrate { dry_run, default } => run_migrate(dry_run, &default),
             Commands::Explain { json, tool, input } => run_explain(json, tool, input),
-            Commands::Init { force } => run_init(force),
+            Commands::Init {
+                force,
+                bypass_permissions,
+            } => run_init(force, bypass_permissions),
             Commands::Policy(cmd) => run_policy(cmd),
             Commands::Bug {
                 title,
@@ -690,7 +698,7 @@ fn run_explain(json_output: bool, tool: Option<String>, input_arg: Option<String
 
 /// Initialize a new clash policy.yaml with safe defaults.
 #[instrument(level = Level::TRACE)]
-fn run_init(force: bool) -> Result<()> {
+fn run_init(force: bool, bypass_permissions: bool) -> Result<()> {
     let path = ClashSettings::policy_file()?;
 
     if path.exists() && !force {
@@ -705,6 +713,28 @@ fn run_init(force: bool) -> Result<()> {
     println!("Wrote default policy to {}", path.display());
     println!("Edit the file to customize rules for your environment.");
 
+    if bypass_permissions {
+        set_bypass_permissions()?;
+    }
+
+    Ok(())
+}
+
+/// Set `bypassPermissions: true` in user-level Claude Code settings.
+///
+/// This tells Claude Code to skip its built-in permission system so Clash
+/// becomes the sole permission handler, avoiding double-prompting.
+fn set_bypass_permissions() -> Result<()> {
+    let claude = claude_settings::ClaudeSettings::new();
+    claude.set_bypass_permissions(claude_settings::SettingsLevel::User, true)?;
+
+    let settings_path = claude
+        .resolver()
+        .settings_path(claude_settings::SettingsLevel::User)?;
+    println!("Set bypassPermissions=true in {}", settings_path.display());
+    println!(
+        "Claude Code will now skip its built-in permission prompts, letting Clash handle all permissions."
+    );
     Ok(())
 }
 

--- a/claude_settings/src/lib.rs
+++ b/claude_settings/src/lib.rs
@@ -442,6 +442,18 @@ impl ClaudeSettings {
         })
     }
 
+    /// Sets bypass_permissions at the specified level.
+    ///
+    /// When enabled, Claude Code starts with permissions bypassed (equivalent to
+    /// `--dangerously-skip-permissions`), letting an external tool like Clash be
+    /// the sole permission handler.
+    #[instrument(level = Level::TRACE, skip(self))]
+    pub fn set_bypass_permissions(&self, level: SettingsLevel, enabled: bool) -> Result<()> {
+        self.update(level, |settings| {
+            settings.bypass_permissions = Some(enabled);
+        })
+    }
+
     /// Sets sandbox enabled/disabled at the specified level.
     #[instrument(level = Level::TRACE, skip(self))]
     pub fn set_sandbox_enabled(&self, level: SettingsLevel, enabled: bool) -> Result<()> {
@@ -784,5 +796,17 @@ mod tests {
 
         let all = manager.list_all().unwrap();
         assert_eq!(all.len(), 2);
+    }
+
+    #[test]
+    fn test_set_bypass_permissions() {
+        let (_temp, manager) = setup_test_manager();
+
+        manager
+            .set_bypass_permissions(SettingsLevel::User, true)
+            .unwrap();
+
+        let read = manager.read(SettingsLevel::User).unwrap().unwrap();
+        assert_eq!(read.bypass_permissions, Some(true));
     }
 }

--- a/claude_settings/src/merge.rs
+++ b/claude_settings/src/merge.rs
@@ -48,6 +48,7 @@ impl Merge for Settings {
             enabled_plugins: merge_option_map(&self.enabled_plugins, &other.enabled_plugins),
             cleanup_period_days: other.cleanup_period_days.or(self.cleanup_period_days),
             language: other.language.clone().or_else(|| self.language.clone()),
+            bypass_permissions: other.bypass_permissions.or(self.bypass_permissions),
             extra: merge_maps(&self.extra, &other.extra),
         }
     }


### PR DESCRIPTION
## Summary
This PR adds support for the `bypassPermissions` setting in Claude Code, allowing Clash to become the sole permission handler and avoid double-prompting users. A new `--bypass-permissions` flag on the `clash init` command automatically configures Claude Code to skip its built-in permission system.

## Key Changes
- **New CLI flag**: Added `--bypass-permissions` to `clash init` command that automatically sets `bypassPermissions: true` in Claude Code's user-level settings
- **Settings support**: Added `bypass_permissions` field to the `Settings` struct with proper serialization/deserialization as `bypassPermissions` (camelCase)
- **Settings management**: Implemented `set_bypass_permissions()` method in `ClaudeSettings` to update the setting at the specified level
- **Merge logic**: Updated settings merge logic to properly handle the new `bypass_permissions` field
- **Builder pattern**: Added `with_bypass_permissions()` helper method to `Settings` for fluent configuration
- **Documentation**: Updated README with recommended usage and added comprehensive doc comments explaining the feature
- **Tests**: Added unit tests for serialization, deserialization, and the settings management functionality

## Implementation Details
- The `bypass_permissions` field is optional and only serialized when explicitly set (using `skip_serializing_if`)
- When enabled, Claude Code starts with permissions bypassed (equivalent to `--dangerously-skip-permissions`), letting Clash handle all permission decisions
- The setting is stored in user-level Claude Code settings, making it persistent across sessions
- The feature is recommended for Clash-managed sessions to provide a unified permission experience

https://claude.ai/code/session_0158HwXvRiTTnsNm1ATnMUcB