### PR TITLE
refactor(sandbox): rewrite proxy from sync std to async tokio+hyper

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -398,6 +398,7 @@ dependencies = [
  "anyhow",
  "base64",
  "bitflags",
+ "bytes",
  "clap",
  "clash_notify",
  "claude_settings",
@@ -407,6 +408,9 @@ dependencies = [
  "figment",
  "flate2",
  "hotln",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
  "landlock",
  "lexpr",
  "libc",
@@ -428,6 +432,7 @@ dependencies = [
  "tar",
  "tempfile",
  "thiserror 2.0.18",
+ "tokio",
  "toml",
  "tracing",
  "tracing-subscriber",
@@ -1035,6 +1040,7 @@ dependencies = [
  "pin-utils",
  "smallvec",
  "tokio",
+ "want",
 ]
 
 [[package]]
@@ -2322,7 +2328,19 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "socket2",
+ "tokio-macros",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2469,6 +2487,12 @@ dependencies = [
  "tracing-core",
  "tracing-log",
 ]
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typenum"
@@ -2624,6 +2648,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,11 @@ libc = "0.2"
 
 uuid = { version = "1", features = ["v4"] }
 ureq = "2"
+tokio = { version = "1", features = ["rt", "net", "io-util", "sync", "time", "macros"] }
+hyper = { version = "1", features = ["http1", "server", "client"] }
+hyper-util = { version = "0.1", features = ["tokio"] }
+http-body-util = "0.1"
+bytes = "1"
 lexpr = "0.2"
 base64 = "0.22"
 dialoguer = "0.11"

--- a/clash/Cargo.toml
+++ b/clash/Cargo.toml
@@ -31,6 +31,11 @@ libc = { workspace = true }
 uuid = { workspace = true }
 hotln = { workspace = true }
 ureq = { workspace = true }
+tokio = { workspace = true }
+hyper = { workspace = true }
+hyper-util = { workspace = true }
+http-body-util = { workspace = true }
+bytes = { workspace = true }
 base64 = { workspace = true }
 console = { workspace = true }
 nu-ansi-term = { workspace = true }

--- a/clash/src/sandbox/proxy.rs
+++ b/clash/src/sandbox/proxy.rs
@@ -1,18 +1,55 @@
 //! HTTP forward proxy for domain-level network filtering.
 //!
 //! Provides a lightweight HTTP proxy that enforces domain allowlists at the
-//! sandbox boundary. Supports both CONNECT tunneling (for HTTPS) and plain
-//! HTTP forwarding. Uses only `std` networking primitives -- no async runtime
-//! or external HTTP crate required.
+//! sandbox boundary.  Supports both CONNECT tunneling (for HTTPS) and plain
+//! HTTP forwarding.  Built on tokio + hyper for correct HTTP framing and
+//! connection lifecycle management.
 
-use std::io::{self, BufRead, BufReader, Write};
-use std::net::{Shutdown, SocketAddr, TcpListener, TcpStream};
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::convert::Infallible;
+use std::io;
+use std::net::SocketAddr;
 use std::sync::Arc;
 use std::thread;
-use std::time::Duration;
 
+use bytes::Bytes;
+use http_body_util::{BodyExt, Empty, Full};
+use hyper::body::Incoming;
+use hyper::server::conn::http1 as server_http1;
+use hyper::service::service_fn;
+use hyper::{Method, Request, Response};
+use hyper_util::rt::TokioIo;
+use tokio::io::copy_bidirectional;
+use tokio::net::TcpStream;
+use tokio::sync::oneshot;
 use tracing::{debug, trace, warn};
+
+// ---------------------------------------------------------------------------
+// Body helpers
+// ---------------------------------------------------------------------------
+
+type BoxBody = http_body_util::combinators::BoxBody<Bytes, Infallible>;
+
+fn empty_body() -> BoxBody {
+    Empty::<Bytes>::new()
+        .map_err(|never| match never {})
+        .boxed()
+}
+
+fn full_body(msg: impl Into<Bytes>) -> BoxBody {
+    Full::new(msg.into())
+        .map_err(|never| match never {})
+        .boxed()
+}
+
+fn error_response(status: u16, reason: &str) -> Response<BoxBody> {
+    let body_text = format!("{status} {reason}\r\n");
+    Response::builder()
+        .status(status)
+        .header("Content-Type", "text/plain")
+        .header("Connection", "close")
+        .body(full_body(body_text))
+        .unwrap()
+}
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -26,25 +63,21 @@ pub struct ProxyConfig {
     pub allowed_domains: Vec<String>,
 }
 
-/// Handle to a running proxy.  Dropping the handle initiates a clean shutdown
-/// of the listener thread.
+/// Handle to a running proxy.  Dropping the handle initiates a clean shutdown.
 pub struct ProxyHandle {
     /// The `127.0.0.1:<port>` address the proxy is listening on.
     pub addr: SocketAddr,
-    shutdown: Arc<AtomicBool>,
-    listener_thread: Option<thread::JoinHandle<()>>,
+    /// Dropping the sender signals the accept loop to stop.
+    shutdown: Option<oneshot::Sender<()>>,
+    /// The std::thread running the tokio runtime.
+    runtime_thread: Option<thread::JoinHandle<()>>,
 }
 
 impl Drop for ProxyHandle {
     fn drop(&mut self) {
-        // Signal the accept loop to stop.
-        self.shutdown.store(true, Ordering::SeqCst);
-
-        // Poke the listener so its non-blocking accept wakes up immediately
-        // rather than waiting for the next poll interval.
-        let _ = TcpStream::connect(self.addr);
-
-        if let Some(handle) = self.listener_thread.take() {
+        // Signal shutdown by dropping the sender.
+        drop(self.shutdown.take());
+        if let Some(handle) = self.runtime_thread.take() {
             let _ = handle.join();
         }
     }
@@ -82,30 +115,32 @@ pub fn is_domain_allowed(host: &str, allowed: &[String]) -> bool {
 /// Start the filtering proxy.
 ///
 /// Binds to `127.0.0.1:0` (OS-assigned ephemeral port), spawns a background
-/// thread that accepts connections, and returns a [`ProxyHandle`] whose
+/// tokio runtime that accepts connections, and returns a [`ProxyHandle`] whose
 /// lifetime controls the proxy.
 pub fn start_proxy(config: ProxyConfig) -> io::Result<ProxyHandle> {
-    let listener = TcpListener::bind("127.0.0.1:0")?;
-    let addr = listener.local_addr()?;
+    // Bind with std so the address is available synchronously.
+    let std_listener = std::net::TcpListener::bind("127.0.0.1:0")?;
+    let addr = std_listener.local_addr()?;
     debug!(addr = %addr, "proxy listening");
 
-    // Make accept non-blocking so we can poll the shutdown flag.
-    listener.set_nonblocking(true)?;
-
-    let shutdown = Arc::new(AtomicBool::new(false));
-    let shutdown_flag = Arc::clone(&shutdown);
+    let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
     let config = Arc::new(config);
 
-    let listener_thread = thread::Builder::new()
-        .name("proxy-accept".into())
+    let runtime_thread = thread::Builder::new()
+        .name("proxy-runtime".into())
         .spawn(move || {
-            accept_loop(listener, shutdown_flag, config);
+            let rt = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("failed to build tokio runtime for proxy");
+
+            rt.block_on(accept_loop(std_listener, shutdown_rx, config));
         })?;
 
     Ok(ProxyHandle {
         addr,
-        shutdown,
-        listener_thread: Some(listener_thread),
+        shutdown: Some(shutdown_tx),
+        runtime_thread: Some(runtime_thread),
     })
 }
 
@@ -113,31 +148,40 @@ pub fn start_proxy(config: ProxyConfig) -> io::Result<ProxyHandle> {
 // Accept loop
 // ---------------------------------------------------------------------------
 
-fn accept_loop(listener: TcpListener, shutdown: Arc<AtomicBool>, config: Arc<ProxyConfig>) {
-    while !shutdown.load(Ordering::SeqCst) {
-        match listener.accept() {
-            Ok((stream, peer)) => {
-                trace!(peer = %peer, "accepted connection");
-                let cfg = Arc::clone(&config);
-                thread::Builder::new()
-                    .name(format!("proxy-conn-{peer}"))
-                    .spawn(move || {
-                        if let Err(e) = handle_client(stream, &cfg) {
-                            debug!(peer = %peer, error = %e, "connection finished with error");
-                        }
-                    })
-                    .ok(); // If spawn fails we just drop the connection.
-            }
-            Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => {
-                // Non-blocking accept found nothing -- sleep briefly then retry.
-                thread::sleep(Duration::from_millis(50));
-            }
-            Err(e) => {
-                if shutdown.load(Ordering::SeqCst) {
-                    break;
+async fn accept_loop(
+    std_listener: std::net::TcpListener,
+    shutdown_rx: oneshot::Receiver<()>,
+    config: Arc<ProxyConfig>,
+) {
+    std_listener
+        .set_nonblocking(true)
+        .expect("failed to set listener non-blocking");
+    let listener = tokio::net::TcpListener::from_std(std_listener)
+        .expect("failed to create tokio TcpListener");
+
+    tokio::pin!(shutdown_rx);
+
+    loop {
+        tokio::select! {
+            result = listener.accept() => {
+                match result {
+                    Ok((stream, peer)) => {
+                        trace!(peer = %peer, "accepted connection");
+                        let cfg = Arc::clone(&config);
+                        tokio::task::spawn(async move {
+                            if let Err(e) = serve_connection(stream, cfg).await {
+                                debug!(peer = %peer, error = %e, "connection finished with error");
+                            }
+                        });
+                    }
+                    Err(e) => {
+                        warn!(error = %e, "accept error");
+                    }
                 }
-                warn!(error = %e, "accept error");
-                thread::sleep(Duration::from_millis(50));
+            }
+            _ = &mut shutdown_rx => {
+                debug!("proxy accept loop shutting down");
+                break;
             }
         }
     }
@@ -145,89 +189,39 @@ fn accept_loop(listener: TcpListener, shutdown: Arc<AtomicBool>, config: Arc<Pro
 }
 
 // ---------------------------------------------------------------------------
-// Per-connection handler
+// Per-connection handler (hyper service)
 // ---------------------------------------------------------------------------
 
-const CLIENT_TIMEOUT: Duration = Duration::from_secs(30);
+async fn serve_connection(
+    stream: TcpStream,
+    config: Arc<ProxyConfig>,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let io = TokioIo::new(stream);
 
-fn handle_client(stream: TcpStream, config: &ProxyConfig) -> io::Result<()> {
-    stream.set_read_timeout(Some(CLIENT_TIMEOUT))?;
-    stream.set_write_timeout(Some(CLIENT_TIMEOUT))?;
+    server_http1::Builder::new()
+        .preserve_header_case(true)
+        .title_case_headers(true)
+        .serve_connection(
+            io,
+            service_fn(move |req| {
+                let cfg = Arc::clone(&config);
+                async move { proxy_handler(req, cfg).await }
+            }),
+        )
+        .with_upgrades()
+        .await?;
 
-    // Keep a clone alive so the socket isn't fully closed when dispatch
-    // drops its copies.  After dispatch returns we drain remaining client
-    // data through this clone, giving the peer time to read our response
-    // before the socket is torn down (prevents RST-before-FIN on macOS).
-    let drain = stream.try_clone()?;
-
-    let reader = BufReader::new(stream.try_clone()?);
-    let result = dispatch(stream, reader, config);
-
-    let _ = drain.set_read_timeout(Some(Duration::from_millis(500)));
-    let _ = io::copy(&mut &drain, &mut io::sink());
-
-    result
+    Ok(())
 }
 
-/// Read the first line, determine whether this is a CONNECT or plain HTTP
-/// request, then dispatch accordingly.
-fn dispatch(
-    client: TcpStream,
-    mut reader: BufReader<TcpStream>,
-    config: &ProxyConfig,
-) -> io::Result<()> {
-    let mut request_line = String::new();
-    reader.read_line(&mut request_line)?;
-    let request_line = request_line.trim_end().to_string();
-
-    if request_line.is_empty() {
-        return Err(io::Error::new(
-            io::ErrorKind::UnexpectedEof,
-            "empty request line",
-        ));
-    }
-
-    trace!(request_line = %request_line, "parsed request line");
-
-    let parts: Vec<&str> = request_line.split_whitespace().collect();
-    if parts.len() < 3 {
-        send_error(&client, 400, "Bad Request")?;
-        return Err(io::Error::new(
-            io::ErrorKind::InvalidData,
-            "malformed request line",
-        ));
-    }
-
-    let method = parts[0].to_ascii_uppercase();
-
-    if method == "CONNECT" {
-        // CONNECT host:port HTTP/1.x
-        let authority = parts[1];
-        let host = extract_host_from_authority(authority);
-
-        // Consume remaining headers (we don't need them for CONNECT).
-        consume_headers(&mut reader)?;
-
-        if !is_domain_allowed(host, &config.allowed_domains) {
-            warn!(host = %host, "CONNECT blocked by allowlist");
-            send_error(&client, 403, "Forbidden")?;
-            return Ok(());
-        }
-
-        debug!(authority = %authority, "CONNECT allowed");
-        handle_connect(client, authority)
+async fn proxy_handler(
+    req: Request<Incoming>,
+    config: Arc<ProxyConfig>,
+) -> Result<Response<BoxBody>, Infallible> {
+    if req.method() == Method::CONNECT {
+        handle_connect(req, &config).await
     } else {
-        // Plain HTTP: GET / POST / etc.
-        let host = resolve_host(&mut reader, parts[1])?;
-
-        if !is_domain_allowed(&host, &config.allowed_domains) {
-            warn!(host = %host, "HTTP request blocked by allowlist");
-            send_error(&client, 403, "Forbidden")?;
-            return Ok(());
-        }
-
-        debug!(host = %host, method = %method, "HTTP request allowed");
-        handle_http(client, reader, &request_line, &host)
+        handle_http(req, &config).await
     }
 }
 
@@ -235,115 +229,148 @@ fn dispatch(
 // CONNECT (HTTPS tunneling)
 // ---------------------------------------------------------------------------
 
-/// Establish an upstream TCP connection, send `200 Connection Established` to
-/// the client, then relay bytes in both directions until either side closes.
-fn handle_connect(mut client: TcpStream, authority: &str) -> io::Result<()> {
-    let upstream = TcpStream::connect(authority).map_err(|e| {
-        let _ = send_error(&client, 502, "Bad Gateway");
-        io::Error::new(
-            e.kind(),
-            format!("failed to connect to upstream {authority}: {e}"),
-        )
-    })?;
+async fn handle_connect(
+    req: Request<Incoming>,
+    config: &ProxyConfig,
+) -> Result<Response<BoxBody>, Infallible> {
+    let authority = match req.uri().authority() {
+        Some(auth) => auth.to_string(),
+        None => {
+            warn!("CONNECT request missing authority");
+            return Ok(error_response(400, "Bad Request"));
+        }
+    };
 
-    client.write_all(b"HTTP/1.1 200 Connection Established\r\n\r\n")?;
-    client.flush()?;
+    let host = extract_host_from_authority(&authority);
 
-    relay(client, upstream)
+    if !is_domain_allowed(host, &config.allowed_domains) {
+        warn!(host = %host, "CONNECT blocked by allowlist");
+        return Ok(error_response(403, "Forbidden"));
+    }
+
+    debug!(authority = %authority, "CONNECT allowed");
+
+    // Verify upstream is reachable before sending 200.
+    let upstream = match TcpStream::connect(&authority).await {
+        Ok(s) => s,
+        Err(e) => {
+            warn!(authority = %authority, error = %e, "failed to connect upstream");
+            return Ok(error_response(502, "Bad Gateway"));
+        }
+    };
+
+    // Spawn the tunnel task.  It awaits the upgrade, then relays bytes.
+    tokio::task::spawn(async move {
+        match hyper::upgrade::on(req).await {
+            Ok(upgraded) => {
+                let mut client = TokioIo::new(upgraded);
+                let mut server = upstream;
+                if let Err(e) = copy_bidirectional(&mut client, &mut server).await {
+                    debug!(error = %e, "tunnel relay finished with error");
+                }
+            }
+            Err(e) => {
+                warn!(error = %e, "CONNECT upgrade failed");
+            }
+        }
+    });
+
+    // Return 200 to trigger the upgrade.
+    Ok(Response::new(empty_body()))
 }
 
 // ---------------------------------------------------------------------------
 // Plain HTTP forwarding
 // ---------------------------------------------------------------------------
 
-/// Forward a plain HTTP request to the origin server and relay the response
-/// back to the client.
-fn handle_http(
-    client: TcpStream,
-    mut reader: BufReader<TcpStream>,
-    request_line: &str,
-    host: &str,
-) -> io::Result<()> {
-    // Collect remaining headers.
-    let mut headers = Vec::new();
-    loop {
-        let mut line = String::new();
-        reader.read_line(&mut line)?;
-        if line == "\r\n" || line == "\n" || line.is_empty() {
-            break;
+async fn handle_http(
+    req: Request<Incoming>,
+    config: &ProxyConfig,
+) -> Result<Response<BoxBody>, Infallible> {
+    let host = match extract_target_host(&req) {
+        Some(h) => h,
+        None => {
+            warn!("could not determine target host");
+            return Ok(error_response(400, "Bad Request"));
         }
-        headers.push(line);
+    };
+
+    if !is_domain_allowed(&host, &config.allowed_domains) {
+        warn!(host = %host, "HTTP request blocked by allowlist");
+        return Ok(error_response(403, "Forbidden"));
     }
 
+    debug!(host = %host, method = %req.method(), "HTTP request allowed");
+
     // Determine upstream address.  Default to port 80.
-    let addr = if host.contains(':') {
-        host.to_string()
+    let addr = if let Some(authority) = req.uri().authority() {
+        let auth_str = authority.to_string();
+        if auth_str.contains(':') {
+            auth_str
+        } else {
+            format!("{auth_str}:80")
+        }
     } else {
         format!("{host}:80")
     };
 
-    let mut upstream = TcpStream::connect(&addr).map_err(|e| {
-        let _ = send_error(&client, 502, "Bad Gateway");
-        io::Error::new(
-            e.kind(),
-            format!("failed to connect to upstream {addr}: {e}"),
-        )
-    })?;
-    upstream.set_read_timeout(Some(CLIENT_TIMEOUT))?;
-    upstream.set_write_timeout(Some(CLIENT_TIMEOUT))?;
+    // Connect to upstream.
+    let upstream = match TcpStream::connect(&addr).await {
+        Ok(s) => s,
+        Err(e) => {
+            warn!(addr = %addr, error = %e, "failed to connect upstream");
+            return Ok(error_response(502, "Bad Gateway"));
+        }
+    };
 
-    // Re-send request line + headers.
-    upstream.write_all(request_line.as_bytes())?;
-    upstream.write_all(b"\r\n")?;
-    for h in &headers {
-        upstream.write_all(h.as_bytes())?;
+    let io = TokioIo::new(upstream);
+
+    // HTTP/1.1 handshake with upstream.
+    let (mut sender, conn) = match hyper::client::conn::http1::handshake(io).await {
+        Ok(parts) => parts,
+        Err(e) => {
+            warn!(error = %e, "upstream handshake failed");
+            return Ok(error_response(502, "Bad Gateway"));
+        }
+    };
+
+    // Drive the upstream connection in the background.
+    tokio::task::spawn(async move {
+        if let Err(e) = conn.await {
+            debug!(error = %e, "upstream connection error");
+        }
+    });
+
+    // Transform URI from absolute-form to origin-form for the upstream.
+    let (mut parts, body) = req.into_parts();
+    let path_and_query = parts
+        .uri
+        .path_and_query()
+        .map(|pq| pq.as_str())
+        .unwrap_or("/");
+    parts.uri = path_and_query.parse().unwrap_or_default();
+    let upstream_req = Request::from_parts(parts, body);
+
+    // Forward the request and collect the response.
+    match sender.send_request(upstream_req).await {
+        Ok(resp) => {
+            let (resp_parts, incoming) = resp.into_parts();
+            match incoming.collect().await {
+                Ok(collected) => {
+                    let body = full_body(collected.to_bytes());
+                    Ok(Response::from_parts(resp_parts, body))
+                }
+                Err(e) => {
+                    warn!(error = %e, "failed to read upstream response");
+                    Ok(error_response(502, "Bad Gateway"))
+                }
+            }
+        }
+        Err(e) => {
+            warn!(error = %e, "failed to forward request");
+            Ok(error_response(502, "Bad Gateway"))
+        }
     }
-    upstream.write_all(b"\r\n")?;
-    upstream.flush()?;
-
-    // Relay the response back.  We don't parse it -- just pipe bytes both
-    // directions until the connection closes.
-    relay(client, upstream)
-}
-
-// ---------------------------------------------------------------------------
-// Bidirectional relay
-// ---------------------------------------------------------------------------
-
-/// Bidirectional byte relay between `client` and `upstream`.
-///
-/// Spawns two threads: one copying client -> upstream and one copying
-/// upstream -> client.  When either direction's copy finishes (EOF or error),
-/// the write side of the other direction is shut down so the peer sees EOF.
-fn relay(client: TcpStream, upstream: TcpStream) -> io::Result<()> {
-    let client_r = client.try_clone()?;
-    let client_w = client.try_clone()?;
-    let upstream_r = upstream.try_clone()?;
-    let upstream_w = upstream.try_clone()?;
-
-    // client -> upstream
-    let c2u = thread::Builder::new()
-        .name("relay-c2u".into())
-        .spawn(move || {
-            let mut src = client_r;
-            let mut dst = upstream_w;
-            let _ = io::copy(&mut src, &mut dst);
-            let _ = dst.shutdown(Shutdown::Write);
-        })?;
-
-    // upstream -> client
-    let u2c = thread::Builder::new()
-        .name("relay-u2c".into())
-        .spawn(move || {
-            let mut src = upstream_r;
-            let mut dst = client_w;
-            let _ = io::copy(&mut src, &mut dst);
-            let _ = dst.shutdown(Shutdown::Write);
-        })?;
-
-    let _ = c2u.join();
-    let _ = u2c.join();
-    Ok(())
 }
 
 // ---------------------------------------------------------------------------
@@ -364,96 +391,29 @@ fn extract_host_from_authority(authority: &str) -> &str {
         .unwrap_or(authority)
 }
 
-/// Determine the target host for a plain HTTP request.
+/// Extract the target hostname from a plain HTTP request.
 ///
-/// Tries the `Host` header first (reading additional header lines from the
-/// buffered reader), then falls back to parsing the absolute-form URI in the
-/// request line.
-fn resolve_host(reader: &mut BufReader<TcpStream>, uri: &str) -> io::Result<String> {
-    // Peek at headers to find `Host:`.  We buffer lines so we can re-send
-    // them later; however, `resolve_host` is only used to decide
-    // allow/deny -- the full header set is read again in `handle_http`.
-    // Because the reader is a `BufReader` and we need the headers later,
-    // we look at the URI first and only fall through to headers if needed.
-
-    // Absolute-form: http://host[:port]/path
-    if let Some(rest) = uri.strip_prefix("http://") {
-        let host_part = rest.split('/').next().unwrap_or(rest);
-        let host = host_part.split(':').next().unwrap_or(host_part);
+/// Checks the absolute-form URI first, then falls back to the Host header.
+fn extract_target_host(req: &Request<Incoming>) -> Option<String> {
+    // Absolute-form URI: http://host[:port]/path
+    if let Some(authority) = req.uri().authority() {
+        let host = authority.host();
         if !host.is_empty() {
-            return Ok(host.to_string());
+            return Some(host.to_string());
         }
     }
 
-    // Read headers looking for Host.
-    // NOTE: we must still leave them in the reader for handle_http to
-    // re-read.  Because BufReader buffers data, and we cannot "unread",
-    // we consume here and accept that handle_http will see them already
-    // consumed.  This is fine -- handle_http collects whatever headers
-    // remain after resolve_host returns.
-    //
-    // In practice the Host header is typically the first header, so the
-    // loop is short.
-    let mut line = String::new();
-    loop {
-        line.clear();
-        let n = reader.read_line(&mut line)?;
-        if n == 0 || line == "\r\n" || line == "\n" {
-            break;
-        }
-        if let Some(value) = line.strip_prefix("Host:").or_else(|| line.strip_prefix("host:")) {
-            let value = value.trim();
-            let host = value.split(':').next().unwrap_or(value);
-            return Ok(host.to_string());
-        }
-        // Also try case-insensitive match.
-        if line.len() > 5 && line[..5].eq_ignore_ascii_case("host:") {
-            let value = line[5..].trim();
-            let host = value.split(':').next().unwrap_or(value);
-            return Ok(host.to_string());
+    // Host header fallback.
+    if let Some(host_value) = req.headers().get(hyper::header::HOST)
+        && let Ok(host_str) = host_value.to_str()
+    {
+        let host = host_str.split(':').next().unwrap_or(host_str);
+        if !host.is_empty() {
+            return Some(host.to_string());
         }
     }
 
-    Err(io::Error::new(
-        io::ErrorKind::InvalidData,
-        "could not determine target host from request",
-    ))
-}
-
-/// Consume (and discard) HTTP headers until the blank line terminator.
-fn consume_headers(reader: &mut BufReader<TcpStream>) -> io::Result<()> {
-    let mut line = String::new();
-    loop {
-        line.clear();
-        let n = reader.read_line(&mut line)?;
-        if n == 0 || line == "\r\n" || line == "\n" {
-            return Ok(());
-        }
-    }
-}
-
-/// Send a minimal HTTP error response.
-fn send_error(stream: &TcpStream, code: u16, reason: &str) -> io::Result<()> {
-    let body = format!("{code} {reason}\r\n");
-    let response = format!(
-        "HTTP/1.1 {code} {reason}\r\n\
-         Content-Length: {}\r\n\
-         Content-Type: text/plain\r\n\
-         Connection: close\r\n\
-         \r\n\
-         {body}",
-        body.len(),
-    );
-    // Use a short-lived clone so we don't need &mut.
-    let mut w = stream.try_clone()?;
-    w.write_all(response.as_bytes())?;
-    w.flush()?;
-    // Explicitly shut down the write half so the client receives a TCP FIN
-    // instead of RST when the socket is dropped.  Without this, the implicit
-    // close can race the response data, producing "Connection reset by peer"
-    // on the client side.
-    let _ = stream.shutdown(Shutdown::Write);
-    Ok(())
+    None
 }
 
 // ---------------------------------------------------------------------------
@@ -464,153 +424,7 @@ fn send_error(stream: &TcpStream, code: u16, reason: &str) -> io::Result<()> {
 mod tests {
     use super::*;
     use std::io::{BufRead, BufReader, Read, Write};
-    use std::net::{SocketAddr, TcpListener, TcpStream};
-    use std::time::Instant;
-
-    // -- Test helpers ------------------------------------------------------
-
-    /// Poll a condition with bounded retries.  Returns `true` if the
-    /// condition was met within `timeout`.
-    fn poll_until(timeout: Duration, interval: Duration, mut f: impl FnMut() -> bool) -> bool {
-        let deadline = Instant::now() + timeout;
-        while Instant::now() < deadline {
-            if f() {
-                return true;
-            }
-            thread::sleep(interval);
-        }
-        false
-    }
-
-    /// A client connection to the proxy with graceful shutdown on drop.
-    ///
-    /// Owns both the stream and a buffered reader over a clone, so there is
-    /// no lifetime tangle between reads and writes.  The `Drop` impl sends
-    /// FIN (via `shutdown(Write)`) and drains outstanding data before the
-    /// socket is closed, preventing the kernel from sending RST.
-    struct ProxyClient {
-        stream: TcpStream,
-        reader: BufReader<TcpStream>,
-    }
-
-    impl ProxyClient {
-        fn connect(addr: SocketAddr) -> Self {
-            let stream = TcpStream::connect(addr).expect("failed to connect to proxy");
-            stream
-                .set_read_timeout(Some(Duration::from_secs(5)))
-                .unwrap();
-            stream
-                .set_write_timeout(Some(Duration::from_secs(5)))
-                .unwrap();
-            let reader = BufReader::new(stream.try_clone().unwrap());
-            Self { stream, reader }
-        }
-
-        fn send_connect(&mut self, authority: &str) {
-            let host = authority.split(':').next().unwrap_or(authority);
-            write!(
-                self.stream,
-                "CONNECT {authority} HTTP/1.1\r\nHost: {host}\r\n\r\n",
-            )
-            .expect("failed to write CONNECT");
-            self.stream.flush().unwrap();
-        }
-
-        fn read_line(&mut self) -> String {
-            let mut line = String::new();
-            self.reader
-                .read_line(&mut line)
-                .expect("failed to read line");
-            line
-        }
-
-        fn read_status_code(&mut self) -> u16 {
-            let line = self.read_line();
-            let code_str = line
-                .split_whitespace()
-                .nth(1)
-                .unwrap_or_else(|| panic!("malformed status line: {line}"));
-            code_str
-                .parse::<u16>()
-                .unwrap_or_else(|_| panic!("non-numeric status code in: {line}"))
-        }
-
-        fn close(self) {
-            drop(self);
-        }
-    }
-
-    impl Drop for ProxyClient {
-        fn drop(&mut self) {
-            // Send FIN to proxy.
-            let _ = self.stream.shutdown(Shutdown::Write);
-            // Drain any remaining data so close doesn't race pending writes.
-            let _ = self
-                .stream
-                .set_read_timeout(Some(Duration::from_millis(500)));
-            let mut discard = [0u8; 1024];
-            while let Ok(n) = self.reader.read(&mut discard) {
-                if n == 0 {
-                    break;
-                }
-            }
-        }
-    }
-
-    /// A mock upstream TCP server for CONNECT tunnel tests.
-    ///
-    /// Accepts one connection, writes `greeting`, shuts down its write half
-    /// (so the relay sees EOF), then drains reads until the client closes.
-    struct UpstreamServer {
-        addr: SocketAddr,
-        handle: Option<thread::JoinHandle<()>>,
-    }
-
-    impl UpstreamServer {
-        fn with_greeting(greeting: &'static [u8]) -> Self {
-            let listener = TcpListener::bind("127.0.0.1:0").expect("failed to bind upstream");
-            let addr = listener.local_addr().unwrap();
-
-            let handle = thread::spawn(move || {
-                let (mut conn, _) = listener.accept().expect("upstream accept");
-                conn.write_all(greeting).expect("upstream write");
-                conn.flush().unwrap();
-                // Signal EOF to the relay's upstream->client direction.
-                let _ = conn.shutdown(Shutdown::Write);
-                // Drain reads so the relay's client->upstream direction
-                // finishes cleanly when the client shuts down.
-                let mut buf = [0u8; 1024];
-                while let Ok(n) = conn.read(&mut buf) {
-                    if n == 0 {
-                        break;
-                    }
-                }
-            });
-
-            Self {
-                addr,
-                handle: Some(handle),
-            }
-        }
-
-        fn port(&self) -> u16 {
-            self.addr.port()
-        }
-
-        fn join(mut self) {
-            if let Some(h) = self.handle.take() {
-                h.join().expect("upstream thread panicked");
-            }
-        }
-    }
-
-    impl Drop for UpstreamServer {
-        fn drop(&mut self) {
-            if let Some(h) = self.handle.take() {
-                let _ = h.join();
-            }
-        }
-    }
+    use std::time::Duration;
 
     // -- Domain matching ---------------------------------------------------
 
@@ -642,77 +456,120 @@ mod tests {
 
     #[test]
     fn test_proxy_lifecycle() {
-        let config = ProxyConfig {
-            allowed_domains: vec!["example.com".to_string()],
-        };
-        let handle = start_proxy(config).expect("failed to start proxy");
+        let handle = start_proxy(ProxyConfig {
+            allowed_domains: vec!["example.com".into()],
+        })
+        .unwrap();
         let addr = handle.addr;
 
-        // Addr should be on loopback with a non-zero port.
         assert_eq!(addr.ip(), std::net::Ipv4Addr::LOCALHOST);
         assert_ne!(addr.port(), 0);
 
         // Should be able to connect.
-        let client = ProxyClient::connect(addr);
-        client.close();
+        let stream = std::net::TcpStream::connect(addr).unwrap();
+        drop(stream);
 
-        // Drop the handle -- proxy should shut down.
+        // Drop the handle -- proxy should shut down deterministically.
         drop(handle);
 
-        // Poll until connections are refused (replaces fixed sleep).
-        let stopped = poll_until(Duration::from_secs(2), Duration::from_millis(50), || {
-            TcpStream::connect_timeout(&addr.into(), Duration::from_millis(100)).is_err()
-        });
-        assert!(stopped, "proxy should have stopped accepting connections");
+        // After drop returns, the listener is closed.
+        assert!(
+            std::net::TcpStream::connect_timeout(&addr.into(), Duration::from_millis(200)).is_err(),
+            "proxy should have stopped accepting connections"
+        );
     }
 
     // -- Proxy blocks unlisted domains -------------------------------------
 
     #[test]
     fn test_proxy_denies_unlisted_domain() {
-        let config = ProxyConfig {
-            allowed_domains: vec!["github.com".to_string()],
-        };
-        let handle = start_proxy(config).expect("failed to start proxy");
+        let handle = start_proxy(ProxyConfig {
+            allowed_domains: vec!["github.com".into()],
+        })
+        .unwrap();
 
-        let mut client = ProxyClient::connect(handle.addr);
-        client.send_connect("evil.com:443");
+        let mut stream = std::net::TcpStream::connect(handle.addr).unwrap();
+        stream
+            .set_read_timeout(Some(Duration::from_secs(5)))
+            .unwrap();
+        write!(
+            stream,
+            "CONNECT evil.com:443 HTTP/1.1\r\nHost: evil.com\r\n\r\n"
+        )
+        .unwrap();
 
-        let code = client.read_status_code();
-        assert_eq!(code, 403, "expected 403 Forbidden");
-
-        client.close();
+        let mut reader = BufReader::new(&stream);
+        let mut line = String::new();
+        reader.read_line(&mut line).unwrap();
+        let code: u16 = line.split_whitespace().nth(1).unwrap().parse().unwrap();
+        assert_eq!(code, 403, "expected 403 Forbidden, got: {line}");
     }
 
     // -- Proxy allows listed domain via CONNECT ----------------------------
 
     #[test]
     fn test_proxy_allows_listed_domain_connect() {
-        let upstream = UpstreamServer::with_greeting(b"HELLO FROM UPSTREAM\n");
+        // Mock upstream server: accepts one connection, writes a greeting,
+        // shuts down its write half, then drains reads.
+        let upstream_listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind upstream");
+        let upstream_port = upstream_listener.local_addr().unwrap().port();
 
-        let config = ProxyConfig {
-            allowed_domains: vec!["localhost".to_string()],
-        };
-        let handle = start_proxy(config).expect("failed to start proxy");
+        let upstream_thread = std::thread::spawn(move || {
+            let (mut conn, _) = upstream_listener.accept().expect("upstream accept");
+            conn.write_all(b"HELLO FROM UPSTREAM\n")
+                .expect("upstream write");
+            conn.flush().unwrap();
+            let _ = conn.shutdown(std::net::Shutdown::Write);
+            let mut buf = [0u8; 1024];
+            while let Ok(n) = conn.read(&mut buf) {
+                if n == 0 {
+                    break;
+                }
+            }
+        });
 
-        let mut client = ProxyClient::connect(handle.addr);
-        let authority = format!("localhost:{}", upstream.port());
-        client.send_connect(&authority);
+        let handle = start_proxy(ProxyConfig {
+            allowed_domains: vec!["localhost".into()],
+        })
+        .unwrap();
 
-        let code = client.read_status_code();
-        assert_eq!(code, 200, "expected 200 Connection Established");
+        let mut stream = std::net::TcpStream::connect(handle.addr).unwrap();
+        stream
+            .set_read_timeout(Some(Duration::from_secs(5)))
+            .unwrap();
+        write!(
+            stream,
+            "CONNECT localhost:{upstream_port} HTTP/1.1\r\nHost: localhost\r\n\r\n"
+        )
+        .unwrap();
 
-        // Consume the blank line after the status.
-        let blank = client.read_line();
-        assert_eq!(blank.trim(), "");
+        let reader_stream = stream.try_clone().unwrap();
+        let mut reader = BufReader::new(reader_stream);
+
+        // Read status line.
+        let mut status = String::new();
+        reader.read_line(&mut status).unwrap();
+        let code: u16 = status.split_whitespace().nth(1).unwrap().parse().unwrap();
+        assert_eq!(code, 200, "expected 200, got: {status}");
+
+        // Consume headers until blank line (hyper may add headers).
+        loop {
+            let mut hdr = String::new();
+            reader.read_line(&mut hdr).unwrap();
+            if hdr.trim().is_empty() {
+                break;
+            }
+        }
 
         // Read the upstream greeting through the tunnel.
-        let greeting = client.read_line();
+        let mut greeting = String::new();
+        reader.read_line(&mut greeting).unwrap();
         assert_eq!(greeting, "HELLO FROM UPSTREAM\n");
 
-        // Graceful close: client FIN → relay c2u EOF → upstream write shutdown
-        // → relay u2c EOF → client drain EOF.  No RSTs.
-        client.close();
-        upstream.join();
+        // Clean shutdown.
+        let _ = stream.shutdown(std::net::Shutdown::Write);
+        drop(stream);
+        drop(reader);
+        upstream_thread.join().expect("upstream thread panicked");
     }
 }


### PR DESCRIPTION
## Summary

- Rewrites the sandbox domain-filtering proxy from synchronous `std::net` + `std::thread` + manual HTTP parsing to async `tokio` + `hyper 1.x`
- Eliminates TCP RST vs FIN races that caused flaky tests on macOS CI
- Public API unchanged — no caller modifications needed

## Key changes

- **hyper** handles HTTP framing and connection lifecycle (no more `BufReader` + `read_line` parsing)
- **`tokio::io::copy_bidirectional`** replaces the manual 2-thread relay with `try_clone`/`shutdown`/drain
- **`hyper::upgrade`** handles CONNECT tunneling correctly
- **Shutdown** via `oneshot::Sender` drop — deterministic, no polling or connect-poke hacks
- **Tests simplified**: plain `std::net::TcpStream` clients work without drain-on-Drop wrappers

## Test plan

- [ ] All 7 proxy tests pass (4 domain matching + 3 integration)
- [ ] 15/15 consecutive runs with zero flakes locally
- [ ] `just check` passes (tests + clippy)
- [ ] CI passes on both Linux and macOS