### PR TITLE
feat: add `clash statusline` for ambient policy visibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,32 @@ For the full command reference, see the [CLI Reference](docs/cli-reference.md).
 
 ---
 
+## Status Line
+
+Clash can display a live scoreboard in Claude Code's status bar, giving you ambient visibility into policy enforcement without interrupting your workflow.
+
+```
+⚡clash ✓12 ✗3 ?1 · ✗ Bash(touch ...)
+  allow with: clash allow '(exec "touch" *)'
+```
+
+The status line shows:
+
+- **Counts**: `✓` allowed, `✗` denied, `?` asked — color-coded green/red/yellow
+- **Last action**: the most recent policy decision with tool name and input summary
+- **Allow hint**: when the last action was denied, a second line shows the narrowest rule to allow it
+
+### Setup
+
+```bash
+clash statusline install     # add status line to Claude Code settings
+clash statusline uninstall   # remove it
+```
+
+After installing, the status line appears automatically in your next Claude Code session.
+
+---
+
 ## Requirements
 
 - **macOS** (Apple Silicon or Intel) or **Linux** (x86_64 or aarch64)

--- a/clash/README.md
+++ b/clash/README.md
@@ -1,3 +1,58 @@
 # clash
 
 The core CLI binary and library. See the [project README](../README.md) for usage and documentation.
+
+## Status Line internals
+
+The `clash statusline` command powers the Claude Code status bar integration. It uses a **stats sidecar** pattern to keep rendering fast regardless of session length.
+
+### Architecture
+
+```
+PreToolUse hook
+  → policy evaluation
+  → log_decision() writes audit.jsonl
+  → update_session_stats() writes stats.json  (atomic: write tmp + rename)
+
+Claude Code (after each assistant message)
+  → clash statusline render
+  → reads stats.json from /tmp/clash-<session_id>/
+  → prints ANSI-colored line to stdout (<10ms)
+```
+
+### Stats sidecar (`stats.json`)
+
+Instead of parsing the growing `audit.jsonl` on every render, the PreToolUse hook maintains a small JSON file with pre-aggregated counters:
+
+```json
+{
+  "allowed": 12,
+  "denied": 3,
+  "asked": 1,
+  "last_tool": "Bash",
+  "last_input_summary": "git status",
+  "last_effect": "allow",
+  "last_at": "1706123456.789",
+  "default_effect": "deny",
+  "last_deny_hint": null
+}
+```
+
+The file is written atomically (write to `.stats.json.tmp`, then `fs::rename`) to prevent partial reads by the concurrent render process.
+
+### Double-count prevention
+
+Stats are updated in the **PreToolUse handler only** (`cmd/hooks.rs`), not inside `log_decision()`. This is intentional: "ask" decisions trigger both PreToolUse and PermissionRequest hooks, and both re-evaluate the policy via `check_permission()` → `log_decision()`. Counting in `log_decision` would double-count asks.
+
+### Deny hints
+
+When a tool is denied, `deny_hint()` generates the narrowest possible allow rule based on the tool type and input:
+
+- `Bash` → `(exec "<binary>" *)` using the first word of the command
+- `Read`/`Write` → `(fs read/write (subpath "<parent>"))` from the file path
+- `WebFetch` → `(net "<domain>")` extracted from the URL
+- Fallback → bare verb shortcuts (`clash allow bash`, etc.)
+
+### Color forcing
+
+The render function calls `console::set_colors_enabled(true)` because Claude Code pipes the status line command's stdout (not a TTY), but the TUI does support ANSI escape codes.

--- a/clash/src/cli.rs
+++ b/clash/src/cli.rs
@@ -1,5 +1,6 @@
 use clap::{Parser, Subcommand};
 
+use crate::cmd::statusline::StatuslineCmd;
 use crate::sandbox_cmd::SandboxCmd;
 
 #[derive(Parser, Debug)]
@@ -274,6 +275,10 @@ pub enum Commands {
         #[arg(long)]
         version: Option<String>,
     },
+
+    /// Display clash status in the Claude Code status line
+    #[command(subcommand)]
+    Statusline(StatuslineCmd),
 
     /// File a bug report to the clash issue tracker
     #[command(alias = "rage", hide = true)]

