### PR TITLE
switch to hotline proxy for bug reporting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ target
 
 # MacOS
 .DS_Store
+
+# env
+.env

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -405,6 +405,7 @@ dependencies = [
  "dialoguer",
  "dirs",
  "figment",
+ "hotln",
  "landlock",
  "lexpr",
  "libc",
@@ -941,6 +942,18 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hotln"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f641ff18588c6cb6f6c7a35f612d9c9fd119d0028ed333d7b61947f279a5b8f"
+dependencies = [
+ "serde_json",
+ "thiserror 2.0.18",
+ "tracing",
+ "ureq",
+]
 
 [[package]]
 name = "http"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ dialoguer = "0.11"
 console = "0.15"
 mac-notification-sys = "0.6"
 notify-rust = "4"
+hotln = "0.1.1"
 
 nu-ansi-term = "0.50"
 reedline = "0.45"

--- a/clash/Cargo.toml
+++ b/clash/Cargo.toml
@@ -29,6 +29,7 @@ lexpr = { workspace = true }
 
 libc = { workspace = true }
 uuid = { workspace = true }
+hotln = { workspace = true }
 ureq = { workspace = true }
 base64 = { workspace = true }
 console = { workspace = true }

--- a/clash/src/lib.rs
+++ b/clash/src/lib.rs
@@ -14,7 +14,6 @@
 //! - [`sandbox`] — Platform-specific (Linux/macOS) sandbox enforcement backends.
 //! - [`audit`] — Structured audit logging of policy decisions.
 //! - [`notifications`] — Desktop notifications and Zulip integration.
-//! - [`linear`] — Linear API client for filing bug reports.
 //!
 //! # Example
 //!
@@ -35,7 +34,6 @@ pub mod cmd;
 pub mod errors;
 pub mod handlers;
 pub mod hooks;
-pub mod linear;
 pub mod network_hints;
 pub mod notifications;
 pub mod permissions;


### PR DESCRIPTION
use our hotln rust crate for bug reporting over a cloudflare worker proxy. for local dev, keeps direct linear api connection if CLASH_HOTLINE_LINEAR_KEY is defined at compile time. 