### PR TITLE
Update skill definitions to s-expression syntax and add interactive policy e2e tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -436,6 +436,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "shlex",
  "tempfile",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,8 @@ dialoguer = "0.11"
 mac-notification-sys = "0.6"
 notify-rust = "4"
 
+shlex = "1"
+
 # Dev dependencies
 tempfile = "3"
 proptest = "1"

--- a/clash-plugin/skills/allow/SKILL.md
+++ b/clash-plugin/skills/allow/SKILL.md
@@ -7,21 +7,27 @@ Help the user add an **allow** rule to their clash policy.
 ## Steps
 
 1. **Determine the rule** from the conversation context. Prefer broad patterns over narrow ones:
-   - Good: `allow bash git *` (covers all git commands)
-   - Avoid: `allow bash git status` (too narrow, user will hit another prompt soon)
+   - Good: `allow '(exec "git" *)'` (covers all git commands)
+   - Avoid: `allow '(exec "git" "status")'` (too narrow, user will hit another prompt soon)
    - If unsure, ask the user what they want to allow.
    - **Bare verb shortcuts**: if the user wants a common capability, use a bare verb:
      - `clash policy allow edit` — allow editing files in the project
      - `clash policy allow bash` — allow running commands in the project
      - `clash policy allow web` — allow web search and fetch
      - `clash policy allow read` — allow reading files in the project
-   - **Full rule** for specific patterns:
-     - `clash policy allow "bash git *"` — allow all git commands
+   - **S-expression rules** for specific patterns:
+     - Exec: `clash policy allow '(exec "git" *)'` — allow all git commands
+     - Exec with subcommand: `clash policy allow '(exec "git" "push" *)'` — allow git push
+     - Fs: `clash policy allow '(fs read (subpath (env PWD)))'` — allow reads under cwd
+     - Fs with path: `clash policy allow '(fs (subpath "/tmp"))'` — allow all fs ops under /tmp
+     - Fs with env: `clash policy allow '(fs write (subpath (env HOME)))'` — allow writes under home
+     - Net: `clash policy allow '(net "github.com")'` — allow network access to github.com
    - If the request involves a **directory path** or filesystem access (e.g., "allow access to ~/Library/Caches"):
-     - Use `"* *"` as the rule with a `--fs` constraint
-     - Example: `clash policy allow "* *" --fs "full:subpath(~/Library/Caches)"`
-     - Capabilities: `read`, `write`, `create`, `delete`, `execute`, or `full` (all of the above)
-     - Filters: `subpath(path)`, `literal(path)`, `regex(pattern)` — combinable with `|` (or) and `&` (and)
+     - Use an `(fs ...)` s-expression with a `(subpath ...)` path filter
+     - Example: `clash policy allow '(fs (subpath "/Users/me/Library/Caches"))'`
+     - Use `(env HOME)` or `(env PWD)` for dynamic paths: `clash policy allow '(fs (subpath (join (env HOME) "/Library/Caches")))'`
+     - Optionally scope to an operation: `read`, `write`, `create`, `delete`, or combine with `(or read write)`
+   - When unsure about the exact syntax, run `clash policy allow --help` to check available options.
 
 2. **Confirm with the user** before making any changes:
    - Show the exact command that will be run
@@ -29,15 +35,15 @@ Help the user add an **allow** rule to their clash policy.
 
 3. **Dry-run first** to preview the change:
    ```bash
-   clash policy allow "RULE" --dry-run
-   # Or with filesystem constraints:
-   clash policy allow "* *" --fs "full:subpath(~/dir)" --dry-run
+   clash policy allow '(exec "git" *)' --dry-run
+   # Or for filesystem access:
+   clash policy allow '(fs write (subpath (env HOME)))' --dry-run
    ```
    Show the output to the user.
 
 4. **Get confirmation**, then apply:
    ```bash
-   clash policy allow "RULE"
+   clash policy allow '(exec "git" *)'
    ```
 
 5. **Report success** and explain that the rule is now active.
@@ -46,7 +52,6 @@ Help the user add an **allow** rule to their clash policy.
 
 - Always dry-run first and show the result before applying
 - Never suggest rules that override intentional deny rules without explicit user consent
