### PR TITLE
feat(policy): add path-based matching to network capability rules

### DIFF
--- a/clash/src/audit.rs
+++ b/clash/src/audit.rs
@@ -294,9 +294,10 @@ fn deny_hint(tool_name: &str, tool_input: &serde_json::Value, cwd: &str) -> Resu
         CapQuery::Fs { op, path } => {
             format!("(fs {} \"{}\")", op, path)
         }
-        CapQuery::Net { domain } => {
-            format!("(net \"{}\")", domain)
-        }
+        CapQuery::Net { domain, path } => match path {
+            Some(p) => format!("(net \"{}\" (subpath \"{}\"))", domain, p),
+            None => format!("(net \"{}\")", domain),
+        },
         CapQuery::Tool { name } => {
             format!("(tool \"{}\")", name)
         }
@@ -319,7 +320,10 @@ fn tool_input_summary(tool_name: &str, input: &serde_json::Value, cwd: &str) -> 
             }
         }
         Some(CapQuery::Fs { path, .. }) => shorten_path(path),
-        Some(CapQuery::Net { domain }) => domain.clone(),
+        Some(CapQuery::Net { domain, path }) => match path {
+            Some(p) => format!("{domain}{p}"),
+            None => domain.clone(),
+        },
         Some(CapQuery::Tool { name }) => name.clone(),
         None => String::new(),
     };

--- a/clash/src/cmd/policy.rs
+++ b/clash/src/cmd/policy.rs
@@ -177,6 +177,7 @@ fn parse_cli_rule(effect: Effect, rule_str: &str) -> Result<Vec<AstRule>> {
                 effect,
                 matcher: CapMatcher::Net(NetMatcher {
                     domain: Pattern::Any,
+                    path: None,
                 }),
                 sandbox: None,
             }]),

--- a/clash/src/debug/replay.rs
+++ b/clash/src/debug/replay.rs
@@ -179,7 +179,10 @@ impl ReplayResult {
                 }
             }
             Some(CapQuery::Fs { op, path }) => format!("(fs {} \"{}\")", op, path),
-            Some(CapQuery::Net { domain }) => format!("(net \"{}\")", domain),
+            Some(CapQuery::Net { domain, path }) => match path {
+                Some(p) => format!("(net \"{}\" (subpath \"{}\"))", domain, p),
+                None => format!("(net \"{}\")", domain),
+            },
             Some(CapQuery::Tool { name }) => format!("(tool \"{}\")", name),
             None => return format!("clash allow '{}'", self.tool_name.to_lowercase()),
         };

--- a/clash/src/session_policy.rs
+++ b/clash/src/session_policy.rs
@@ -170,6 +170,7 @@ pub fn suggest_allow_rule(
             effect: Effect::Allow,
             matcher: CapMatcher::Net(NetMatcher {
                 domain: Pattern::Any,
+                path: None,
             }),
             sandbox: None,
         }),
@@ -273,6 +274,7 @@ fn suggest_net_rule(tool_input: &serde_json::Value) -> Option<Rule> {
         effect: Effect::Allow,
         matcher: CapMatcher::Net(NetMatcher {
             domain: Pattern::Literal(domain),
+            path: None,
         }),
         sandbox: None,
     })

--- a/clash/src/shell.rs
+++ b/clash/src/shell.rs
@@ -1352,6 +1352,7 @@ fn parse_bare_verb(effect: Effect, verb: &str) -> Result<Vec<Rule>> {
             effect,
             matcher: CapMatcher::Net(NetMatcher {
                 domain: Pattern::Any,
+                path: None,
             }),
             sandbox: None,
         }]),

