### PR TITLE
ci: auto-tag on merge to main

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -1,0 +1,50 @@
+name: Auto-tag on version bump
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+  actions: write
+
+jobs:
+  tag-and-dispatch:
+    if: startsWith(github.event.head_commit.message, 'chore: bump package versions to v')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Extract version from Cargo.toml
+        id: version
+        run: |
+          version=$(grep '^version' clash/Cargo.toml | head -1 | sed 's/.*"\(.*\)"/\1/')
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "tag=v$version" >> "$GITHUB_OUTPUT"
+
+      - name: Check if tag already exists
+        id: check
+        run: |
+          if git rev-parse "refs/tags/${{ steps.version.outputs.tag }}" >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create and push tag
+        if: steps.check.outputs.exists == 'false'
+        run: |
+          git tag "${{ steps.version.outputs.tag }}" -m "chore: bump package versions to ${{ steps.version.outputs.tag }}"
+          git push origin "${{ steps.version.outputs.tag }}"
+
+      - name: Dispatch release workflow
+        if: steps.check.outputs.exists == 'false'
+        run: gh workflow run release.yml --ref "${{ steps.version.outputs.tag }}"
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Dispatch publish workflow
+        if: steps.check.outputs.exists == 'false'
+        run: gh workflow run publish.yml --ref "${{ steps.version.outputs.tag }}"
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,6 +3,7 @@ name: Publish to crates.io
 on:
   push:
     tags: ["v*"]
+  workflow_dispatch:
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,7 @@ name: Release
 on:
   push:
     tags: ["v*"]
+  workflow_dispatch:
 
 permissions:
   contents: write

--- a/justfile
+++ b/justfile
@@ -112,16 +112,15 @@ release version:
     cargo check --quiet 2>/dev/null
     echo "  updated Cargo.lock"
 
-    # Commit and tag
+    # Commit and push (tag is created automatically when PR merges to main)
     git add -A '*.toml' Cargo.lock
     git commit -m "chore: bump package versions to v$new"
-    git tag "v$new" -m "chore: bump package versions to v$new"
-    git push --follow-tags
+    git push -u origin "$tag"
     gh pr create -f
 
     echo ""
-    echo "Created commit and tag v$new."
-    echo "To trigger the release, merge the pr"
+    echo "Pushed branch $tag."
+    echo "Merge the PR to trigger auto-tagging and release."
 
 # Launch a Claude session for a GitHub issue in a new tmux window.
 # Usage: just work 123


### PR DESCRIPTION
## Summary

- Add auto-tag.yml workflow that detects version-bump commits on main, creates an annotated tag on the merge commit, and dispatches release + publish workflows
- Remove tag creation from just release — it now only pushes the branch and creates a PR
- Add workflow_dispatch trigger to release.yml and publish.yml so they can be dispatched by the auto-tag workflow

## Why

Previously just release created the tag on the feature branch. After merging to main, the tag pointed to a stale branch commit rather than a commit in main history. Now the tag is always created on main after the PR merges.

Uses workflow_dispatch (explicitly exempted from GITHUB_TOKEN no-chaining restriction) so no PAT is needed.

## Test plan

- [ ] Merge this PR to main
- [ ] Run just release X.Y.Z and confirm no tag is created locally
- [ ] Merge the version-bump PR
- [ ] Confirm auto-tag.yml runs, creates the tag, and dispatches release + publish
- [ ] Confirm tag sits on a commit in main history