-- Never suggest `allow "* *"` or `allow "bash *"` without explaining the security implications and getting explicit user consent
-- If the user asks to allow something that is currently denied, warn them that deny rules always take precedence (even over constrained allows) and they may need to remove the deny rule first
-- If the user wants an allow rule to override a broader ask, suggest adding inline constraints (url, args, etc.) to the allow rule — constrained allows beat unconstrained asks
-- Prefer scoped rules (e.g., `allow "bash git *"`) over broad wildcards
+- Never suggest `allow '(exec)'` or `allow '(fs)'` (match-anything rules) without explaining the security implications and getting explicit user consent
+- If the user asks to allow something that is currently denied, warn them that deny rules always take precedence (even over allows) and they may need to remove the deny rule first
+- Prefer scoped rules (e.g., `allow '(exec "git" *)'`) over broad wildcards

--- a/clash-plugin/skills/deny/SKILL.md
+++ b/clash-plugin/skills/deny/SKILL.md
@@ -7,25 +7,28 @@ Help the user add a **deny** rule to their clash policy.
 ## Steps
 
 1. **Determine the rule** from the conversation context. Consider what the user wants to block:
-   - Example: `clash policy deny "bash git push*"` (block git push)
-   - Example: `clash policy deny "bash sudo *"` (block sudo commands)
-   - Example: `clash policy deny "* *" --fs "write+delete:subpath(~/important)"` (block writes to a directory)
+   - Exec: `clash policy deny '(exec "git" "push" *)'` (block git push)
+   - Exec broad: `clash policy deny '(exec "sudo" *)'` (block sudo commands)
+   - Fs: `clash policy deny '(fs write (subpath (env HOME)))'` (block writes under home)
+   - Fs scoped: `clash policy deny '(fs (or write delete) (subpath "/important"))'` (block writes and deletes under a directory)
+   - Net: `clash policy deny '(net "evil.com")'` (block network access to a domain)
+   - Bare verbs also work for broad rules: `clash policy deny bash`, `clash policy deny edit`
    - If unsure, ask the user what they want to deny.
 
 2. **Confirm with the user** before making any changes:
    - Show the exact command that will be run
    - Explain what the rule means in plain English
-   - Remind the user that **deny always wins** — this rule will block the action even if a constrained allow or ask rule also matches
+   - Remind the user that **deny always wins** — this rule will block the action even if an allow rule also matches
 
 3. **Dry-run first** to preview the change:
    ```bash
-   clash policy deny "RULE" --dry-run
+   clash policy deny '(exec "git" "push" *)' --dry-run
    ```
    Show the output to the user.
 
 4. **Get confirmation**, then apply:
    ```bash
-   clash policy deny "RULE"
+   clash policy deny '(exec "git" "push" *)'
    ```
 
 5. **Report success** and explain that the deny rule is now active.
@@ -33,6 +36,6 @@ Help the user add a **deny** rule to their clash policy.
 ## Safety guidelines
 
 - Always dry-run first and show the result before applying
-- Explain that deny rules always take precedence, regardless of constraint specificity
-- Warn if the deny rule is very broad (e.g., `deny "bash *"` or `deny "* *"`) as it may block legitimate operations
+- Explain that deny rules always take precedence, regardless of specificity
+- Warn if the deny rule is very broad (e.g., `deny '(exec)'` or `deny '(fs)'`) as it may block legitimate operations
 - Suggest using `ask` instead of `deny` if the user might want to approve the action on a case-by-case basis

--- a/clash-plugin/skills/edit/SKILL.md
+++ b/clash-plugin/skills/edit/SKILL.md
@@ -24,20 +24,22 @@ If the user has already stated what they want to change, proceed. Otherwise, ask
 
 Translate the user's intent into a rule. The effect (allow/deny) is part of the subcommand:
 
-- **Allow**: `clash policy allow "verb noun"` where verb is `bash`, `read`, `write`, `edit`, or `*`, and noun is a glob pattern
-- **Deny**: `clash policy deny "verb noun"`
 - **Bare verb shortcuts**: `clash policy allow edit` (expands to allow editing with cwd-scoped filesystem access)
+- **Exec rules**: `clash policy allow '(exec "git" *)'` — allow all git commands
+- **Fs rules**: `clash policy allow '(fs read (subpath (env PWD)))'` — allow reads under cwd
+- **Net rules**: `clash policy allow '(net "github.com")'` — allow network access to github.com
+- **Deny**: `clash policy deny '(exec "git" "push" *)'` — block git push
 
 Preview the change with `--dry-run`:
 
 ```bash
-clash policy allow "bash git *" --dry-run
+clash policy allow '(exec "git" *)' --dry-run
 ```
 
 Show the preview to the user. After confirmation, apply:
 
 ```bash
-clash policy allow "bash git *"
+clash policy allow '(exec "git" *)'
 ```
 
 To target a specific profile, add `--profile NAME`.
