### PR TITLE
chore: add curl | bash install script

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,15 @@ There are two ways to run clash depending on what you're doing:
 ### Install (use clash in your day-to-day work)
 
 ```bash
-cargo install clash
+curl -fsSL https://raw.githubusercontent.com/empathic/clash/main/install.sh | bash
 clash init
 claude
+```
+
+This downloads the latest release binary to `~/.local/bin/` (Apple Silicon Mac, Linux x86_64, Linux aarch64). On Intel Mac or other platforms, install via Cargo:
+
+```bash
+cargo install clash
 ```
 
 `clash init` writes a default policy, installs the Claude Code plugin from GitHub, installs the status line, and walks you through initial configuration. After init, every `claude` session automatically loads clash.
@@ -223,9 +229,13 @@ It checks policy files, plugin registration, PATH, file permissions, and sandbox
 
 ### "command not found: clash"
 
-Make sure `~/.cargo/bin` is on your `PATH`:
+Make sure the install directory is on your `PATH`:
 
 ```bash
+# If installed via the install script
+export PATH="$HOME/.local/bin:$PATH"
+
+# If installed via cargo
 export PATH="$HOME/.cargo/bin:$PATH"
 ```
 
@@ -284,7 +294,8 @@ Clash stays installed but becomes a complete pass-through — no policy enforcem
 claude plugin uninstall clash
 
 # 2. Remove the binary
