### PR TITLE
docs: clarify exec rule enforcement scope (#138)

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,8 @@ Allowed exec rules can carry sandbox constraints that clash compiles into OS-enf
 
 Even if a command is allowed by policy, the sandbox ensures it can only access the paths you specify.
 
+> **Note:** Exec rules (like `(deny (exec "git" "push" *))`) apply to the top-level command Claude runs. If an allowed command spawns a subprocess that runs a denied command, the exec rule does not fire. Kernel sandbox restrictions on filesystem and network access *do* apply to all child processes. See [#136](https://github.com/empathic/clash/issues/136) for tracking deeper exec enforcement.
+
 For the full rule syntax, see the [Policy Writing Guide](docs/policy-guide.md).
 
 ---

--- a/docs/adr/003-fs-sandbox-bash.md
+++ b/docs/adr/003-fs-sandbox-bash.md
@@ -38,3 +38,4 @@ In v2, this maps to:
 - Sandbox is one-way — once applied, the process cannot gain additional permissions
 - Filter expression semantics differ slightly: `And(a, b)` / `Or(a, b)` both collect rules from both sides in sandbox generation (the boolean logic is approximated by the union of sandbox rules)
 - Regex-based filters have limited support on some platforms
+- Kernel-level sandbox enforcement covers filesystem and network access only. Exec-level argument matching (e.g., `(deny (exec "git" "push" *))`) operates at the hook level and only evaluates the top-level command — child processes within the sandbox are not checked against exec rules ([#136](https://github.com/empathic/clash/issues/136))

--- a/docs/policy-grammar.md
+++ b/docs/policy-grammar.md
@@ -57,6 +57,8 @@ tool_matcher    = "(" "tool" pattern? ")"
 
 Matches command execution. The first pattern matches the binary name. Arguments can be matched positionally (default) or in any order using `:has`.
 
+> **Scope:** Exec matching applies to the top-level command that Claude Code invokes. Child processes spawned by the command are not matched against exec rules. See [policy-semantics.md](./policy-semantics.md#capability-model) for details.
+
 #### Positional matching (default)
 
 Subsequent patterns match positional arguments left-to-right.

--- a/docs/policy-guide.md
+++ b/docs/policy-guide.md
@@ -47,6 +47,8 @@ Clash controls three capability domains, not individual tools. A single rule can
 
 The first pattern matches the binary name, subsequent patterns match positional arguments. More arguments = more specific.
 
+> **Scope:** Exec rules evaluate the top-level command that Claude Code invokes via the Bash tool. They do not apply to child processes spawned by that command. For example, `(deny (exec "git" "push" *))` prevents Claude from directly running `git push`, but if an allowed command like `make deploy` internally calls `git push`, the deny rule does not fire — the policy engine only sees the top-level `make` command. Sandbox restrictions for filesystem and network access *are* enforced on all child processes at the kernel level (see [Sandbox Policies](#sandbox-policies)).
+
 ### Fs — File Operations
 
 ```
@@ -190,6 +192,10 @@ Named sandbox references must point to a policy defined with `(policy "name" ...
 ### Default behavior
 
 When no `:sandbox` is specified on an exec allow, the spawned process gets no filesystem/network access beyond bare minimum (deny-all sandbox by default).
+
+### What sandboxes enforce
+
+Sandbox policies constrain **filesystem and network access** at the kernel level — these restrictions are inherited by all child processes and cannot be bypassed. However, sandboxes do not enforce **exec-level argument matching** on child processes. If a sandboxed command spawns a subprocess, the subprocess inherits the filesystem and network restrictions but is not checked against exec rules. Tracking issue: [#136](https://github.com/empathic/clash/issues/136).
 
 ---
 

--- a/docs/session-context.md
+++ b/docs/session-context.md
@@ -156,3 +156,5 @@ Suggest one of these fixes:
 - When the user asks to allow something currently denied, they must remove the deny rule first
 - Always use `--dry-run` before applying policy changes
 - Summarize command output in plain English — never paste raw terminal output to the user
+- Exec rules (e.g., `(deny (exec "git" "push" *))`) apply only to the **top-level command** Claude invokes via Bash. They do NOT catch commands run by child processes. If a user asks whether an exec deny rule prevents a subprocess from running a command, explain this limitation honestly
+- Kernel sandbox restrictions on filesystem and network access DO apply to all child processes and cannot be bypassed


### PR DESCRIPTION
## Summary

- Added exec rule enforcement scope notes to all documentation files, ensuring they accurately reflect that exec rules only evaluate the **top-level command** Claude Code invokes via the Bash tool hook — not child processes spawned by that command
- Clarified the two-layer enforcement model: **kernel-level** (Landlock/Seatbelt) for fs/net restrictions (applies to all descendants) vs **hook-level** for exec argument matching (top-level only)
- All additions link to #136 for tracking deeper exec enforcement

### Files changed

| File | Change |
|------|--------|
| `docs/policy-guide.md` | Scope note under Exec section + new "What sandboxes enforce" subsection |
| `docs/policy-semantics.md` | Notes after Capability Model table, Evaluation Algorithm, and Sandbox Generation |
| `docs/policy-grammar.md` | Scope note in Exec Matcher section |
| `README.md` | Note after Kernel Sandbox section |
| `docs/session-context.md` | Bullets in Important Behaviors so Claude represents scope honestly |
| `docs/adr/003-fs-sandbox-bash.md` | Bullet under Negative consequences |

Closes #138

## Test plan

- [x] Read each changed file and verify the new text is accurate and consistent
- [x] Verify all `#136` issue links resolve correctly
- [x] Verify the `policy-semantics.md#capability-model` anchor link from policy-grammar.md resolves
- [x] Build the binary (`cargo build`) and confirm the updated session-context.md is compiled in