### PR TITLE
EMP-78: Build artifacts on release with DotSlash manifest generation

### DIFF
--- a/.github/workflows/dotslash-config.json
+++ b/.github/workflows/dotslash-config.json
@@ -1,0 +1,24 @@
+{
+  "outputs": {
+    "clash": {
+      "platforms": {
+        "macos-aarch64": {
+          "regex": "^clash-aarch64-apple-darwin",
+          "path": "clash"
+        },
+        "macos-x86_64": {
+          "regex": "^clash-x86_64-apple-darwin",
+          "path": "clash"
+        },
+        "linux-x86_64": {
+          "regex": "^clash-x86_64-unknown-linux",
+          "path": "clash"
+        },
+        "linux-aarch64": {
+          "regex": "^clash-aarch64-unknown-linux",
+          "path": "clash"
+        }
+      }
+    }
+  }
+}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,99 @@
+name: Release
+
+on:
+  push:
+    tags: ["v*"]
+
+permissions:
+  contents: write
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    name: Build ${{ matrix.target }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: aarch64-apple-darwin
+            os: macos-latest
+          - target: x86_64-apple-darwin
+            os: macos-13
+          - target: x86_64-unknown-linux-musl
+            os: ubuntu-latest
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install musl-tools
+        if: matrix.target == 'x86_64-unknown-linux-musl'
+        run: sudo apt-get update && sudo apt-get install -y musl-tools
+
+      - name: Install cross-compilation tools
+        if: matrix.target == 'aarch64-unknown-linux-gnu'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-aarch64-linux-gnu
+
+      - name: Add Rust target
+        run: rustup target add ${{ matrix.target }}
+
+      - name: Build
+        env:
+          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
+        run: cargo build --release --target ${{ matrix.target }} -p clash
+
+      - name: Package
+        shell: bash
+        run: |
+          cd target/${{ matrix.target }}/release
+          tar czf ../../../clash-${{ matrix.target }}.tar.gz clash
+          cd ../../..
+          sha256sum clash-${{ matrix.target }}.tar.gz > clash-${{ matrix.target }}.tar.gz.sha256 2>/dev/null || \
+            shasum -a 256 clash-${{ matrix.target }}.tar.gz > clash-${{ matrix.target }}.tar.gz.sha256
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: clash-${{ matrix.target }}
+          path: |
+            clash-${{ matrix.target }}.tar.gz
+            clash-${{ matrix.target }}.tar.gz.sha256
+
+  release:
+    name: Create Release
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          merge-multiple: true
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: artifacts/*
+          generate_release_notes: true
+
+  dotslash:
+    name: Generate DotSlash manifest
+    needs: release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: facebook/dotslash-publish-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          config: .github/workflows/dotslash-config.json
+          tag: ${{ github.ref_name }}


### PR DESCRIPTION
## Summary
- Add GitHub Actions release workflow triggered on `v*` tag push
- Build matrix produces `.tar.gz` archives for 4 platforms (macOS aarch64/x86_64, Linux x86_64-musl/aarch64-gnu)
- SHA256 checksums generated alongside each archive
- Runs `facebook/dotslash-publish-release` to auto-generate DotSlash manifest

## Test plan
- [ ] Push a test tag to verify workflow triggers
- [ ] Verify all 4 platform builds complete
- [ ] Verify checksums are correct
- [ ] Verify DotSlash manifest is attached to release

Closes EMP-78

🤖 Generated with [Claude Code](https://claude.com/claude-code)