### PR TITLE
feat(hooks): add CLASH_DISABLE env var to bypass all hooks

### DIFF
--- a/clash/src/cmd/doctor.rs
+++ b/clash/src/cmd/doctor.rs
@@ -64,6 +64,7 @@ pub fn run() -> Result<()> {
     println!();
 
     let checks = vec![
+        ("Disabled", check_disabled()),
         ("Policy files", check_policy_files()),
         ("Policy parsing", check_policy_parsing()),
         ("Plugin installed", check_plugin_installed()),
@@ -108,6 +109,18 @@ pub fn run() -> Result<()> {
     }
 
     Ok(())
+}
+
+/// Check 0: Is clash disabled via environment variable?
+fn check_disabled() -> CheckResult {
+    if crate::settings::is_disabled() {
+        CheckResult::Warn(format!(
+            "{} is set — all hooks are pass-through. Unset to re-enable.",
+            crate::settings::CLASH_DISABLE_ENV,
+        ))
+    } else {
+        CheckResult::Pass("Clash is enabled.".into())
+    }
 }
 
 /// Check 1: Do policy files exist?

--- a/clash/src/cmd/hooks.rs
+++ b/clash/src/cmd/hooks.rs
@@ -11,8 +11,36 @@ use crate::settings::{ClashSettings, HookContext};
 use claude_settings::PermissionRule;
 
 impl HooksCmd {
+    /// Handle hook when clash is disabled — drain stdin and return pass-through.
+    fn run_disabled(&self) -> Result<()> {
+        info!("Clash is disabled (CLASH_DISABLE), returning pass-through");
+        let output = match self {
+            Self::SessionStart => {
+                // Still read stdin to avoid broken pipe.
+                let _ = crate::hooks::SessionStartHookInput::from_reader(std::io::stdin().lock());
+                HookOutput::session_start(Some(
+                    "Clash is disabled (CLASH_DISABLE is set). \
+                     All hooks are pass-through — no policy enforcement is active. \
+                     Unset CLASH_DISABLE to re-enable."
+                        .into(),
+                ))
+            }
+            _ => {
+                // Drain stdin to avoid broken pipe, but skip parsing.
+                let _ = std::io::copy(&mut std::io::stdin().lock(), &mut std::io::sink());
+                HookOutput::continue_execution()
+            }
+        };
+        output.write_stdout()?;
+        Ok(())
+    }
+
     #[instrument(level = Level::TRACE, skip(self))]
     pub fn run(&self) -> Result<()> {
+        if crate::settings::is_disabled() {
+            return self.run_disabled();
+        }
+
         let output = match self {
             Self::PreToolUse => {
                 let input = ToolUseHookInput::from_reader(std::io::stdin().lock())?;

--- a/clash/src/cmd/status.rs
+++ b/clash/src/cmd/status.rs
@@ -10,6 +10,22 @@ use crate::style;
 /// Show policy status: layers, rules with shadowing, and potential issues.
 #[instrument(level = Level::TRACE)]
 pub fn run(_json: bool, verbose: bool) -> Result<()> {
+    if crate::settings::is_disabled() {
+        println!("{}", style::banner());
+        println!();
+        println!(
+            "  {} Clash is {}",
+            style::yellow_bold("!"),
+            style::yellow_bold("DISABLED")
+        );
+        println!(
+            "  {} is set — all hooks are pass-through, no policy enforcement is active.",
+            style::cyan("CLASH_DISABLE")
+        );
+        println!("  Unset the variable to re-enable clash.");
+        return Ok(());
+    }
+
     let settings = ClashSettings::load_or_create()?;
     let tree = match settings.decision_tree() {
         Some(t) => t,

--- a/clash/src/cmd/statusline.rs
+++ b/clash/src/cmd/statusline.rs
@@ -49,6 +49,13 @@ fn render(format: &str) -> Result<()> {
     // so the console crate would suppress them. Force colors on.
     console::set_colors_enabled(true);
 
+    if crate::settings::is_disabled() {
+        // Drain stdin to avoid broken pipe.
+        let _ = serde_json::from_reader::<_, serde_json::Value>(std::io::stdin().lock());
+        print!("{}clash {}", style::cyan("⚡"), style::yellow("disabled"));
+        return Ok(());
+    }
+
     let payload: StdinPayload = serde_json::from_reader(std::io::stdin().lock())
         .context("Failed to read JSON from stdin")?;
 

--- a/docs/session-context.md
+++ b/docs/session-context.md
@@ -152,6 +152,18 @@ Suggest one of these fixes:
 
 **Do NOT retry the command** — it will fail again until the sandbox policy is updated.
 
+### Disabling Clash
+
+Set `CLASH_DISABLE=1` in the environment to temporarily disable all clash hooks for a session.
+When disabled, clash becomes a complete pass-through — no policy evaluation, no sandbox enforcement,
+no permission decisions. All tool calls proceed as if clash were not installed.
+
+```bash
+CLASH_DISABLE=1 claude          # disable for this session only
+```
+
+Set `CLASH_DISABLE=0` or unset the variable to re-enable clash.
+
 ### Important Behaviors
 
 - Deny rules ALWAYS take precedence over allow rules, regardless of specificity


### PR DESCRIPTION
## Summary

- Adds `CLASH_DISABLE` environment variable that turns clash into a complete pass-through — all hooks return immediately without evaluating policy
- When disabled, `SessionStart` still returns context informing Claude that clash is disabled
- `clash status`, statusline, and `clash doctor` all report the disabled state prominently

## Usage

```bash
CLASH_DISABLE=1 claude          # disable for this session only
```

Set `CLASH_DISABLE=0`, `CLASH_DISABLE=false`, or unset the variable to re-enable.

## Changes

| File | Change |
|------|--------|
| `clash/src/settings.rs` | `CLASH_DISABLE_ENV` constant + `is_disabled()` function + 7 unit tests |
| `clash/src/cmd/hooks.rs` | `run_disabled()` — early return pass-through for all 4 hook types |
| `clash/src/cmd/status.rs` | "DISABLED" banner when env var is set |
| `clash/src/cmd/statusline.rs` | "clash disabled" in status line |
| `clash/src/cmd/doctor.rs` | New "Disabled" diagnostic check |
| `docs/session-context.md` | "Disabling Clash" section with usage example |

## Test plan

- [x] All 420 existing tests pass (`just check`)
- [x] 7 new unit tests for `is_disabled()` covering: unset, empty, "0", "false", "1", "true", arbitrary value
- [x] Smoke tested all 4 hooks with `CLASH_DISABLE=1` — returns pass-through
- [x] Smoke tested `CLASH_DISABLE=0` — normal policy evaluation runs
- [x] Smoke tested `clash status` and `clash doctor` with disabled state
- [x] No new clippy warnings

Closes #170