### PR TITLE
feat(sandbox): support localhost-only network policy

### DIFF
--- a/clash/src/debug/sandbox.rs
+++ b/clash/src/debug/sandbox.rs
@@ -225,6 +225,7 @@ fn format_network(network: &NetworkPolicy) -> String {
     match network {
         NetworkPolicy::Deny => style::red("denied (all network blocked)"),
         NetworkPolicy::Allow => style::green("allowed (unrestricted)"),
+        NetworkPolicy::Localhost => style::yellow("localhost only"),
         NetworkPolicy::AllowDomains(domains) => {
             format!("{}: {}", style::yellow("filtered"), domains.join(", "))
         }
@@ -263,6 +264,12 @@ mod tests {
     fn test_format_network_allow() {
         let s = format_network(&NetworkPolicy::Allow);
         assert!(s.contains("unrestricted"));
+    }
+
+    #[test]
+    fn test_format_network_localhost() {
+        let s = format_network(&NetworkPolicy::Localhost);
+        assert!(s.contains("localhost"));
     }
 
     #[test]

--- a/clash/src/sandbox/linux.rs
+++ b/clash/src/sandbox/linux.rs
@@ -37,6 +37,12 @@ pub fn exec_sandboxed(
         NetworkPolicy::Deny => {
             install_seccomp_network_filter()?;
         }
+        NetworkPolicy::Localhost => {
+            // Localhost-only: seccomp cannot filter connect() by destination
+            // address, so this is advisory. Block bind/listen/accept to prevent
+            // server-side operations.
+            install_seccomp_advisory_network_filter()?;
+        }
         NetworkPolicy::AllowDomains(_) => {
             // On Linux, seccomp cannot filter connect() by destination address
             // (the address arg is a pointer seccomp can't dereference). We allow

--- a/clash/src/sandbox/macos.rs
+++ b/clash/src/sandbox/macos.rs
@@ -96,8 +96,11 @@ pub fn compile_to_sbpl(policy: &SandboxPolicy, cwd: &str) -> String {
         NetworkPolicy::Allow => {
             p += "(allow network*)\n";
         }
-        NetworkPolicy::AllowDomains(_) => {
-            // Allow only localhost connections (to reach the domain-filtering proxy).
+        NetworkPolicy::Localhost | NetworkPolicy::AllowDomains(_) => {
+            // Allow only localhost connections. For Localhost, this is the
+            // complete enforcement. For AllowDomains, a proxy on localhost
+            // handles domain filtering.
+            //
             // Seatbelt's (remote ip) filter only accepts "localhost" or "*" as
             // host — raw IPs like "127.0.0.1" are not valid. "localhost" covers
             // both IPv4 (127.0.0.1) and IPv6 (::1) loopback.
@@ -279,5 +282,43 @@ mod tests {
         let pattern = "/tmp/foo\"bar";
         let result = sbpl_filter(pattern, PathMatch::Regex);
         assert_eq!(result, "(regex #\"/tmp/foo\"bar\")");
+    }
+
+    // ── Network policy SBPL ────────────────────────────────────────
+
+    #[test]
+    fn sbpl_localhost_allows_only_loopback() {
+        let policy = SandboxPolicy {
+            default: Cap::READ | Cap::EXECUTE,
+            rules: vec![],
+            network: NetworkPolicy::Localhost,
+        };
+        let profile = compile_to_sbpl(&policy, "/tmp");
+        assert!(
+            profile.contains("(allow network-outbound (remote ip \"localhost:*\"))"),
+            "Localhost policy should allow outbound to localhost"
+        );
+        assert!(
+            profile.contains("(deny network*)"),
+            "Localhost policy should deny all other network"
+        );
+    }
+
+    #[test]
+    fn sbpl_localhost_same_as_allow_domains() {
+        let localhost_policy = SandboxPolicy {
+            default: Cap::READ | Cap::EXECUTE,
+            rules: vec![],
+            network: NetworkPolicy::Localhost,
+        };
+        let domains_policy = SandboxPolicy {
+            default: Cap::READ | Cap::EXECUTE,
+            rules: vec![],
+            network: NetworkPolicy::AllowDomains(vec!["example.com".into()]),
+        };
+        let localhost_profile = compile_to_sbpl(&localhost_policy, "/tmp");
+        let domains_profile = compile_to_sbpl(&domains_policy, "/tmp");
+        // Both should produce the same network section (localhost-only + deny rest)
+        assert_eq!(localhost_profile, domains_profile);
     }
 }

--- a/clash/src/sandbox_cmd.rs
+++ b/clash/src/sandbox_cmd.rs
@@ -434,6 +434,13 @@ fn exec_with_proxy(
     command: &[String],
 ) -> Result<()> {
     match &policy.network {
+        NetworkPolicy::Localhost => {
+            // Localhost-only: kernel enforces the restriction directly,
+            // no proxy needed. Exec the sandboxed command directly.
+            match sandbox::exec_sandboxed(policy, cwd, command, None) {
+                Err(e) => anyhow::bail!("sandbox exec failed: {}", e),
+            }
+        }
         NetworkPolicy::AllowDomains(domains) => {
             let proxy_handle = sandbox::proxy::start_proxy(sandbox::proxy::ProxyConfig {
                 allowed_domains: domains.clone(),

--- a/clester/tests/scripts/v2_net_localhost.yaml
+++ b/clester/tests/scripts/v2_net_localhost.yaml
@@ -1,0 +1,42 @@
+meta:
+  name: v2 sexpr policy — localhost-only network rules
+  description: Test that localhost-only net rules allow local and deny external
+
+clash:
+  policy_sexpr: |
+    (default deny "main")
+    (policy "main"
+      (allow (net "localhost")))
+
+steps:
+  - name: webfetch localhost allowed
+    hook: pre-tool-use
+    tool_name: WebFetch
+    tool_input:
+      url: "http://localhost:8080/api/status"
+    expect:
+      decision: allow
+
+  - name: webfetch 127.0.0.1 denied (literal match only)
+    hook: pre-tool-use
+    tool_name: WebFetch
+    tool_input:
+      url: "http://127.0.0.1:3000/health"
+    expect:
+      decision: deny
+
+  - name: webfetch external domain denied
+    hook: pre-tool-use
+    tool_name: WebFetch
+    tool_input:
+      url: "https://github.com/anthropics/claude-code"
+    expect:
+      decision: deny
+
+  - name: websearch denied
+    hook: pre-tool-use
+    tool_name: WebSearch
+    tool_input:
+      query: "test query"
+    expect:
+      decision: deny

--- a/docs/policy-grammar.md
+++ b/docs/policy-grammar.md
@@ -160,11 +160,20 @@ Matches network access by domain, optionally scoped to URL paths.
 ```
 (net)                                        ; match any network access
 (net "github.com")                           ; match github.com exactly
+(net "localhost")                            ; match localhost only
 (net "github.com" (subpath "/owner/repo"))   ; match github.com under /owner/repo
 (net /.*\.example\.com/ (regex "/api/.*"))   ; match example.com subdomains under /api/
 ```
 
 Path filters on net rules use the same syntax as filesystem path filters (`subpath`, `literal`, `regex`, `or`, `not`) but match against the URL path of the request rather than a filesystem path. Path filtering is enforced at the policy evaluation layer; the kernel sandbox proxy only performs domain-level filtering.
+
+#### Localhost-only network access
+
+When all allowed net domains are loopback addresses (`"localhost"`, `"127.0.0.1"`, `"::1"`), Clash automatically uses a lightweight localhost-only sandbox mode. This is enforced directly at the kernel level without spawning an HTTP proxy, making it more efficient than domain-filtered networking. On macOS, Seatbelt restricts connections to localhost at the kernel level. On Linux, enforcement is advisory (seccomp cannot filter connect destinations).
+
+```
+(allow (net "localhost"))   ; localhost-only — no proxy overhead
+```
 
 ### Tool Matcher
 

--- a/docs/policy-guide.md
+++ b/docs/policy-guide.md
@@ -205,13 +205,16 @@ Sandboxes automatically grant access to:
 
 ### Sandbox network restrictions
 
-Sandbox network access has three modes:
+Sandbox network access has four modes:
 
 - `(allow (net))` or `(allow (net *))` — sandbox **allows** all network access (no restrictions)
+- `(allow (net "localhost"))` — sandbox allows **localhost-only** connections, enforced at the kernel level without a proxy
 - `(allow (net "domain.com"))` — sandbox allows network access **only to listed domains** via a local HTTP proxy
 - No net rule — sandbox **denies** all network access
 
-Domain-specific net rules like `(allow (net "crates.io"))` are enforced using a local HTTP proxy. The OS sandbox restricts the process to localhost-only connections, and clash starts a proxy that checks each request against the domain allowlist. Programs that respect `HTTP_PROXY`/`HTTPS_PROXY` environment variables (curl, cargo, npm, pip, etc.) are filtered; programs that bypass the proxy can still reach any host on Linux (advisory enforcement). On macOS, Seatbelt blocks non-localhost connections at the kernel level.
+**Localhost-only mode**: When all allowed domains are loopback addresses (`"localhost"`, `"127.0.0.1"`, `"::1"`), Clash uses a lightweight localhost-only mode that is enforced directly by the OS sandbox without spawning an HTTP proxy. This is useful for processes that need to connect to local development servers but should not access the internet. On macOS, Seatbelt blocks non-localhost connections at the kernel level. On Linux, enforcement is advisory (seccomp cannot filter connect destinations).
+
+**Domain filtering**: Domain-specific net rules like `(allow (net "crates.io"))` are enforced using a local HTTP proxy. The OS sandbox restricts the process to localhost-only connections, and clash starts a proxy that checks each request against the domain allowlist. Programs that respect `HTTP_PROXY`/`HTTPS_PROXY` environment variables (curl, cargo, npm, pip, etc.) are filtered; programs that bypass the proxy can still reach any host on Linux (advisory enforcement). On macOS, Seatbelt blocks non-localhost connections at the kernel level.
 
 Subdomain matching is supported: `(allow (net "github.com"))` also permits `api.github.com`.
 


### PR DESCRIPTION
## Summary

- Adds `NetworkPolicy::Localhost` variant that enforces localhost-only connections at the kernel level without spawning an HTTP proxy
- When all allowed net domains are loopback addresses (`localhost`, `127.0.0.1`, `::1`), the decision tree automatically optimizes `AllowDomains` to `Localhost` to avoid fork+proxy overhead
- On macOS, Seatbelt restricts connections to localhost at kernel level; on Linux, seccomp blocks bind/listen/accept (advisory — cannot filter connect destinations)
- Updates policy grammar and guide docs, adds unit tests and e2e test

## Bug fix included

Fixed a missing `trace_path` argument in `exec_with_proxy`'s Localhost arm (`sandbox_cmd.rs`) that would have caused a compilation failure on Linux. This was invisible on macOS because the function is behind `#[cfg(not(target_os = "macos"))]`.

## Test plan

- [x] `just check` passes (537 unit tests, clippy clean)
- [x] Unit tests for loopback domain detection and Localhost policy generation
- [x] SBPL compilation tests verifying Localhost produces correct macOS sandbox profile
- [x] Serde round-trip test for `NetworkPolicy::Localhost`
- [x] E2E test (`v2_net_localhost.yaml`) verifying policy-layer allow/deny decisions
- [ ] Linux compilation verification (CI)

Closes #123
