### PR TITLE
fix(sandbox): add Landlock Refer access right to WRITE capability

### DIFF
--- a/clash/src/sandbox/linux.rs
+++ b/clash/src/sandbox/linux.rs
@@ -100,7 +100,7 @@ fn cap_to_access_fs(caps: Cap) -> landlock::BitFlags<AccessFs> {
         access |= AccessFs::ReadFile | AccessFs::ReadDir;
     }
     if caps.contains(Cap::WRITE) {
-        access |= AccessFs::WriteFile | AccessFs::Truncate;
+        access |= AccessFs::WriteFile | AccessFs::Truncate | AccessFs::Refer;
     }
     if caps.contains(Cap::CREATE) {
         access |= AccessFs::MakeReg


### PR DESCRIPTION
## Summary

- Map Landlock's `AccessFs::Refer` to the `WRITE` capability in the Linux sandbox backend.
- Without this, sandboxed processes that write to a temp file and rename it into place (cargo, rustc, gcc) get `EXDEV` errors. Landlock blocks cross-directory renames when `Refer` is not granted.
- `Refer` is only added to paths that already have `WRITE`, so this does not expand which paths are writable.

## Context

Discovered while dogfooding `clash` on its own repo. The sandbox's `WRITE` capability granted `WriteFile` and `Truncate` but omitted `Refer`, making `cargo build` fail inside any sandbox with filesystem restrictions.

## Test plan

- [x] `cargo build` succeeds inside a sandbox with `(allow (fs (or write create delete) (subpath (env PWD))))`
- [x] `cargo clippy` passes
- [x] Existing sandbox tests pass