@@ -47,42 +49,14 @@ To target a specific profile, add `--profile NAME`.
 Preview the removal:
 
 ```bash
-clash policy remove "allow bash *" --dry-run
+clash policy remove '(allow (exec "git" *))' --dry-run
 ```
 
 After confirmation:
 
 ```bash
-clash policy remove "allow bash *"
+clash policy remove '(allow (exec "git" *))'
 ```
-
-## Removing or changing constraints on a rule
-
-There is no single command to remove a constraint (e.g., `url`, `args`, `fs`) from a rule.
-Use a remove-then-re-add workflow:
-
-1. Remove the existing rule (this deletes the rule and all its constraints):
-
-```bash
-clash policy remove "allow bash *"
-```
-
-2. Re-add the rule — either without constraints, or with only the constraints you want to keep:
-
-```bash
-# No constraints:
-clash policy allow "bash *"
-
-# With specific constraints:
-clash policy allow "bash *" --fs "full:subpath(~/dir)" --url "example.com" --args "--safe-flag"
-```
-
-Available inline constraint flags:
-- `--fs` — filesystem constraints as `"caps:filter_expr"` (e.g., `"full:subpath(~/dir)"`, `"read+write:subpath(.)"`)
-- `--url` — domain patterns (e.g., `"github.com"`, `"!evil.com"` to forbid)
-- `--args` — argument constraints (e.g., `"--dry-run"`, `"!--delete"` to forbid)
-- `--pipe` — allow piped input (boolean flag)
-- `--redirect` — allow output redirection (boolean flag)
 
 ## Validating changes
 

--- a/clester/Cargo.toml
+++ b/clester/Cargo.toml
@@ -11,3 +11,4 @@ serde_json = { workspace = true }
 serde_yaml = { workspace = true }
 tempfile = { workspace = true }
 clap = { workspace = true }
+shlex = { workspace = true }

