### PR TITLE
ci: adopt Release Please for automated releases

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,44 @@
+name: Release Please
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+  pull-requests: write
+  actions: write
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: googleapis/release-please-action@v4
+        id: release
+        with:
+          config-file: release-please-config.json
+          manifest-file: .release-please-manifest.json
+
+      - name: Dispatch release workflow
+        if: ${{ steps.release.outputs.release_created == 'true' }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'release.yml',
+              ref: '${{ steps.release.outputs.tag_name }}',
+            });
+
+      - name: Dispatch publish workflow
+        if: ${{ steps.release.outputs.release_created == 'true' }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'publish.yml',
+              ref: '${{ steps.release.outputs.tag_name }}',
+            });

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,0 +1,6 @@
+{
+  "clash": "0.3.6",
+  "clash_notify": "0.3.6",
+  "claude_settings": "0.3.6",
+  "clester": "0.3.6"
+}

--- a/justfile
+++ b/justfile
@@ -73,54 +73,10 @@ clash *ARGS:
 fix:
     cargo fix --allow-dirty
 
-# Bump all crate versions, commit, tag, and push to trigger a release.
-# Usage: just release 0.4.0
-release version:
-    #!/usr/bin/env bash
-    set -euo pipefail
-    git switch main
-    new="{{version}}"
-    tag="v$new"
-    git switch -c "$tag"
-
-    # Validate semver format
-    if ! [[ "$new" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-        echo "error: version must be semver (e.g., 0.4.0), got: $new" >&2
-        exit 1
-    fi
-
-    # Detect current version from clash/Cargo.toml
-    old=$(grep '^version' clash/Cargo.toml | head -1 | sed 's/.*"\(.*\)"/\1/')
-    if [ "$old" = "$new" ]; then
-        echo "error: version $new is already the current version" >&2
-        exit 1
-    fi
-
-    echo "Bumping $old → $new"
-
-    # Update all Cargo.toml files (perl -pi works on both macOS and Linux)
-    for f in clash/Cargo.toml clash_notify/Cargo.toml claude_settings/Cargo.toml clester/Cargo.toml; do
-        perl -pi -e "s/^version = \"$old\"/version = \"$new\"/" "$f"
-        echo "  updated $f"
-    done
-
-    # Update workspace dependency versions
-    perl -pi -e "s/version = \"$old\"/version = \"$new\"/g" Cargo.toml
-    echo "  updated Cargo.toml (workspace deps)"
-
-    # Regenerate lockfile
-    cargo check --quiet 2>/dev/null
-    echo "  updated Cargo.lock"
-
-    # Commit and push (tag is created automatically when PR merges to main)
-    git add -A '*.toml' Cargo.lock
-    git commit -m "chore: bump package versions to v$new"
-    git push -u origin "$tag"
-    gh pr create -f
-
-    echo ""
-    echo "Pushed branch $tag."
-    echo "Merge the PR to trigger auto-tagging and release."
+# Release: merge the Release Please PR on GitHub.
+# Release Please auto-creates a PR with version bumps + changelog
+# from conventional commits. Merging it creates the tag and triggers
+# the release + publish workflows.
 
 # Launch a Claude session for a GitHub issue in a new tmux window.
 # Usage: just work 123

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "release-type": "rust",
+  "include-component-in-tag": false,
+  "separate-pull-requests": false,
+  "bump-minor-pre-major": true,
+  "bump-patch-for-minor-pre-major": true,
+  "bootstrap-sha": "4b7d769",
+  "packages": {
+    "clash": {},
+    "clash_notify": {},
+    "claude_settings": {},
+    "clester": {
+      "skip-github-release": true
+    }
+  },
+  "plugins": [
+    {
+      "type": "cargo-workspace",
+      "merge": false
+    },
+    {
+      "type": "linked-versions",
+      "groupName": "clash",
+      "components": ["clash", "clash_notify", "claude_settings", "clester"]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Replaces the manual `just release` + auto-tag workflow (#229) with [Release Please](https://github.com/googleapis/release-please).

- Add `release-please-config.json` and `.release-please-manifest.json` for the cargo workspace (all 4 crates linked to the same version)
- Add `release-please.yml` workflow that dispatches release + publish on tag creation
- Delete `auto-tag.yml` (superseded)
- Remove manual `release` recipe from justfile

## How it works

1. Merge feature PRs with conventional commits (`feat:`, `fix:`, etc.)
2. Release Please auto-creates/updates a Release PR with version bumps + changelogs
3. Merge the Release PR when ready to release
4. Release Please creates the tag on main, then dispatches `release.yml` and `publish.yml`

No PAT required — uses `workflow_dispatch` (exempt from GITHUB_TOKEN chaining restriction).

## Test plan

- [ ] Merge this PR
- [ ] Confirm Release Please creates a Release PR from accumulated conventional commits
- [ ] Merge the Release PR
- [ ] Confirm tag is created on main, release + publish workflows are dispatched