--- a/clester/tests/scripts/v2_net_path_rules.yaml
+++ b/clester/tests/scripts/v2_net_path_rules.yaml
@@ -1,0 +1,85 @@
+meta:
+  name: v2 sexpr policy — network rules with path filtering
+  description: Test net capability rules with subpath, regex, and literal path filters
+
+clash:
+  policy_sexpr: |
+    (default deny "main")
+    (policy "main"
+      (allow (net "github.com" (subpath "/owner/repo")))
+      (allow (net "api.example.com" /^\/v[0-9]+\//))
+      (allow (net "docs.example.com" "/exact/page"))
+      (deny  (net "evil.com")))
+
+steps:
+  - name: webfetch under allowed subpath
+    hook: pre-tool-use
+    tool_name: WebFetch
+    tool_input:
+      url: "https://github.com/owner/repo/issues/42"
+    expect:
+      decision: allow
+
+  - name: webfetch exact allowed subpath
+    hook: pre-tool-use
+    tool_name: WebFetch
+    tool_input:
+      url: "https://github.com/owner/repo"
+    expect:
+      decision: allow
+
+  - name: webfetch outside allowed subpath denied by default
+    hook: pre-tool-use
+    tool_name: WebFetch
+    tool_input:
+      url: "https://github.com/other/repo"
+    expect:
+      decision: deny
+
+  - name: webfetch github root denied by default
+    hook: pre-tool-use
+    tool_name: WebFetch
+    tool_input:
+      url: "https://github.com/"
+    expect:
+      decision: deny
+
+  - name: webfetch regex path match
+    hook: pre-tool-use
+    tool_name: WebFetch
+    tool_input:
+      url: "https://api.example.com/v2/users"
+    expect:
+      decision: allow
+
+  - name: webfetch regex path no match
+    hook: pre-tool-use
+    tool_name: WebFetch
+    tool_input:
+      url: "https://api.example.com/old/users"
+    expect:
+      decision: deny
+
+  - name: webfetch literal path match
+    hook: pre-tool-use
+    tool_name: WebFetch
+    tool_input:
+      url: "https://docs.example.com/exact/page"
+    expect:
+      decision: allow
+
+  - name: webfetch literal path no match
+    hook: pre-tool-use
+    tool_name: WebFetch
+    tool_input:
+      url: "https://docs.example.com/other/page"
+    expect:
+      decision: deny
+
+  - name: websearch does not match path-scoped rules
+    hook: pre-tool-use
+    tool_name: WebSearch
+    tool_input:
+      query: "github owner repo"
+    expect:
+      decision: deny

--- a/docs/policy-grammar.md
+++ b/docs/policy-grammar.md
@@ -62,7 +62,7 @@ exec_matcher    = "(" "exec" pattern? args_spec ")"
 args_spec       = pattern*                         ; positional (default)
                 | ":has" pattern+                  ; orderless set-membership
 fs_matcher      = "(" "fs" op_pattern? path_filter? ")"
-net_matcher     = "(" "net" pattern? ")"
+net_matcher     = "(" "net" pattern? path_filter? ")"
 tool_matcher    = "(" "tool" pattern? ")"
 ```
 
@@ -155,13 +155,16 @@ Matches filesystem operations. Optional operation filter and path filter.
 
 ### Net Matcher
 
-Matches network access by domain.
+Matches network access by domain, optionally scoped to URL paths.
 
 ```
-(net)                          ; match any network access
-(net "github.com")             ; match github.com exactly
-(net /.*\.example\.com/)       ; match example.com subdomains
+(net)                                        ; match any network access
+(net "github.com")                           ; match github.com exactly
+(net "github.com" (subpath "/owner/repo"))   ; match github.com under /owner/repo
+(net /.*\.example\.com/ (regex "/api/.*"))   ; match example.com subdomains under /api/
 ```
+
+Path filters on net rules use the same syntax as filesystem path filters (`subpath`, `literal`, `regex`, `or`, `not`) but match against the URL path of the request rather than a filesystem path. Path filtering is enforced at the policy evaluation layer; the kernel sandbox proxy only performs domain-level filtering.
 
 ### Tool Matcher
 


### PR DESCRIPTION
## Summary

Closes #98.

- Adds path-based matching to network capability rules, allowing users to scope network access to specific URL paths (e.g., `(allow (net "github.com" (subpath "/owner/repo")))`)
- Reuses the existing `PathFilter` infrastructure from filesystem rules for full consistency — `subpath`, `regex`, `literal`, `or`, and `not` all work
- Path filtering is enforced at the policy evaluation layer (pre-tool-use hook) since HTTPS paths are encrypted and cannot be filtered at the kernel sandbox proxy level

### Changes across the full policy pipeline

| Layer | File(s) | Change |
|-------|---------|--------|
| AST | `ast.rs` | `path: Option<PathFilter>` on `NetMatcher` |
| Parser | `parse.rs` | Accept optional path filter as second `(net ...)` argument |
| Compiler | `compile.rs`, `decision_tree.rs` | Compile net path filters via existing `CompiledPathFilter` |
| Evaluator | `eval.rs` | Extract URL path from WebFetch, pass to `CompiledNet::matches` |
| Specificity | `specificity.rs` | Use `path_filter_rank` as secondary dimension for net rules |
| Display | `wizard.rs` | Human-readable descriptions for net path filters |
| Versioning | `version.rs` | Bump policy version to 3 for net path filter syntax |
| Docs | `policy-grammar.md` | Updated grammar and examples |
| Tests | `eval.rs`, `parse.rs`, `specificity.rs`, clester YAML | Unit + end-to-end coverage |

### Example syntax

```scheme
; Allow only a specific repo
(allow (net "github.com" (subpath "/owner/repo")))

; Allow API versioned paths via regex
(allow (net "api.example.com" /^\/v[0-9]+\//))

; Allow an exact path
(allow (net "docs.example.com" "/exact/page"))
```

## Test plan

- [x] 491 unit tests pass (`cargo test`)
- [x] All doctests pass
- [x] `cargo clippy` clean (1 pre-existing warning unrelated to this change)
- [x] `cargo fmt` clean
- [x] 152 clester end-to-end steps pass (including new 9-step `v2_net_path_rules.yaml`)
- [x] `just check` passes