--- a/clester/README.md
+++ b/clester/README.md
@@ -1,0 +1,365 @@
+# clester
+
+End-to-end testing tool for clash. Simulates Claude Code hook invocations and CLI commands against the clash binary, then asserts on the results.
+
+## Quick Start
+
+```bash
+just clester          # run all e2e tests
+just clester -v       # verbose (show stdout/stderr)
+just ci               # full CI (unit tests + clippy + e2e)
+```
+
+## Writing Tests
+
+Test scripts are YAML files in `clester/tests/scripts/`. Each script defines an isolated test environment (policy, settings), a sequence of steps (hook invocations or CLI commands), and expected outcomes.
+
+### Minimal Example
+
+```yaml
+meta:
+  name: git commands are allowed
+
+clash:
+  policy_sexpr: |
+    (default deny "main")
+    (policy "main"
+      (allow (exec "git" *)))
+
+steps:
+  - name: git status is allowed
+    hook: pre-tool-use
+    tool_name: Bash
+    tool_input:
+      command: git status
+    expect:
+      decision: allow
+
+  - name: npm is denied
+    hook: pre-tool-use
+    tool_name: Bash
+    tool_input:
+      command: npm install
+    expect:
+      decision: deny
+```
+
+## Script Format
+
+### `meta`
+
+Required. Test metadata.
+
+```yaml
+meta:
+  name: human-readable test name    # required
+  description: optional details     # optional
+```
+
+### `clash`
+
+Optional. Configures the clash policy for the test. Use `policy_sexpr` for s-expression policies (current format).
+
+```yaml
+clash:
+  policy_sexpr: |
+    (default deny "main")
+    (policy "main"
+      (allow (exec "git" *))
+      (deny (exec "git" "push" *))
+      (allow (fs read (subpath "/tmp")))
+      (allow (net "github.com")))
+```
+
+### `settings`
+
+Optional. Configures Claude Code settings files at user, project, and project-local levels.
+
+```yaml
+settings:
+  user:                        # ~/.claude/settings.json
+    permissions:
+      allow: ["Bash(git:*)"]
+      deny: ["Read(.env)"]
+  project:                     # .claude/settings.json
+    permissions:
+      deny: ["Bash(rm:*)"]
+  project_local:               # .claude/settings.local.json
+    permissions:
+      allow: ["Bash(npm:*)"]
+```
+
+### `steps`
+
+Required. An ordered list of steps. Each step is either a **hook step** (simulates a Claude Code hook invocation) or a **command step** (runs a clash CLI command). Every step must have exactly one of `hook` or `command`.
+
+## Step Types
+
+### Hook Steps
+
+Simulate Claude Code calling clash via hooks. Use these to test policy evaluation — whether a given tool invocation would be allowed, denied, or asked.
+
+```yaml
+- name: descriptive step name
+  hook: pre-tool-use              # hook type (see below)
+  tool_name: Bash                 # Claude Code tool name
+  tool_input:                     # tool-specific input
+    command: git status
+  expect:
+    decision: allow               # expected policy decision
+```
+
+**Hook types:**
+
+| Hook | Purpose |
+|------|---------|
+| `pre-tool-use` | Evaluate policy before a tool runs (returns allow/deny/ask) |
+| `post-tool-use` | Notify after a tool runs (informational, no decision) |
+| `permission-request` | Handle a permission prompt (returns allow/deny/ask) |
+| `notification` | Handle a notification event (informational) |
+
+**Tool names and inputs:**
+
+```yaml
+# Bash — command execution
+tool_name: Bash
+tool_input:
+  command: git status
+
+# Read — file reading
+tool_name: Read
+tool_input:
+  file_path: /etc/passwd
+
+# Write — file writing
+tool_name: Write
+tool_input:
+  file_path: /tmp/output.txt
+  content: hello world
+
+# Edit — file editing
+tool_name: Edit
+tool_input:
+  file_path: /tmp/file.txt
+  old_string: foo
+  new_string: bar
+
+# WebFetch — HTTP requests
+tool_name: WebFetch
+tool_input:
+  url: "https://github.com"
+
+# WebSearch — web search
+tool_name: WebSearch
+tool_input:
+  query: "test query"
+```
+
+### Command Steps
+
+Run clash CLI commands directly. Use these to test interactive policy modification — adding, removing, or inspecting rules mid-test.
+
+```yaml
+- name: add an allow rule
+  command: policy allow '(exec "npm" *)'
+  expect:
+    exit_code: 0
+```
+
+The `command` value is the arguments to `clash` (not including `clash` itself). It's parsed with shell-style quoting, so single quotes work for s-expressions.
+
+**Common commands:**
+
+```yaml
+# Add rules
+command: policy allow '(exec "npm" *)'
+command: policy deny '(exec "git" "push" *)'
+command: policy allow '(fs read (subpath "/tmp"))'
+
+# Remove rules
+command: policy remove '(allow (exec "npm" *))'
+
+# Preview without persisting
+command: policy allow '(exec "npm" *)' --dry-run
+
+# Inspect the policy
+command: policy list
+command: policy explain bash "git push"
+command: status
+```
+
+## Assertions
+
+Every step has an `expect` block. All fields are optional — only specified fields are checked.
+
+```yaml
+expect:
+  decision: allow           # expected policy decision: "allow", "deny", or "ask"
+  exit_code: 0              # expected process exit code (default: not checked)
+  no_decision: true         # expect no hook-specific output (for post-tool-use/notification)
+  reason_contains: "policy" # substring match on the decision reason
+  stdout_contains: "(allow" # substring match on stdout
+  stderr_contains: "warning" # substring match on stderr
+```
+
+| Field | Use with | Purpose |
+|-------|----------|---------|
+| `decision` | hook steps | Check the policy decision (allow/deny/ask) |
+| `exit_code` | both | Check the process exit code |
+| `no_decision` | hook steps | Verify no decision was returned (informational hooks) |
+| `reason_contains` | hook steps | Substring match on the decision reason |
+| `stdout_contains` | command steps | Substring match on stdout |
+| `stderr_contains` | command steps | Substring match on stderr |
+
+## Patterns
+
+### Testing static policies
+
+Set up a policy and verify tool invocations are evaluated correctly:
+
+```yaml
+clash:
+  policy_sexpr: |
+    (default deny "main")
+    (policy "main"
+      (allow (exec "git" *))
+      (deny (fs read "/etc/passwd")))
+
+steps:
+  - name: git is allowed
+    hook: pre-tool-use
+    tool_name: Bash
+    tool_input: { command: git status }
+    expect: { decision: allow }
+
+  - name: reading /etc/passwd is denied
+    hook: pre-tool-use
+    tool_name: Read
+    tool_input: { file_path: "/etc/passwd" }
+    expect: { decision: deny }
+```
+
+### Testing interactive policy changes
+
+Modify the policy mid-test and verify the changes take effect:
+
+```yaml
+clash:
+  policy_sexpr: |
+    (default deny "main")
+    (policy "main"
+      (allow (exec "git" *)))
+
+steps:
+  # Baseline
+  - name: npm is denied
+    hook: pre-tool-use
+    tool_name: Bash
+    tool_input: { command: npm install }
+    expect: { decision: deny }
+
+  # Modify policy
+  - name: allow npm
+    command: policy allow '(exec "npm" *)'
+    expect: { exit_code: 0 }
+
+  # Verify change took effect
+  - name: npm is now allowed
+    hook: pre-tool-use
+    tool_name: Bash
+    tool_input: { command: npm install }
+    expect: { decision: allow }
+```
+
+### Testing dry-run (no side effects)
+
+Verify that `--dry-run` previews changes without persisting them:
+
+```yaml
+steps:
+  - name: dry-run shows the new rule
+    command: policy allow '(exec "npm" *)' --dry-run
+    expect:
+      exit_code: 0
+      stdout_contains: "(allow (exec \"npm\" *))"
+
+  - name: npm is still denied (dry-run didn't persist)
+    hook: pre-tool-use
+    tool_name: Bash
+    tool_input: { command: npm install }
+    expect: { decision: deny }
+```
+
+### Testing deny overrides allow
+
+Verify that deny rules take precedence:
+
+```yaml
+clash:
+  policy_sexpr: |
+    (default deny "main")
+    (policy "main"
+      (allow (exec "git" *)))
+
+steps:
+  - name: git push is allowed (baseline)
+    hook: pre-tool-use
+    tool_name: Bash
+    tool_input: { command: git push origin main }
+    expect: { decision: allow }
+
+  - name: deny git push
+    command: policy deny '(exec "git" "push" *)'
+    expect: { exit_code: 0 }
+
+  - name: git push is now denied
+    hook: pre-tool-use
+    tool_name: Bash
+    tool_input: { command: git push origin main }
+    expect: { decision: deny }
+
+  - name: git status is still allowed
+    hook: pre-tool-use
+    tool_name: Bash
+    tool_input: { command: git status }
+    expect: { decision: allow }
+```
+
+## How It Works
+
+Each test script runs in an isolated environment:
+
+```
+/tmp/clester-XXXXX/
+├── home/                  <- $HOME for the test
+│   ├── .claude/
+│   │   └── settings.json  <- from settings.user
+│   └── .clash/
+│       └── policy.sexpr   <- from clash.policy_sexpr
+└── project/               <- cwd for the test
+    ├── .claude/
+    │   ├── settings.json  <- from settings.project
+    │   └── settings.local.json
+    └── .git/              <- so clash finds the project root
+```
+
+- `HOME` is set to the temp `home/` directory, so clash reads/writes `$HOME/.clash/policy.sexpr` in isolation.
+- `CLASH_CONFIG` and `CLASH_POLICY_FILE` are removed to prevent system config from leaking in.
+- Command steps that modify the policy (e.g., `policy allow`) write to the same `policy.sexpr` file that subsequent hook steps read from — this is how interactive policy changes are tested.
+- The temp directory is cleaned up when the test finishes.
+
+## Running
+
+```bash
+# Run all tests
+just clester
+
+# Run a single test
+./target/debug/clester run clester/tests/scripts/v2_basic.yaml
+
+# Run with verbose output
+just clester -v
+
+# Validate scripts without executing
+./target/debug/clester validate clester/tests/scripts/
+```

