### PR TITLE
fix: Make clash init idempotent and prevent test binary symlinks

### DIFF
--- a/clash/src/settings.rs
+++ b/clash/src/settings.rs
@@ -51,6 +51,11 @@ impl ClashSettings {
         Self::settings_dir().map(|d| d.join("policy.sexpr"))
     }
 
+    /// Path to a legacy YAML policy file (pre-sexp migration).
+    pub fn legacy_policy_file() -> Result<PathBuf> {
+        Self::settings_dir().map(|d| d.join("policy.yaml"))
+    }
+
     /// Return the policy parse/compile error, if any.
     pub fn policy_error(&self) -> Option<&str> {
         self.policy_error.as_deref()


### PR DESCRIPTION
- clash init now re-enters the wizard if a policy already exists, converts
  legacy YAML policies via claude -p, and launches the wizard on fresh install
- Skip symlinking test binaries (target/debug/deps/) into ~/.local/bin