-cargo uninstall clash
+cargo uninstall clash          # if installed via cargo
+rm -f ~/.local/bin/clash       # if installed via the install script
 
 # 3. (Optional) Remove the plugin marketplace entry
 claude plugin marketplace remove clash

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+# Install clash — Command Line Agent Safety Harness
+# Usage: curl -fsSL https://raw.githubusercontent.com/empathic/clash/main/install.sh | bash
+#
+# Environment variables:
+#   CLASH_INSTALL_DIR  Override install directory (default: ~/.local/bin)
+
+set -euo pipefail
+
+REPO="empathic/clash"
+INSTALL_DIR="${CLASH_INSTALL_DIR:-$HOME/.local/bin}"
+
+main() {
+    check_dependencies
+
+    local os arch target version tmpdir
+    os="$(detect_os)"
+    arch="$(detect_arch)"
+    target="$(resolve_target "$os" "$arch")"
+    version="$(fetch_latest_version)"
+
+    echo "Installing clash ${version} (${target}) to ${INSTALL_DIR}..."
+
+    tmpdir="$(mktemp -d)"
+    trap 'rm -rf "$tmpdir"' EXIT
+
+    download_and_verify "$version" "$target" "$tmpdir"
+    install_binary "$tmpdir"
+
+    echo "Installed clash to ${INSTALL_DIR}/clash"
+    check_path
+    echo "Run 'clash init' to get started."
+}
+
+check_dependencies() {
+    local missing=()
+    for cmd in curl tar; do
+        if ! command -v "$cmd" &>/dev/null; then
+            missing+=("$cmd")
+        fi
+    done
+    if ! command -v sha256sum &>/dev/null && ! command -v shasum &>/dev/null; then
+        missing+=("sha256sum or shasum")
+    fi
+    if [ ${#missing[@]} -gt 0 ]; then
+        echo "Error: required commands not found: ${missing[*]}" >&2
+        exit 1
+    fi
+}
+
+detect_os() {
+    case "$(uname -s)" in
+        Linux)  echo "linux" ;;
+        Darwin) echo "macos" ;;
+        *)
+            echo "Error: unsupported OS '$(uname -s)'. Clash supports macOS and Linux." >&2
+            exit 1
+            ;;
+    esac
+}
+
+detect_arch() {
+    case "$(uname -m)" in
+        x86_64|amd64)  echo "x86_64" ;;
+        aarch64|arm64) echo "aarch64" ;;
+        *)
+            echo "Error: unsupported architecture '$(uname -m)'." >&2
+            exit 1
+            ;;
+    esac
+}
+
+resolve_target() {
+    local os="$1" arch="$2"
+    case "${os}-${arch}" in
+        macos-aarch64) echo "aarch64-apple-darwin" ;;
+        linux-x86_64)  echo "x86_64-unknown-linux-musl" ;;
+        linux-aarch64) echo "aarch64-unknown-linux-gnu" ;;
+        macos-x86_64)
+            echo "Error: no prebuilt binary for Intel Mac." >&2
+            echo "Install via Cargo instead: cargo install clash" >&2
+            exit 1
+            ;;
+        *)
+            echo "Error: unsupported platform '${os}-${arch}'." >&2
+            exit 1
+            ;;
+    esac
+}
+
+fetch_latest_version() {
+    local url version
+    # Follow the /releases/latest redirect to get the tag from the final URL
+    url="$(curl -fsSL -o /dev/null -w '%{url_effective}' "https://github.com/${REPO}/releases/latest")"
+    version="${url##*/}"  # extract tag name after last /
+    if [ -z "$version" ]; then
+        echo "Error: could not determine latest release." >&2
+        echo "Check https://github.com/${REPO}/releases" >&2
+        exit 1
+    fi
+    echo "$version"
+}
+
+download_and_verify() {
+    local version="$1" target="$2" tmpdir="$3"
+    local base_url="https://github.com/${REPO}/releases/download/${version}"
+    local tarball="clash-${target}.tar.gz"
+
+    echo "Downloading ${tarball}..."
+    curl -fsSL "${base_url}/${tarball}" -o "${tmpdir}/${tarball}"
+    curl -fsSL "${base_url}/${tarball}.sha256" -o "${tmpdir}/${tarball}.sha256"
+
+    # sha256sum -c expects the tarball in the current directory
+    cd "$tmpdir"
+    echo "Verifying checksum..."
+    if command -v sha256sum &>/dev/null; then
+        sha256sum -c "${tarball}.sha256"
+    else
+        shasum -a 256 -c "${tarball}.sha256"
+    fi
+
+    tar xzf "$tarball"
+}
+
+install_binary() {
+    local tmpdir="$1"
+    mkdir -p "$INSTALL_DIR"
+    mv "${tmpdir}/clash" "${INSTALL_DIR}/clash"
+    chmod +x "${INSTALL_DIR}/clash"
+}
+
+check_path() {
+    case ":$PATH:" in
+        *":${INSTALL_DIR}:"*) ;;
+        *)
+            echo ""
+            echo "Note: ${INSTALL_DIR} is not in your PATH. Add it with:"
+            echo "  export PATH=\"${INSTALL_DIR}:\$PATH\""
+            echo ""
+            ;;
+    esac
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

- Add `install.sh` that downloads the latest GitHub release binary to `~/.local/bin/` with platform detection and SHA256 checksum verification
- Update README to show `curl | bash` as the primary install method, with `cargo install` as a fallback for Intel Mac and other platforms
- Update troubleshooting and uninstall sections to cover both install methods

### Install script features

- Detects OS (macOS/Linux) and architecture (x86_64/aarch64)
- Maps to the correct release target triple
- Verifies SHA256 checksums (hard error if no checksum tool available)
- Cleans up temp files on exit
- Warns if `~/.local/bin` is not in PATH
- Graceful error on Intel Mac (directs to `cargo install`)
- Supports `CLASH_INSTALL_DIR` env var for custom install location

Closes #210

## Test plan

- [ ] Run `bash install.sh` on Apple Silicon Mac and verify binary lands in `~/.local/bin/`
- [ ] Run on Linux x86_64 and verify correct target is downloaded
- [ ] Verify SHA256 checksum is validated (tamper with checksum file to test failure)
- [ ] Run on Intel Mac and verify helpful error message
- [ ] Verify `check_path` warns when `~/.local/bin` is not in PATH
- [ ] Review README install, troubleshooting, and uninstall sections for consistency