--- a/clash/src/cmd/mod.rs
+++ b/clash/src/cmd/mod.rs
@@ -7,4 +7,5 @@ pub mod launch;
 pub mod policy;
 pub mod schema;
 pub mod status;
+pub mod statusline;
 pub mod update;

--- a/clash/src/cmd/statusline.rs
+++ b/clash/src/cmd/statusline.rs
@@ -1,0 +1,289 @@
+//! `clash statusline` — ambient policy enforcement visibility.
+//!
+//! Renders a compact scoreboard for the Claude Code status line showing
+//! policy decision counts and the last action taken.
+
+use anyhow::{Context, Result};
+use clap::Subcommand;
+use serde::Deserialize;
+
+use crate::audit::{SessionStats, StatsReadError, read_session_stats};
+use crate::policy::Effect;
+use crate::style;
+
+/// Subcommands for `clash statusline`.
+#[derive(Subcommand, Debug)]
+pub enum StatuslineCmd {
+    /// Render status line (reads JSON from stdin, prints formatted output)
+    Render {
+        /// Output format: "compact" (default) or "full"
+        #[arg(long, default_value = "compact")]
+        format: String,
+    },
+    /// Install the status line into Claude Code settings
+    Install,
+    /// Remove the status line from Claude Code settings
+    Uninstall,
+}
+
+/// JSON payload received on stdin from Claude Code.
+#[derive(Deserialize)]
+struct StdinPayload {
+    session_id: String,
+}
+
+pub fn run(cmd: StatuslineCmd) -> Result<()> {
+    match cmd {
+        StatuslineCmd::Render { format } => render(&format),
+        StatuslineCmd::Install => install(),
+        StatuslineCmd::Uninstall => uninstall(),
+    }
+}
+
+/// Render the status line to stdout.
+///
+/// Expects a JSON payload with `session_id` on stdin. Prints an
+/// ANSI-colored scoreboard, or a diagnostic to stderr on stats errors.
+fn render(format: &str) -> Result<()> {
+    // Claude Code supports ANSI colors in status lines, but stdout is piped
+    // so the console crate would suppress them. Force colors on.
+    console::set_colors_enabled(true);
+
+    let payload: StdinPayload = serde_json::from_reader(std::io::stdin().lock())
+        .context("Failed to read JSON from stdin")?;
+
+    let stats = match read_session_stats(&payload.session_id) {
+        Ok(s) => s,
+        Err(StatsReadError::NotFound) => SessionStats::default(),
+        Err(StatsReadError::Io(e)) => {
+            eprint!("{}clash: stats unreadable: {e}", style::cyan("⚡"));
+            return Ok(());
+        }
+        Err(StatsReadError::Malformed(e)) => {
+            eprint!("{}clash: stats corrupted: {e}", style::cyan("⚡"));
+            return Ok(());
+        }
+    };
+    let output = format_stats(&stats, format);
+    print!("{}", output);
+    Ok(())
+}
+
+/// Format session stats into a status line string.
+fn format_stats(stats: &SessionStats, _format: &str) -> String {
+    let prefix = format!("{}clash", style::cyan("⚡"));
+    let total = stats.allowed + stats.denied + stats.asked;
+
+    if total == 0 {
+        return format!("{} ready", prefix);
+    }
+
+    let counts = format!(
+        "{}{} {}{} {}{}",
+        effect_symbol(Effect::Allow),
+        stats.allowed,
+        effect_symbol(Effect::Deny),
+        stats.denied,
+        effect_symbol(Effect::Ask),
+        stats.asked,
+    );
+
+    let last = match (&stats.last_effect, &stats.last_tool) {
+        (Some(eff), Some(tool)) => {
+            let symbol = effect_symbol(*eff);
+            let summary = stats
+                .last_input_summary
+                .as_deref()
+                .filter(|s| !s.is_empty() && *s != "{}" && *s != "null")
+                .map(|s| format!("({})", s))
+                .unwrap_or_default();
+            format!(" · {} {}{}", symbol, tool, summary)
+        }
+        _ => String::new(),
+    };
+
+    let last_was_deny = stats.last_effect == Some(Effect::Deny);
+
+    let hint = match &stats.last_deny_hint {
+        Some(cmd) if last_was_deny => {
+            format!("\n  {} {}", style::dim("allow with:"), style::dim(cmd))
+        }
+        _ => String::new(),
+    };
+
+    format!("{} {}{}{}", prefix, counts, last, hint)
+}
+
+/// Map an effect to its colored symbol.
+fn effect_symbol(effect: Effect) -> String {
+    match effect {
+        Effect::Allow => style::green("✓"),
+        Effect::Deny => style::red("✗"),
+        Effect::Ask => style::yellow("?"),
+    }
+}
+
+/// Install the clash status line into Claude Code user settings.
+fn install() -> Result<()> {
+    let cs = claude_settings::ClaudeSettings::new();
+
+    // Check if statusLine is already set.
+    let current = cs.read_or_default(claude_settings::SettingsLevel::User)?;
+    if current.extra.contains_key("statusLine") {
+        let existing = &current.extra["statusLine"];
+        let is_clash = existing
+            .get("command")
+            .and_then(|v| v.as_str())
+            .is_some_and(|c| c.contains("clash statusline"));
+
+        if is_clash {
+            println!(
+                "{} Status line is already installed.",
+                style::green_bold("✓")
+            );
+            return Ok(());
+        }
+
+        println!(
+            "{} A statusLine is already configured in your Claude Code settings.",
+            style::yellow_bold("⚠")
+        );
+        println!("  Current: {}", existing);
+        println!("  To use clash, remove the existing statusLine first, or manually set:");
+        println!(
+            "  {}",
+            style::dim(
+                r#"  "statusLine": {"type": "command", "command": "clash statusline render"}"#
+            )
+        );
+        return Ok(());
+    }
+
+    cs.update(claude_settings::SettingsLevel::User, |s| {
+        s.extra.insert(
+            "statusLine".into(),
+            serde_json::json!({
+                "type": "command",
+                "command": "clash statusline render"
+            }),
+        );
+    })?;
+
+    println!(
+        "{} Status line installed. It will appear in your next Claude Code session.",
+        style::green_bold("✓")
+    );
+    Ok(())
+}
+
+/// Remove the clash status line from Claude Code user settings.
+fn uninstall() -> Result<()> {
+    let cs = claude_settings::ClaudeSettings::new();
+    let current = cs.read_or_default(claude_settings::SettingsLevel::User)?;
+
+    match current.extra.get("statusLine") {
+        None => {
+            println!("{} No statusLine is configured.", style::dim("ℹ"));
+        }
+        Some(val) => {
+            let is_clash = val
+                .get("command")
+                .and_then(|v| v.as_str())
+                .is_some_and(|c| c.contains("clash statusline"));
+
+            if !is_clash {
+                println!(
+                    "{} The current statusLine was not installed by clash. Remove it manually.",
+                    style::yellow_bold("⚠")
+                );
+                return Ok(());
+            }
+
+            cs.update(claude_settings::SettingsLevel::User, |s| {
+                s.extra.remove("statusLine");
+            })?;
+
+            println!(
+                "{} Status line removed from Claude Code settings.",
+                style::green_bold("✓")
+            );
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn stats_with(allowed: u64, denied: u64, asked: u64) -> SessionStats {
+        SessionStats {
+            allowed,
+            denied,
+            asked,
+
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn test_zero_decisions_shows_ready() {
+        let stats = stats_with(0, 0, 0);
+        let output = format_stats(&stats, "compact");
+        assert!(output.contains("ready"), "got: {output}");
+    }
+
+    #[test]
+    fn test_nonzero_decisions_shows_counts() {
+        let stats = stats_with(5, 2, 1);
+        let output = format_stats(&stats, "compact");
+        // The output has ANSI color codes, so check for the numbers.
+        assert!(
+            output.contains('5'),
+            "should contain allowed count, got: {output}"
+        );
+        assert!(
+            output.contains('2'),
+            "should contain denied count, got: {output}"
+        );
+        assert!(
+            output.contains('1'),
+            "should contain asked count, got: {output}"
+        );
+    }
+
+    #[test]
+    fn test_includes_last_action() {
+        let stats = SessionStats {
+            allowed: 3,
+            denied: 0,
+            asked: 0,
+            last_tool: Some("Bash".into()),
+            last_input_summary: Some("git status".into()),
+            last_effect: Some(Effect::Allow),
+            last_at: Some("1706123456.789".into()),
+
+            last_deny_hint: None,
+        };
+        let output = format_stats(&stats, "compact");
+        assert!(
+            output.contains("Bash"),
+            "should contain tool name, got: {output}"
+        );
+        assert!(
+            output.contains("git status"),
+            "should contain summary, got: {output}"
+        );
+    }
+
+    #[test]
+    fn test_prefix_contains_clash() {
+        let stats = stats_with(1, 0, 0);
+        let output = format_stats(&stats, "compact");
+        assert!(
+            output.contains("clash"),
+            "should contain 'clash' prefix, got: {output}"
+        );
+    }
+}

--- a/clash/src/main.rs
+++ b/clash/src/main.rs
@@ -65,6 +65,7 @@ fn main() -> Result<()> {
                 yes,
                 version,
             } => cmd::update::run(check, yes, version),
+            Commands::Statusline(cmd) => cmd::statusline::run(cmd),
             Commands::Launch { policy, args } => cmd::launch::run(policy, args),
             Commands::Bug {
                 title,

--- a/clash/src/policy/mod.rs
+++ b/clash/src/policy/mod.rs
@@ -53,3 +53,16 @@ impl fmt::Display for Effect {
         }
     }
 }
+
+impl std::str::FromStr for Effect {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "allow" => Ok(Effect::Allow),
+            "deny" => Ok(Effect::Deny),
+            "ask" => Ok(Effect::Ask),
+            _ => Err(format!("unknown effect: {s:?}")),
+        }
+    }
+}

--- a/plans/done/statusline.2026.02.20.md
+++ b/plans/done/statusline.2026.02.20.md
@@ -1,0 +1,491 @@
+# Problem
+
+Users have no ambient visibility into what Clash is doing. All enforcement feedback is either
+ephemeral (denial messages that scroll away), agent-only (additional_context that users never see),
+or on-demand (requires running `/clash:status` or `/clash:audit`). A user who hasn't been denied
+recently has no indication that Clash is running at all.
+
+This is a trust problem. Clash's value proposition is "I protect you so you don't have to click
+yes/no on every action." But if the user can't *see* that protection happening, they have to
+take it on faith. The status line is the only mechanism in Claude Code that is both **continuous**
+and **user-facing** — it's the right place for Clash to occupy persistent UI real estate.
+
+## Axioms
+
+- The status line must be fast. It runs after every assistant message (debounced 300ms). If
+  `clash statusline` takes >50ms, users will notice lag. The hot path must be a file read,
+  not a policy compilation or audit log parse.
+- The status line should be informative without being noisy. One line of ambient context,
+  not a dashboard. Users glance at it, they don't study it.
+- The status line must degrade gracefully. If the session directory doesn't exist, if the
+  stats file is missing, if the policy can't be loaded — print something reasonable, never
+  error or blank out.
+- The status line is a *complement* to denial messages and `/clash:status`, not a replacement.
+  It shows "what is happening" at a glance; the other tools explain "why" in depth.
+
+## Protocol summary
+
+The Claude Code status line is configured in `~/.claude/settings.json`:
+
+```json
+{
+  "statusLine": {
+    "type": "command",
+    "command": "clash statusline"
+  }
+}
+```
+
+The command receives JSON on stdin with session metadata:
+- `session_id` — unique session identifier (maps to `/tmp/clash-<session_id>/`)
+- `model.id`, `model.display_name` — current model
+- `workspace.current_dir`, `workspace.project_dir` — working directory
+- `cost.total_cost_usd`, `cost.total_duration_ms` — session cost/time
+- `context_window.used_percentage` — context usage
+- `version` — Claude Code version
+
+The command prints text to stdout. Supports:
+- Multiple lines (each `echo` = separate row in the status area)
+- ANSI escape codes for colors
+- OSC 8 escape sequences for clickable links
+
+**When it updates:** After each assistant message, permission mode change, or vim mode toggle.
+Debounced at 300ms. If a new update triggers while the script is still running, the in-flight
+execution is cancelled.
+
+## Design
+
+### What to display
+
+**Single-line default format:**
+```
+⚡ deny-all | ✓47 ✗3 ?2
+```
+
+Components:
+- `⚡` — Clash brand mark, color-coded by posture (red=deny-all, green=allow-all, yellow=ask-default)
+- `deny-all` — the default policy effect, so users always know the posture
+- `✓47` — allowed count (green)
+- `✗3` — denied count (red)
+- `?2` — asked count (yellow)
+
+The scoreboard answers the question "is Clash doing anything?" at a glance. If the user sees
+`✓200 ✗0`, they know everything's flowing. If they see `✗15`, they know something's being
+actively blocked and might want to investigate.
+
+**Optional two-line format (for users who want more):**
+```
+⚡ deny-all +exec +fs:rw -net | ✓47 ✗3 ?2
+  last: ✗ denied exec(git push) 3s ago
+```
+
+Second line shows the most recent decision with age. This gives a real-time "ticker tape"
+without requiring `/clash:audit`.
+
+### What NOT to display
+
+- Full rule listings — that's what `/clash:status` is for
+- Audit log entries — that's what `/clash:audit` is for
+- Policy file paths or layer information — too detailed for ambient display
+- Anything that requires the user to understand policy syntax
+
+### Performance architecture
+
+The status line command runs frequently (~every assistant message). It must be fast.
+
+**Current state:** Clash writes per-session audit logs to `/tmp/clash-<session_id>/audit.jsonl`.
+Parsing this file on every render is O(n) in the number of decisions — it grows unboundedly
+during a session and would get slower over time.
+
+**Solution: a stats sidecar file.** On every `log_decision()` call, Clash atomically writes a
+small stats file alongside the audit log:
+
+```
+/tmp/clash-<session_id>/stats.json
+```
+
+Contents:
+```json
+{
+  "allowed": 47,
+  "denied": 3,
+  "asked": 2,
+  "last_tool": "Bash",
+  "last_input_summary": "git push origin main",
+  "last_effect": "deny",
+  "last_at": 1706123456.789,
+  "default_effect": "deny"
+}
+```
+
+The `clash statusline` command then:
+1. Reads `session_id` from stdin JSON (~negligible, it's small)
+2. Reads `/tmp/clash-<session_id>/stats.json` (single small file read)
+3. Formats and prints
+
+No policy compilation, no audit log parsing, no decision tree evaluation. Target: <10ms.
+
+The `default_effect` field is written at session init time (by `handle_session_start`) and
+captures the policy's default effect so the status line doesn't need to load/compile the policy.
+
+### Integration with existing status lines
+
+Users may already have a status line configured (git info, cost tracking, context bars). Clash
+should not clobber their existing setup. Two approaches:
+
+**Option A: Composable script.** `clash statusline` is a standalone command that outputs one line.
+Users compose it into their existing status line script:
+
+```bash
+#!/bin/bash
+input=$(cat)
+# Line 1: Clash status
+echo "$input" | clash statusline
+# Line 2: their existing stuff
+MODEL=$(echo "$input" | jq -r '.model.display_name')
+echo "[$MODEL] ..."
+```
+
+**Option B: Clash wraps the existing command.** `clash statusline --wrap "~/.claude/statusline.sh"`
+reads stdin, pipes it to both Clash's own formatter and the user's script, concatenates output.
+
+**Recommendation:** Option A for v1. It's simpler, doesn't require Clash to know about the user's
+existing config, and follows the Unix philosophy. Option B could be a convenience in v2.
+
+### Installation
+
+`clash statusline install` writes the config to `~/.claude/settings.json`:
+- If no `statusLine` field exists: set it to `{"type": "command", "command": "clash statusline"}`
+- If a `statusLine` field already exists: warn and suggest the composable approach (option A)
+
+`clash statusline uninstall` removes the config (or the Clash portion).
+
+This could also be part of `clash init` — after setting up the policy, offer to install the
+status line: "Want Clash status in your Claude Code status bar? (clash statusline install)"
+
+## Proposed implementation
+
+### `clash statusline` subcommand
+
+New CLI subcommand that reads Claude Code's status line JSON from stdin, reads session stats,
+and prints formatted output.
+
+```rust
+/// Display clash status in the Claude Code status line
+Statusline {
+    /// Output format
+    #[arg(long, default_value = "compact")]
+    format: StatuslineFormat,
+}
+
+enum StatuslineFormat {
+    Compact,  // single line: ⚡ deny-all | ✓47 ✗3 ?2
+    Full,     // two lines: adds last decision
+}
+```
+
+The command:
+1. Reads JSON from stdin, extracts `session_id`
+2. Reads `/tmp/clash-<session_id>/stats.json`
+3. Formats output based on `--format`
+4. Prints to stdout
+
+If stats.json doesn't exist (session just started, no decisions yet):
+```
+⚡ deny-all | ready
+```
+
+If the session directory doesn't exist at all:
+```
+⚡ clash
+```
+
+### Stats sidecar file
+
+Extend `audit::log_decision()` to also write/update the stats file. This is an atomic
+write (write to temp file, rename) to prevent partial reads by the status line command.
+
+The stats file includes `default_effect` which is set during `handle_session_start` via a
+new `audit::init_session_stats()` function that writes the initial stats with zero counters
+and the policy's default effect.
+
+### `clash statusline install/uninstall`
+
+Reads and modifies `~/.claude/settings.json` using the existing `claude_settings` crate.
+Adds or removes the `statusLine` field.
+
+## Execution plan
+
+### Workstreams and task DAG
+
+```
+WS1: Stats sidecar ──────────┐
+  T1: Define stats.json schema │
+  T2: Write stats in log_decision │
+  T3: Init stats in session_start ├──→ WS3: Testing
+                                  │      T9: Unit tests (stats write)
+WS2: Statusline command ─────┤      T10: Unit tests (format output)
+  T4: CLI subcommand definition  │      T11: Clester e2e (full flow)
+  T5: Stdin JSON parsing         │
+  T6: Stats file reading         │
+  T7: Output formatting          ├──→ WS3
+  T8: Install/uninstall          │
+```
+
+**Dependencies:**
+- WS2 depends on WS1 (needs stats file to exist)
+- T4-T5 can start in parallel with WS1 (stdin parsing doesn't need stats)
+- T6-T7 need T1-T3 complete (schema must be defined)
+- T8 is independent of everything else
+- WS3 needs WS1 + WS2 complete
+
+### WS1: Stats sidecar file
+
+**T1: Define stats.json schema**
+
+```rust
+#[derive(Debug, Serialize, Deserialize)]
+pub struct SessionStats {
+    pub allowed: u64,
+    pub denied: u64,
+    pub asked: u64,
+    pub last_tool: Option<String>,
+    pub last_input_summary: Option<String>,
+    pub last_effect: Option<String>,
+    pub last_at: Option<String>,
+    pub default_effect: String,
+}
+```
+
+The struct lives in `audit.rs` alongside the existing audit types.
+
+Files: `clash/src/audit.rs`
+
+**T2: Write stats in log_decision**
+
+After writing the audit log entry (existing behavior), also update the stats file:
+1. Read current stats from `/tmp/clash-<session_id>/stats.json` (or start from defaults)
+2. Increment the appropriate counter (allowed/denied/asked)
+3. Update last_* fields
+4. Atomic write (write to `.stats.json.tmp`, rename to `stats.json`)
+
+The read-increment-write cycle is safe because Clash hook invocations are sequential per session
+(Claude Code waits for PreToolUse to complete before the next tool call).
+
+Files: `clash/src/audit.rs`
+
+**T3: Init stats in session_start**
+
+Extend `audit::init_session()` to also write the initial stats file:
+```json
+{
+  "allowed": 0, "denied": 0, "asked": 0,
+  "last_tool": null, "last_input_summary": null,
+  "last_effect": null, "last_at": null,
+  "default_effect": "deny"
+}
+```
+
+The `default_effect` is determined by loading the policy settings and reading the compiled
+default effect. This is the one place where policy compilation happens — at session start,
+not on every status line render.
+
+Files: `clash/src/audit.rs`, `clash/src/handlers.rs`
+
+### WS2: Statusline command
+
+**T4: CLI subcommand definition**
+
+Add `Statusline` variant to the `Commands` enum in `cli.rs`:
+
+```rust
+/// Display clash status in the Claude Code status line
+Statusline {
+    #[command(subcommand)]
+    cmd: Option<StatuslineCmd>,
+    /// Output format (when no subcommand given)
+    #[arg(long, default_value = "compact")]
+    format: StatuslineFormat,
+}
+
+enum StatuslineCmd {
+    /// Install the status line into Claude Code settings
+    Install,
+    /// Remove the status line from Claude Code settings
+    Uninstall,
+}
+```
+
+When invoked without a subcommand, it reads stdin and prints the status line.
+When invoked with `install` or `uninstall`, it modifies settings.
+
+Files: `clash/src/cli.rs`, `clash/src/cmd/statusline.rs` (new)
+
+**T5: Stdin JSON parsing**
+
+Parse the Claude Code status line JSON input. We only need `session_id` from it, but should
+define a struct for the full input in case we want more fields later:
+
+```rust
+#[derive(Deserialize)]
+struct StatuslineInput {
+    session_id: String,
+    // Future: model, workspace, cost, context_window for richer display
+}
+```
+
+Read from stdin with a timeout or size limit — if Claude Code sends malformed input, don't hang.
+
+Files: `clash/src/cmd/statusline.rs`
+
+**T6: Stats file reading**
+
+Read `/tmp/clash-<session_id>/stats.json`. Handle gracefully:
+- File doesn't exist → return default SessionStats
+- File is malformed → return default SessionStats (log warning to stderr, not stdout)
+- Permission error → return default SessionStats
+
+Files: `clash/src/cmd/statusline.rs`
+
+**T7: Output formatting**
+
+Format the output string. Use the existing `style.rs` ANSI color helpers.
+
+**Compact format:**
+```rust
+fn format_compact(stats: &SessionStats) -> String {
+    let posture_color = match stats.default_effect.as_str() {
+        "deny" => RED,
+        "allow" => GREEN,
+        "ask" => YELLOW,
+        _ => RESET,
+    };
+    let shield = format!("{posture_color}⚡{RESET}");
+    let posture = &stats.default_effect;
+    let allowed = format!("{GREEN}✓{}{RESET}", stats.allowed);
+    let denied = format!("{RED}✗{}{RESET}", stats.denied);
+    let asked = format!("{YELLOW}?{}{RESET}", stats.asked);
+
+    format!("{shield} {posture}-all | {allowed} {denied} {asked}")
+}
+```
+
+**Full format:** adds a second line with the last decision:
+```rust
+fn format_full(stats: &SessionStats) -> String {
+    let line1 = format_compact(stats);
+    let line2 = match (&stats.last_tool, &stats.last_effect) {
+        (Some(tool), Some(effect)) => {
+            let summary = stats.last_input_summary.as_deref().unwrap_or("");
+            let age = format_age(stats.last_at.as_deref());
+            let effect_colored = color_effect(effect);
+            format!("  last: {effect_colored} {tool}({summary}) {age}")
+        }
+        _ => "  ready".to_string(),
+    };
+    format!("{line1}\n{line2}")
+}
+```
+
+Edge cases:
+- Zero decisions: show `ready` instead of `✓0 ✗0 ?0`
+- Very long input summaries: truncate to ~30 chars (status line has limited width)
+- Terminal doesn't support color: `style.rs` already handles TTY detection
+
+Files: `clash/src/cmd/statusline.rs`, `clash/src/style.rs`
+
+**T8: Install/uninstall**
+
+`clash statusline install`:
+1. Load `~/.claude/settings.json` via `claude_settings`
+2. Check if `statusLine` key exists
+3. If not: add `{"type": "command", "command": "clash statusline"}`
+4. If yes: warn "Status line already configured. To compose with Clash, add
+   `echo \"$input\" | clash statusline` to your existing script."
+5. Write back
+
+`clash statusline uninstall`:
+1. Load settings
+2. If `statusLine.command` contains "clash statusline": remove the `statusLine` key
+3. If it doesn't (user composed it into their own script): warn "Your status line
+   references a custom script. Remove the `clash statusline` call manually."
+4. Write back
+
+Files: `clash/src/cmd/statusline.rs`, `claude_settings/src/lib.rs` (if needed)
+
+### WS3: Testing
+
+**T9: Unit tests for stats write**
+- `log_decision` creates/updates stats.json
+- Counters increment correctly for each effect
+- Last decision fields update
+- Atomic write doesn't corrupt on concurrent read
+- Missing session dir doesn't panic
+
+Files: `clash/src/audit.rs`
+
+**T10: Unit tests for format output**
+- Compact format with various counter values
+- Full format with last decision
+- Zero-decision "ready" state
+- Input summary truncation
+- Graceful degradation (missing stats file, malformed input)
+
+Files: `clash/src/cmd/statusline.rs`
+
+**T11: Clester e2e test**
+- Full flow: session start → tool use → status line reads stats
+- Verify stats.json is created and updated
+- Verify `clash statusline` produces expected output
+
+Files: `clester/tests/scripts/`
+
+## Integration with onboarding
+
+The status line complements the interactive onboarding plan. Specifically:
+
+- **Phase 1 (deny-all):** The status line shows `⚡ deny-all | ✗N` — the user sees denials
+  accumulating, reinforcing that Clash is active and protecting them.
+- **Phase 2 (presets):** After `clash allow editing`, the allowed count starts climbing while
+  denials for edit/write disappear. The shift is visible: `✓30 ✗2` vs earlier `✓5 ✗15`.
+- **Phase 3 (broad allows):** The status line shows mostly allows with rare denials, confirming
+  the policy is working as intended.
+
+The status line could also be installed automatically during `clash init` (the onboarding plan's
+T3/T4), making it part of the default Clash experience rather than an opt-in feature.
+
+## Future directions (not in v1)
+
+- **Clickable counts:** OSC 8 links on `✗3` that open `clash audit --filter deny` output
+- **Policy posture summary:** `+exec +fs:rw -net` compact capability listing
+- **Composable wrapper:** `clash statusline --wrap "existing-script.sh"` for seamless integration
+- **Notification flash:** Brief color flash on the `⚡` when a new denial occurs
+- **Plugin-provided fields:** If Claude Code ever adds extension points to the status line input
+  JSON, Clash could publish data directly rather than going through the stats sidecar
+
+## Open questions
+
+- **Should `clash init` auto-install the status line?** Pro: every Clash user gets ambient
+  visibility by default. Con: modifying `settings.json` without being asked may surprise users.
+  Could be an opt-in prompt during init: "Install Clash status bar? [Y/n]"
+
+- **Should the status line show policy posture detail?** The compact `deny-all` is clear, but
+  `+exec +fs:rw -net` requires understanding capability domains. This might be too much for
+  new users but valuable for experienced ones. Could be a `--format full` feature.
+
+- **Cache invalidation for default_effect:** If the user changes their policy mid-session (e.g.,
+  `clash allow editing`), the `default_effect` in stats.json is stale. Should the stats file
+  update when the policy changes? The default effect itself doesn't change (it's always
+  deny/allow/ask from the policy header), so this is likely fine. But the posture *feeling*
+  changes — after adding allows, the user is more permissive even though the default is still
+  deny. Should the status line reflect this somehow?
+
+- **Performance on slow filesystems:** The stats file is in `/tmp` which is typically fast.
+  But on some systems (networked home dirs, encrypted volumes), even a single file read could
+  be slow. Should the status line command have a hard timeout (e.g., 30ms) after which it
+  prints a fallback?
+
+- **Session policy bug:** During research for this plan, we observed that `clash policy allow
+  --scope session` claims success but the rule is not loaded by the evaluator or shown by
+  `policy list`. This is a separate bug but worth tracking — it affects the status line story
+  because session-scoped policy changes would ideally be reflected in the status line display.


### PR DESCRIPTION
feat: add `clash statusline` for ambient policy visibility
Live scoreboard in Claude Code's status bar showing policy enforcement
activity — persistent, at-a-glance visibility without interrupting
workflow.

Displays:
- Decision counts: ✓ allowed, ✗ denied, ? asked (color-coded)
- Last action: effect symbol + tool name + input summary
- Deny hint: when the last action was denied, shows the exact allow rule
  to unblock it (e.g. `clash allow '(exec "touch" "foo")'`)

New commands:
- `clash statusline render` — prints formatted status line to stdout
- `clash statusline install` — adds statusLine config to Claude Code
- `clash statusline uninstall` — removes it

Design notes:
- Stats are persisted atomically per session, updated at most once per
  tool use to avoid double-counting
- Deny hints and input summaries are derived from the eval layer's
  capability queries, ensuring consistency with policy enforcement
- ANSI colors are force-enabled since Claude Code pipes stdout but
  supports escape codes in the status bar