### PR TITLE
ci: add merge_group trigger for merge queue support

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -5,6 +5,7 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
+  merge_group:
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
## Summary
- Adds the `merge_group` event trigger to the Rust CI workflow so GitHub merge queues can run checks on queued PRs.

## Test plan
- [ ] Verify CI runs on this PR as usual
- [ ] Enable merge queue in repo settings and confirm queued PRs trigger the Rust workflow