### PR TITLE
Inline sandbox policies and net-only policies

### DIFF
--- a/.clash/policy.sexpr
+++ b/.clash/policy.sexpr
@@ -2,6 +2,7 @@
 
 (policy "main"
   (allow (exec))
+  (allow (exec "clash" "bug" *) :sandbox (allow (net *)))
   (allow (fs (or read write create delete) (subpath (env PWD))))
   (allow (fs (or read write create delete) (subpath "/var/folders")))
   (allow (exec "ls" "-lha")))

--- a/clash/src/policy/decision_tree.rs
+++ b/clash/src/policy/decision_tree.rs
@@ -738,7 +738,7 @@ mod tests {
     }
 
     #[test]
-    fn implicit_sandbox_none_without_fs_rules() {
+    fn implicit_sandbox_net_only_without_fs_rules() {
         let env = TestEnv::new(&[]);
         let tree = compile_policy_with_env(
             r#"
@@ -751,7 +751,28 @@ mod tests {
         )
         .unwrap();
 
-        // No fs rules → no implicit sandbox
+        // No fs rules but net allowed → sandbox with network allow
+        let sandbox = tree
+            .build_implicit_sandbox()
+            .expect("net-only implicit sandbox should be present");
+        assert_eq!(sandbox.network, NetworkPolicy::Allow);
+        assert!(sandbox.rules.is_empty());
+    }
+
+    #[test]
+    fn implicit_sandbox_none_when_no_rules() {
+        let env = TestEnv::new(&[]);
+        let tree = compile_policy_with_env(
+            r#"
+(default deny "main")
+(policy "main"
+  (allow (exec)))
+"#,
+            &env,
+        )
+        .unwrap();
+
+        // No fs or net rules → no implicit sandbox
         assert!(tree.build_implicit_sandbox().is_none());
     }
 

--- a/docs/policy-semantics.md
+++ b/docs/policy-semantics.md
@@ -49,12 +49,12 @@ DecisionTree (IR)               ← compile.rs
 2. **Find default** — extract the `(default effect "name")` declaration
 3. **Build policy map** — index all `(policy "name" ...)` blocks by name
 4. **Flatten** — recursively resolve `(include ...)` into a flat rule list
-5. **Validate sandbox references** — verify each `:sandbox "name"` points to an existing policy
+5. **Validate sandbox references** — verify each named `:sandbox "name"` points to an existing policy; compile inline `:sandbox (rule ...)` rules immediately
 6. **Group** — split rules by capability domain (exec/fs/net)
 7. **Compile matchers** — convert AST patterns to IR with pre-compiled regexes, resolve `(env NAME)` references
 8. **Sort by specificity** — most specific rules first within each domain
 9. **Detect conflicts** — reject rules with equal specificity but different effects that could match the same request
-10. **Compile sandbox policies** — for each sandbox reference, compile the referenced policy's rules into standalone rule sets
+10. **Compile sandbox policies** — for each named sandbox reference, compile the referenced policy's rules into standalone rule sets (inline sandbox rules are compiled in step 5)
 
 ---
 
@@ -149,7 +149,12 @@ This enables the `clash explain` command and structured audit logging.
 
 ## Sandbox Generation
 
-When an exec allow rule matches with `:sandbox "name"`, the referenced policy's rules are pre-compiled in `sandbox_policies`. These rules define the filesystem and network permissions for the spawned process.
+When an exec allow rule matches with a `:sandbox` annotation, the sandbox rules define the filesystem and network permissions for the spawned process. Sandbox rules can be specified two ways:
+
+- **Named**: `:sandbox "name"` references a `(policy "name" ...)` block whose rules are pre-compiled into `sandbox_policies`.
+- **Inline**: `:sandbox (allow (net *)) (allow (fs ...))` compiles the inline rules directly into `sandbox_policies` under a synthetic key.
+
+Both forms produce the same compiled representation — downstream evaluation is identical.
 
 The sandbox policy is enforced at the kernel level:
 - **Linux**: Landlock LSM restricts file and network access


### PR DESCRIPTION
- allow sandbox policies with only net rules (previously required an fs rule)
- support inline sandbox policies along with named sandbox policies