--- a/clester/tests/scripts/v2_policy_allow.yaml
+++ b/clester/tests/scripts/v2_policy_allow.yaml
@@ -1,0 +1,78 @@
+meta:
+  name: v2 interactive policy — allow command
+  description: >
+    Test that `clash policy allow` modifies the policy at runtime
+    and subsequent hook invocations respect the new rules.
+
+clash:
+  policy_sexpr: |
+    (default deny "main")
+    (policy "main"
+      (allow (exec "git" *)))
+
+steps:
+  # Baseline: git is allowed, npm is denied
+  - name: git status is allowed (baseline)
+    hook: pre-tool-use
+    tool_name: Bash
+    tool_input:
+      command: git status
+    expect:
+      decision: allow
+
+  - name: npm install is denied (baseline)
+    hook: pre-tool-use
+    tool_name: Bash
+    tool_input:
+      command: npm install
+    expect:
+      decision: deny
+
+  # Dry-run: preview adding npm allow
+  - name: dry-run allow npm
+    command: policy allow '(exec "npm" *)' --dry-run
+    expect:
+      exit_code: 0
+      stdout_contains: "(allow (exec \"npm\" *))"
+
+  # npm should still be denied (dry-run doesn't persist)
+  - name: npm install still denied after dry-run
+    hook: pre-tool-use
+    tool_name: Bash
+    tool_input:
+      command: npm install
+    expect:
+      decision: deny
+
+  # Actually add the allow rule
+  - name: allow npm commands
+    command: policy allow '(exec "npm" *)'
+    expect:
+      exit_code: 0
+
+  # Verify npm is now allowed
+  - name: npm install is now allowed
+    hook: pre-tool-use
+    tool_name: Bash
+    tool_input:
+      command: npm install
+    expect:
+      decision: allow
+
+  # Verify git is still allowed
+  - name: git status still allowed
+    hook: pre-tool-use
+    tool_name: Bash
+    tool_input:
+      command: git status
+    expect:
+      decision: allow
+
+  # Verify unrelated commands are still denied
+  - name: curl still denied
+    hook: pre-tool-use
+    tool_name: Bash
+    tool_input:
+      command: curl https://example.com
+    expect:
+      decision: deny

