### PR TITLE
Fix plugin build and update Quick Start

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,13 +21,10 @@ Clash gives you granular control. Write policy rules that decide what to **allow
 
 ```bash
 # 1. Install (requires Rust toolchain)
-cargo install --path clash
+just install
 
-# 2. Initialize — creates ~/.clash/policy.yaml and installs the plugin
-clash init --bypass-permissions
-
-# 3. Launch Claude Code with clash managing permissions
-clash launch
+# 2. Start Claude Code — clash is now managing permissions
+claude
 ```
 
 That's it. Clash is now intercepting every tool call and evaluating it against your policy. The default policy allows reads and writes within your project, prompts before git commits, and denies destructive operations like `git push`, `git reset --hard`, and `sudo`.

--- a/justfile
+++ b/justfile
@@ -13,7 +13,7 @@ build-plugin-in target_dir:
     rm -rf {{target_dir}}
     plugin="$base/clash-plugin"
     mkdir -p "$plugin/bin"
-    cp -r clash-plugin/ $plugin
+    cp -r clash-plugin/. "$plugin"
     cp target/debug/clash "$plugin/bin/clash"
     echo $plugin
 


### PR DESCRIPTION
## Summary
- Fix `cp -r` in `build-plugin-in` that was double-nesting the plugin directory, causing Claude Code to not find `.claude-plugin/`, hooks, or skills
- Update README Quick Start to use `just install` instead of the broken `cargo install` + `clash init` + `clash launch` flow