### PR TITLE
Improve error messages with colored output, causal chains, and actionable hints

### DIFF
--- a/clash/src/errors.rs
+++ b/clash/src/errors.rs
@@ -1,0 +1,81 @@
+//! User-facing error display.
+//!
+//! Formats anyhow errors with causal chains, colored output, and actionable
+//! help hints extracted from domain-specific error types.
+
+use std::io::{IsTerminal, Write};
+
+use crate::policy::error::{CompileError, PolicyParseError};
+
+/// Display a user-facing error to stderr with optional verbose output.
+///
+/// Format:
+///   error: top-level message
+///     caused by: chain item 1
+///     caused by: chain item 2
+///
+///   hint: actionable suggestion (if available)
+///
+/// When verbose is false and there's a deeper chain, appends:
+///   run with --verbose for full details
+///
+/// When verbose is true, appends the full Debug representation.
+pub fn display_error(err: &anyhow::Error, verbose: bool) {
+    let color = use_color();
+    let mut stderr = std::io::stderr().lock();
+
+    // Top-level error message.
+    if color {
+        let _ = write!(stderr, "\x1b[1;31merror\x1b[0m: {}", err);
+    } else {
+        let _ = write!(stderr, "error: {}", err);
+    }
+    let _ = writeln!(stderr);
+
+    // Causal chain (skip the root error itself).
+    let chain: Vec<_> = err.chain().skip(1).collect();
+    if chain.len() == 1 {
+        if color {
+            let _ = writeln!(stderr, "  \x1b[2mcaused by: {}\x1b[0m", chain[0]);
+        } else {
+            let _ = writeln!(stderr, "  caused by: {}", chain[0]);
+        }
+    } else {
+        for (i, cause) in chain.iter().enumerate() {
+            if color {
+                let _ = writeln!(stderr, "  \x1b[2m{}: {}\x1b[0m", i + 1, cause);
+            } else {
+                let _ = writeln!(stderr, "  {}: {}", i + 1, cause);
+            }
+        }
+    }
+
+    // Extract a help hint from the first matching domain error in the chain.
+    let hint = err.chain().find_map(|cause| {
+        if let Some(e) = cause.downcast_ref::<PolicyParseError>() {
+            return e.help();
+        }
+        if let Some(e) = cause.downcast_ref::<CompileError>() {
+            return e.help();
+        }
+        None
+    });
+
+    if let Some(hint) = hint {
+        if color {
+            let _ = writeln!(stderr, "\n  \x1b[1;36mhint\x1b[0m: {}", hint);
+        } else {
+            let _ = writeln!(stderr, "\n  hint: {}", hint);
+        }
+    }
+
+    if verbose {
+        let _ = writeln!(stderr, "\nFull error chain:\n{:?}", err);
+    } else if !chain.is_empty() {
+        let _ = writeln!(stderr, "\n  run with --verbose for full details");
+    }
+}
+
+fn use_color() -> bool {
+    std::env::var("NO_COLOR").is_err() && std::io::stderr().is_terminal()
+}

--- a/clash/src/lib.rs
+++ b/clash/src/lib.rs
@@ -30,6 +30,7 @@
 //! ```
 
 pub mod audit;
+pub mod errors;
 pub mod handlers;
 pub mod hooks;
 pub mod linear;

--- a/clash/src/main.rs
+++ b/clash/src/main.rs
@@ -1,4 +1,3 @@
-use std::boxed;
 use std::fs::OpenOptions;
 
 use anyhow::{Context, Result};
@@ -252,7 +251,8 @@ fn main() -> Result<()> {
         let resp = match cli.command {
             Commands::Hook(hook_cmd) => {
                 if let Err(e) = hook_cmd.run() {
-                    error!(cmd=?hook_cmd, "Hook error: {}", e);
+                    error!(cmd=?hook_cmd, "Hook error: {:?}", e);
+                    clash::errors::display_error(&e, cli.verbose);
                     std::process::exit(exit_code::BLOCKING_ERROR);
                 }
                 Ok(())
@@ -271,8 +271,8 @@ fn main() -> Result<()> {
             } => run_bug_report(title, description, include_config, include_logs),
         };
         if let Err(err) = resp {
-            error!("{}", err);
-            eprintln!("Error: {}", err);
+            error!("{:?}", err);
+            clash::errors::display_error(&err, cli.verbose);
             std::process::exit(1);
         }
     });

--- a/clash/src/policy/error.rs
+++ b/clash/src/policy/error.rs
@@ -103,6 +103,25 @@ pub enum CompileError {
     ProfileError(String),
 }
 
+impl CompileError {
+    /// Return a help message suggesting how to fix this error, if applicable.
+    pub fn help(&self) -> Option<String> {
+        match self {
+            CompileError::InvalidGlob { pattern, .. } => Some(format!(
+                "check glob pattern '{}': use * for single segment, ** for recursive, ? for single char",
+                pattern
+            )),
+            CompileError::InvalidFilterRegex { pattern, .. } => Some(format!(
+                "check regex '{}': special characters like (, ), [, ] need escaping with \\",
+                pattern
+            )),
+            CompileError::ProfileError(_) => {
+                Some("check profile definitions for missing or circular includes".into())
+            }
+        }
+    }
+}
+
 /// Unified policy error wrapping parse and compile errors.
 #[derive(Debug, thiserror::Error)]
 pub enum PolicyError {


### PR DESCRIPTION
Adds a display_error module that formats anyhow errors with ANSI-colored
output, walks causal chains, extracts help hints from PolicyParseError and
CompileError via downcast_ref, and wires up the existing --verbose flag
for full debug output.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