--- a/clester/tests/scripts/v2_policy_deny.yaml
+++ b/clester/tests/scripts/v2_policy_deny.yaml
@@ -1,0 +1,54 @@
+meta:
+  name: v2 interactive policy — deny command
+  description: >
+    Test that `clash policy deny` adds deny rules at runtime
+    and that deny rules override allow rules.
+
+clash:
+  policy_sexpr: |
+    (default deny "main")
+    (policy "main"
+      (allow (exec "git" *)))
+
+steps:
+  # Baseline: git push is allowed
+  - name: git push allowed (baseline)
+    hook: pre-tool-use
+    tool_name: Bash
+    tool_input:
+      command: git push origin main
+    expect:
+      decision: allow
+
+  # Deny git push specifically
+  - name: deny git push
+    command: policy deny '(exec "git" "push" *)'
+    expect:
+      exit_code: 0
+
+  # Verify git push is now denied
+  - name: git push is now denied
+    hook: pre-tool-use
+    tool_name: Bash
+    tool_input:
+      command: git push origin main
+    expect:
+      decision: deny
+
+  # Verify git status is still allowed (deny is specific to push)
+  - name: git status still allowed
+    hook: pre-tool-use
+    tool_name: Bash
+    tool_input:
+      command: git status
+    expect:
+      decision: allow
+
+  # Verify git diff is still allowed
+  - name: git diff still allowed
+    hook: pre-tool-use
+    tool_name: Bash
+    tool_input:
+      command: git diff
+    expect:
+      decision: allow

--- a/clester/tests/scripts/v2_policy_explain.yaml
+++ b/clester/tests/scripts/v2_policy_explain.yaml
@@ -1,0 +1,46 @@
+meta:
+  name: v2 interactive policy — explain and list commands
+  description: >
+    Test that `clash policy list` and `clash policy explain`
+    produce useful output for inspecting the active policy.
+
+clash:
+  policy_sexpr: |
+    (default deny "main")
+    (policy "main"
+      (allow (exec "git" *))
+      (deny (exec "git" "push" *)))
+
+steps:
+  # List the active policy
+  - name: list shows rules
+    command: policy list
+    expect:
+      exit_code: 0
+      stdout_contains: "git"
+
+  # Explain a command that should be allowed
+  - name: explain git status
+    command: policy explain bash "git status"
+    expect:
+      exit_code: 0
+      stdout_contains: allow
+
+  # Explain a command that should be denied
+  - name: explain git push
+    command: policy explain bash "git push origin"
+    expect:
+      exit_code: 0
+      stdout_contains: deny
+
+  # Add a new rule and verify explain reflects it
+  - name: allow npm
+    command: policy allow '(exec "npm" *)'
+    expect:
+      exit_code: 0
+
+  - name: explain npm install after allow
+    command: policy explain bash "npm install"
+    expect:
+      exit_code: 0
+      stdout_contains: allow

--- a/clester/tests/scripts/v2_policy_fs.yaml
+++ b/clester/tests/scripts/v2_policy_fs.yaml
@@ -1,0 +1,55 @@
+meta:
+  name: v2 interactive policy — filesystem rules
+  description: >
+    Test interactive policy changes for filesystem access using
+    s-expression syntax with subpath filters.
+
+clash:
+  policy_sexpr: |
+    (default deny "main")
+    (policy "main"
+      (allow (exec "git" *)))
+
+steps:
+  # Baseline: reads are denied
+  - name: read is denied (baseline)
+    hook: pre-tool-use
+    tool_name: Read
+    tool_input:
+      file_path: /tmp/somefile.txt
+    expect:
+      decision: deny
+
+  # Allow fs reads under /tmp
+  - name: allow reads under /tmp
+    command: policy allow '(fs read (subpath "/tmp"))'
+    expect:
+      exit_code: 0
+
+  # Verify reads under /tmp are now allowed
+  - name: read under /tmp is allowed
+    hook: pre-tool-use
+    tool_name: Read
+    tool_input:
+      file_path: /tmp/somefile.txt
+    expect:
+      decision: allow
+
+  # Verify reads outside /tmp are still denied
+  - name: read outside /tmp is still denied
+    hook: pre-tool-use
+    tool_name: Read
+    tool_input:
+      file_path: /etc/passwd
+    expect:
+      decision: deny
+
+  # Writes should still be denied (we only allowed read)
+  - name: write under /tmp is still denied
+    hook: pre-tool-use
+    tool_name: Write
+    tool_input:
+      file_path: /tmp/output.txt
+      content: hello
+    expect:
+      decision: deny

--- a/clester/tests/scripts/v2_policy_remove.yaml
+++ b/clester/tests/scripts/v2_policy_remove.yaml
@@ -1,0 +1,54 @@
+meta:
+  name: v2 interactive policy — remove command
+  description: >
+    Test that `clash policy remove` removes rules at runtime
+    and subsequent hook invocations reflect the removal.
+
+clash:
+  policy_sexpr: |
+    (default deny "main")
+    (policy "main"
+      (allow (exec "git" *))
+      (allow (fs read)))
+
+steps:
+  # Baseline: both rules active
+  - name: git status allowed (baseline)
+    hook: pre-tool-use
+    tool_name: Bash
+    tool_input:
+      command: git status
+    expect:
+      decision: allow
+
+  - name: read file allowed (baseline)
+    hook: pre-tool-use
+    tool_name: Read
+    tool_input:
+      file_path: /tmp/somefile.txt
+    expect:
+      decision: allow
+
+  # Remove the exec git rule
+  - name: remove git allow rule
+    command: policy remove '(allow (exec "git" *))'
+    expect:
+      exit_code: 0
+
+  # Verify git is now denied (default deny applies)
+  - name: git status now denied
+    hook: pre-tool-use
+    tool_name: Bash
+    tool_input:
+      command: git status
+    expect:
+      decision: deny
+
+  # Verify fs read is still allowed (unaffected)
+  - name: read file still allowed
+    hook: pre-tool-use
+    tool_name: Read
+    tool_input:
+      file_path: /tmp/somefile.txt
+    expect:
+      decision: allow


### PR DESCRIPTION
Fix allow/deny/edit skill definitions that still referenced YAML-era --fs flags
and inline constraint syntax. Replace with current s-expression grammar examples.

Add command step support to clester so tests can run clash CLI commands (policy
allow/deny/remove/list/explain) mid-test and verify the changes take effect in
subsequent hook evaluations. This enables full e2e testing of interactive policy
workflows that were previously untestable.

Changes:
- Skills: replace stale --fs/--url/--args flag syntax with s-expressions
- clester: add `command` step type, `stdout_contains`/`stderr_contains` assertions
- clester: add `run_command()` for CLI invocation with shlex arg parsing
- clester: add step validation (hook vs command mutual exclusivity)
- clester: clear CLASH_POLICY_FILE env to prevent test env leakage
- Add 5 new e2e test scripts covering allow/deny/remove/fs/explain workflows
- Add clester README documenting the test script format
