### PR TITLE
feat(policy): adopt ctx.* namespace for observables

### DIFF
--- a/clash/src/policy/ast.rs
+++ b/clash/src/policy/ast.rs
@@ -195,21 +195,50 @@ pub enum PathExpr {
 ///
 /// Replaces the former `WhenPredicate` (command/tool only) and `ObservableRef`
 /// (proxy/fs only) with a single enum covering all observable domains.
+///
+/// Observable names follow the `ctx.*` namespace defined in the v2 language spec.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Observable {
-    /// `command` — matches exec queries (binary + args).
+    /// `command` — invocation-type predicate matching exec queries (binary + args).
     Command,
-    /// `tool` — matches tool queries by name.
+    /// `tool` — invocation-type predicate matching tool queries by name.
     Tool,
-    /// `proxy.method`
-    ProxyMethod,
-    /// `proxy.domain`
-    ProxyDomain,
-    /// `fs.action`
+
+    // -- ctx.http namespace --------------------------------------------------
+    /// `ctx.http.domain` — destination domain (formerly `proxy.domain`).
+    HttpDomain,
+    /// `ctx.http.method` — HTTP method (formerly `proxy.method`).
+    HttpMethod,
+    /// `ctx.http.port` — destination port.
+    HttpPort,
+    /// `ctx.http.path` — URL path.
+    HttpPath,
+
+    // -- ctx.fs namespace ----------------------------------------------------
+    /// `ctx.fs.action` — operation type (formerly `fs.action`).
     FsAction,
-    /// `fs.path`
+    /// `ctx.fs.path` — file path (formerly `fs.path`).
     FsPath,
-    /// `[fs.action fs.path]` — tuple of observables.
+    /// `ctx.fs.exists` — whether the target exists.
+    FsExists,
+
+    // -- ctx.process namespace -----------------------------------------------
+    /// `ctx.process.command` — executable name.
+    ProcessCommand,
+    /// `ctx.process.args` — argument list.
+    ProcessArgs,
+
+    // -- ctx.tool namespace --------------------------------------------------
+    /// `ctx.tool.name` — tool name.
+    ToolName,
+    /// `ctx.tool.args` — tool arguments (dynamic, nullable accessors).
+    ToolArgs,
+
+    // -- ctx.state -----------------------------------------------------------
+    /// `ctx.state` — agent state.
+    State,
+
+    /// `[ctx.fs.action ctx.fs.path]` — tuple of observables.
     Tuple(Vec<Observable>),
 }
 
@@ -376,10 +405,18 @@ impl fmt::Display for Observable {
         match self {
             Observable::Command => write!(f, "command"),
             Observable::Tool => write!(f, "tool"),
-            Observable::ProxyMethod => write!(f, "proxy.method"),
-            Observable::ProxyDomain => write!(f, "proxy.domain"),
-            Observable::FsAction => write!(f, "fs.action"),
-            Observable::FsPath => write!(f, "fs.path"),
+            Observable::HttpDomain => write!(f, "ctx.http.domain"),
+            Observable::HttpMethod => write!(f, "ctx.http.method"),
+            Observable::HttpPort => write!(f, "ctx.http.port"),
+            Observable::HttpPath => write!(f, "ctx.http.path"),
+            Observable::FsAction => write!(f, "ctx.fs.action"),
+            Observable::FsPath => write!(f, "ctx.fs.path"),
+            Observable::FsExists => write!(f, "ctx.fs.exists"),
+            Observable::ProcessCommand => write!(f, "ctx.process.command"),
+            Observable::ProcessArgs => write!(f, "ctx.process.args"),
+            Observable::ToolName => write!(f, "ctx.tool.name"),
+            Observable::ToolArgs => write!(f, "ctx.tool.args"),
+            Observable::State => write!(f, "ctx.state"),
             Observable::Tuple(obs) => {
                 write!(f, "[")?;
                 for (i, o) in obs.iter().enumerate() {

--- a/clash/src/policy/compile.rs
+++ b/clash/src/policy/compile.rs
@@ -494,7 +494,7 @@ fn compile_match_to_sandbox(
     network: &mut NetworkPolicy,
 ) -> Result<()> {
     match &block.observable {
-        Observable::ProxyDomain => {
+        Observable::HttpDomain => {
             // Each arm adds to NetworkPolicy.
             for arm in &block.arms {
                 let effect = match arm.effect {
@@ -520,13 +520,13 @@ fn compile_match_to_sandbox(
                                 }
                             }
                         }
-                        _ => bail!("proxy.domain match arm must be a single pattern"),
+                        _ => bail!("ctx.http.domain match arm must be a single pattern"),
                     }
                 }
-                // :deny arms for proxy.domain are implicitly handled by deny-default.
+                // :deny arms for ctx.http.domain are implicitly handled by deny-default.
             }
         }
-        Observable::ProxyMethod => {
+        Observable::HttpMethod | Observable::HttpPort | Observable::HttpPath => {
             // Deferred for MVP — skip.
         }
         Observable::FsPath => {
@@ -558,7 +558,7 @@ fn compile_match_to_sandbox(
             }
         }
         Observable::Tuple(obs) => {
-            // Handle [fs.action fs.path] tuple.
+            // Handle [ctx.fs.action ctx.fs.path] tuple.
             if obs.len() == 2
                 && matches!(obs[0], Observable::FsAction)
                 && matches!(obs[1], Observable::FsPath)
@@ -571,14 +571,14 @@ fn compile_match_to_sandbox(
                     };
                     match &arm.pattern {
                         ArmPattern::Tuple(elems) if elems.len() == 2 => {
-                            // First element: fs.action → caps.
+                            // First element: ctx.fs.action → caps.
                             let caps = match &elems[0] {
                                 ArmPatternElement::Pat(pat) => {
                                     action_pattern_to_caps_from_pat(pat)?
                                 }
                                 _ => Cap::all(),
                             };
-                            // Second element: fs.path → sandbox rules.
+                            // Second element: ctx.fs.path → sandbox rules.
                             match &elems[1] {
                                 ArmPatternElement::Path(pf) => {
                                     let compiled_pf = compile_path_filter(pf, env)?;
@@ -607,7 +607,7 @@ fn compile_match_to_sandbox(
                                 }
                                 other => {
                                     bail!(
-                                        "unsupported path pattern in [fs.action fs.path] arm: {other:?}"
+                                        "unsupported path pattern in [ctx.fs.action ctx.fs.path] arm: {other:?}"
                                     )
                                 }
                             }
@@ -622,13 +622,25 @@ fn compile_match_to_sandbox(
                             });
                         }
                         other => {
-                            bail!("expected tuple pattern for [fs.action fs.path], got: {other:?}")
+                            bail!("expected tuple pattern for [ctx.fs.action ctx.fs.path], got: {other:?}")
                         }
                     }
                 }
             } else {
-                bail!("unsupported observable tuple: only [fs.action fs.path] is supported")
+                bail!("unsupported observable tuple: only [ctx.fs.action ctx.fs.path] is supported")
             }
+        }
+        Observable::FsExists => {
+            // Deferred — requires runtime stat check.
+        }
+        Observable::ProcessCommand | Observable::ProcessArgs => {
+            // Process observables don't apply to sandbox rules.
+        }
+        Observable::ToolName | Observable::ToolArgs => {
+            // Tool context observables don't apply to sandbox rules.
+        }
+        Observable::State => {
+            // State observable doesn't apply to sandbox rules.
         }
         Observable::Command | Observable::Tool => {
             // Command/tool observables don't apply to sandbox rules (sandbox restricts fs/net only).
@@ -675,11 +687,11 @@ fn compile_arm_path_to_sandbox(
 fn action_pattern_to_caps(pattern: &ArmPattern) -> Result<Cap> {
     match pattern {
         ArmPattern::Single(pat) => action_pattern_to_caps_from_pat(pat),
-        _ => bail!("expected single pattern for fs.action arm"),
+        _ => bail!("expected single pattern for ctx.fs.action arm"),
     }
 }
 
-/// Convert a Pattern (from fs.action position) to Cap flags.
+/// Convert a Pattern (from ctx.fs.action position) to Cap flags.
 fn action_pattern_to_caps_from_pat(pat: &Pattern) -> Result<Cap> {
     match pat {
         Pattern::Any => Ok(Cap::all()),
@@ -897,22 +909,22 @@ fn compile_when_guard(
                 name: pat.clone(),
             })?))
         }
-        Observable::ProxyDomain => {
+        Observable::HttpDomain => {
             let pat = match pattern {
                 ArmPattern::Single(p) => p,
-                _ => bail!("proxy.domain observable requires a single pattern"),
+                _ => bail!("ctx.http.domain observable requires a single pattern"),
             };
             let domain = compile_pattern(pat)?;
             Ok(Predicate::Net(CompiledNet { domain, path: None }))
         }
-        Observable::ProxyMethod => {
+        Observable::HttpMethod | Observable::HttpPort | Observable::HttpPath => {
             // Deferred — always true for now
             Ok(Predicate::True)
         }
         Observable::FsAction => {
             let pat = match pattern {
                 ArmPattern::Single(p) => p,
-                _ => bail!("fs.action observable requires a single pattern"),
+                _ => bail!("ctx.fs.action observable requires a single pattern"),
             };
             let op = pattern_to_op_pattern(pat)?;
             Ok(Predicate::Fs(CompiledFs { op, path: None }))
@@ -926,7 +938,7 @@ fn compile_when_guard(
                         path: None,
                     }));
                 }
-                _ => bail!("fs.path observable requires a path filter pattern"),
+                _ => bail!("ctx.fs.path observable requires a path filter pattern"),
             };
             let compiled_pf = compile_path_filter(pf, env)?;
             Ok(Predicate::Fs(CompiledFs {
@@ -934,13 +946,43 @@ fn compile_when_guard(
                 path: Some(compiled_pf),
             }))
         }
+        Observable::FsExists => {
+            // Deferred — always true for now
+            Ok(Predicate::True)
+        }
+        Observable::ProcessCommand => {
+            // ctx.process.command in a when guard: match on binary name
+            let pat = match pattern {
+                ArmPattern::Single(p) => p,
+                _ => bail!("ctx.process.command observable requires a single pattern"),
+            };
+            let compiled = compile_pattern(pat)?;
+            Ok(Predicate::Command(CompiledExec {
+                bin: compiled,
+                args: vec![],
+                has_args: vec![],
+            }))
+        }
+        Observable::ProcessArgs | Observable::ToolArgs | Observable::State => {
+            // Deferred — always true for now
+            Ok(Predicate::True)
+        }
+        Observable::ToolName => {
+            let pat = match pattern {
+                ArmPattern::Single(p) => p,
+                _ => bail!("ctx.tool.name observable requires a single pattern"),
+            };
+            Ok(Predicate::Tool(compile_tool_to_compiled(&ToolMatcher {
+                name: pat.clone(),
+            })?))
+        }
         Observable::Tuple(_) => {
             bail!("tuple observables are not supported in when guards")
         }
     }
 }
 
-/// Convert a Pattern to an OpPattern (for fs.action when guards).
+/// Convert a Pattern to an OpPattern (for ctx.fs.action when guards).
 fn pattern_to_op_pattern(pat: &Pattern) -> Result<OpPattern> {
     match pat {
         Pattern::Any => Ok(OpPattern::Any),
@@ -972,7 +1014,7 @@ fn pattern_to_op_pattern(pat: &Pattern) -> Result<OpPattern> {
             }
             Ok(OpPattern::Or(ops))
         }
-        _ => bail!("unsupported pattern type for fs.action"),
+        _ => bail!("unsupported pattern type for ctx.fs.action"),
     }
 }
 
@@ -1022,10 +1064,18 @@ fn compile_observable_to_ir(obs: &Observable) -> Result<crate::policy::tree::Obs
     match obs {
         Observable::Command => Ok(ir::Observable::Command),
         Observable::Tool => Ok(ir::Observable::Tool),
-        Observable::ProxyMethod => Ok(ir::Observable::ProxyMethod),
-        Observable::ProxyDomain => Ok(ir::Observable::ProxyDomain),
+        Observable::HttpDomain => Ok(ir::Observable::HttpDomain),
+        Observable::HttpMethod => Ok(ir::Observable::HttpMethod),
+        Observable::HttpPort => Ok(ir::Observable::HttpPort),
+        Observable::HttpPath => Ok(ir::Observable::HttpPath),
         Observable::FsAction => Ok(ir::Observable::FsAction),
         Observable::FsPath => Ok(ir::Observable::FsPath),
+        Observable::FsExists => Ok(ir::Observable::FsExists),
+        Observable::ProcessCommand => Ok(ir::Observable::ProcessCommand),
+        Observable::ProcessArgs => Ok(ir::Observable::ProcessArgs),
+        Observable::ToolName => Ok(ir::Observable::ToolName),
+        Observable::ToolArgs => Ok(ir::Observable::ToolArgs),
+        Observable::State => Ok(ir::Observable::State),
         Observable::Tuple(obs) => {
             let inner = obs
                 .iter()
@@ -2845,7 +2895,7 @@ mod tests {
   (when (command "git" *) :allow)
   (when (command "cargo")
     (sandbox
-      (match proxy.domain
+      (match ctx.http.domain
         "crates.io" :allow
         * :deny))))
 "#;
@@ -2866,15 +2916,15 @@ mod tests {
 (policy "rust"
   (when (command (or "cargo" "rustc"))
     (sandbox
-      (match proxy.domain
+      (match ctx.http.domain
         (or "github.com" "crates.io") :allow)
-      (match [fs.action fs.path]
+      (match [ctx.fs.action ctx.fs.path]
         ["read" (subpath "/home/user/project")] :allow
         [* (subpath "/tmp")] :allow))))
 (policy "web"
   (when (tool (or "WebSearch" "WebFetch"))
     (sandbox
-      (match proxy.domain
+      (match ctx.http.domain
         "github.com" :allow
         * :deny))))
 (policy "main"
@@ -2896,10 +2946,10 @@ mod tests {
 (policy "main"
   (when (command "cargo")
     (sandbox
-      (match proxy.domain
+      (match ctx.http.domain
         "crates.io" :allow
         * :deny)
-      (match [fs.action fs.path]
+      (match [ctx.fs.action ctx.fs.path]
         ["read" (subpath "/home/user")] :allow
         [* (subpath "/tmp")] :allow))))
 "#;
@@ -2927,7 +2977,7 @@ mod tests {
 (policy "main"
   (when (command "cargo")
     (sandbox
-      (match proxy.domain
+      (match ctx.http.domain
         "crates.io" :allow))))
 "#;
         let env = TestEnv::new(&[("PWD", "/home/user")]);
@@ -2949,7 +2999,7 @@ mod tests {
 (policy "main"
   (when (command "cargo")
     (sandbox
-      (match proxy.domain
+      (match ctx.http.domain
         "crates.io" :allow))))
 "#;
         let internals: &[(&str, &str)] = &[(

--- a/clash/src/policy/parse.rs
+++ b/clash/src/policy/parse.rs
@@ -593,17 +593,43 @@ fn parse_when_body_item(expr: &SExpr, ctx: &ParseContext) -> Result<PolicyItem> 
 
 /// Parse a when guard `(observable pattern)` → `(Observable, ArmPattern)`.
 ///
-/// Handles all observable types:
+/// Handles invocation-type guards and ctx.* observable guards:
 /// - `(command ...)` → Observable::Command + ArmPattern::Exec
 /// - `(tool ...)` → Observable::Tool + ArmPattern::Single
-/// - `(proxy.domain ...)` → Observable::ProxyDomain + ArmPattern::Single
-/// - `(fs.action ...)` → Observable::FsAction + ArmPattern::Single
-/// - `(fs.path ...)` → Observable::FsPath + ArmPattern::SinglePath
+/// - `(ctx.http.domain ...)` → Observable::HttpDomain + ArmPattern::Single
+/// - `(ctx.fs.action ...)` → Observable::FsAction + ArmPattern::Single
+/// - `(ctx.fs.path ...)` → Observable::FsPath + ArmPattern::SinglePath
+///
+/// Deprecated flat names (`proxy.domain`, `fs.action`, etc.) are accepted with warnings.
 fn parse_when_guard(expr: &SExpr, ctx: &ParseContext) -> Result<(Observable, ArmPattern)> {
     let list = require_list(expr, "when guard")?;
     ensure!(!list.is_empty(), "empty when guard");
     let head = require_atom(&list[0], "guard keyword")?;
-    match head {
+
+    // Map deprecated names to their canonical ctx.* equivalents.
+    let (canonical, deprecated) = match head {
+        "proxy.domain" => {
+            tracing::warn!("deprecated when guard `proxy.domain`: use `ctx.http.domain`");
+            ("ctx.http.domain", true)
+        }
+        "proxy.method" => {
+            tracing::warn!("deprecated when guard `proxy.method`: use `ctx.http.method`");
+            ("ctx.http.method", true)
+        }
+        "fs.action" => {
+            tracing::warn!("deprecated when guard `fs.action`: use `ctx.fs.action`");
+            ("ctx.fs.action", true)
+        }
+        "fs.path" => {
+            tracing::warn!("deprecated when guard `fs.path`: use `ctx.fs.path`");
+            ("ctx.fs.path", true)
+        }
+        other => (other, false),
+    };
+    let _ = deprecated; // suppress unused warning
+
+    match canonical {
+        // Invocation-type guards
         "command" => {
             let m = parse_exec_matcher(&list[1..], ctx)?;
             Ok((Observable::Command, ArmPattern::Exec(m)))
@@ -612,41 +638,46 @@ fn parse_when_guard(expr: &SExpr, ctx: &ParseContext) -> Result<(Observable, Arm
             let m = parse_tool_matcher(&list[1..], ctx)?;
             Ok((Observable::Tool, ArmPattern::Single(m.name)))
         }
-        "proxy.domain" => {
+
+        // ctx.http guards
+        "ctx.http.domain" => {
             ensure!(
                 list.len() == 2,
-                "(proxy.domain) guard expects exactly 1 pattern"
+                "(ctx.http.domain) guard expects exactly 1 pattern"
             );
             let pat = parse_pattern(&list[1], ctx)?;
-            Ok((Observable::ProxyDomain, ArmPattern::Single(pat)))
+            Ok((Observable::HttpDomain, ArmPattern::Single(pat)))
         }
-        "proxy.method" => {
+        "ctx.http.method" => {
             ensure!(
                 list.len() == 2,
-                "(proxy.method) guard expects exactly 1 pattern"
+                "(ctx.http.method) guard expects exactly 1 pattern"
             );
             let pat = parse_pattern(&list[1], ctx)?;
-            Ok((Observable::ProxyMethod, ArmPattern::Single(pat)))
+            Ok((Observable::HttpMethod, ArmPattern::Single(pat)))
         }
-        "fs.action" => {
+
+        // ctx.fs guards
+        "ctx.fs.action" => {
             ensure!(
                 list.len() == 2,
-                "(fs.action) guard expects exactly 1 pattern"
+                "(ctx.fs.action) guard expects exactly 1 pattern"
             );
             let pat = parse_pattern(&list[1], ctx)?;
             Ok((Observable::FsAction, ArmPattern::Single(pat)))
         }
-        "fs.path" => {
+        "ctx.fs.path" => {
             ensure!(
                 list.len() == 2,
-                "(fs.path) guard expects exactly 1 path filter"
+                "(ctx.fs.path) guard expects exactly 1 path filter"
             );
             let pf = parse_path_filter(&list[1], ctx)?;
             Ok((Observable::FsPath, ArmPattern::SinglePath(pf)))
         }
+
         other => bail!(
             "unknown when guard: {other} (expected 'command', 'tool', \
-             'proxy.domain', 'proxy.method', 'fs.action', or 'fs.path')"
+             'ctx.http.domain', 'ctx.http.method', 'ctx.fs.action', or 'ctx.fs.path')"
         ),
     }
 }
@@ -715,17 +746,55 @@ fn parse_sandbox_match_block(list: &[SExpr], ctx: &ParseContext) -> Result<Match
     parse_match_block_inner(list, ctx, true)
 }
 
-/// Parse an observable reference: `command`, `tool`, `proxy.method`, `proxy.domain`,
-/// `fs.action`, `fs.path`, or `[fs.action fs.path]` (bracket tuple).
+/// Parse an observable reference: `command`, `tool`, or any `ctx.*` observable,
+/// plus deprecated flat names (`proxy.domain`, `fs.action`, etc.).
 fn parse_observable(expr: &SExpr) -> Result<Observable> {
     match expr {
         SExpr::Atom(s, _) => match s.as_str() {
+            // Invocation-type observables (unchanged)
             "command" => Ok(Observable::Command),
             "tool" => Ok(Observable::Tool),
-            "proxy.method" => Ok(Observable::ProxyMethod),
-            "proxy.domain" => Ok(Observable::ProxyDomain),
-            "fs.action" => Ok(Observable::FsAction),
-            "fs.path" => Ok(Observable::FsPath),
+
+            // ctx.http namespace
+            "ctx.http.domain" => Ok(Observable::HttpDomain),
+            "ctx.http.method" => Ok(Observable::HttpMethod),
+            "ctx.http.port" => Ok(Observable::HttpPort),
+            "ctx.http.path" => Ok(Observable::HttpPath),
+
+            // ctx.fs namespace
+            "ctx.fs.action" => Ok(Observable::FsAction),
+            "ctx.fs.path" => Ok(Observable::FsPath),
+            "ctx.fs.exists" => Ok(Observable::FsExists),
+
+            // ctx.process namespace
+            "ctx.process.command" => Ok(Observable::ProcessCommand),
+            "ctx.process.args" => Ok(Observable::ProcessArgs),
+
+            // ctx.tool namespace
+            "ctx.tool.name" => Ok(Observable::ToolName),
+            "ctx.tool.args" => Ok(Observable::ToolArgs),
+
+            // ctx.state
+            "ctx.state" => Ok(Observable::State),
+
+            // Deprecated flat names — accept with warning
+            "proxy.domain" => {
+                tracing::warn!("deprecated observable `proxy.domain`: use `ctx.http.domain`");
+                Ok(Observable::HttpDomain)
+            }
+            "proxy.method" => {
+                tracing::warn!("deprecated observable `proxy.method`: use `ctx.http.method`");
+                Ok(Observable::HttpMethod)
+            }
+            "fs.action" => {
+                tracing::warn!("deprecated observable `fs.action`: use `ctx.fs.action`");
+                Ok(Observable::FsAction)
+            }
+            "fs.path" => {
+                tracing::warn!("deprecated observable `fs.path`: use `ctx.fs.path`");
+                Ok(Observable::FsPath)
+            }
+
             other => bail!("unknown observable: {other}"),
         },
         SExpr::List(children, _) => {
@@ -806,7 +875,7 @@ fn parse_arm_pattern(
         }
     }
 
-    // Fall back to general pattern (tool, proxy.domain, fs.action, etc.)
+    // Fall back to general pattern (tool, ctx.http.domain, ctx.fs.action, etc.)
     let p = parse_pattern(expr, ctx)?;
     Ok(ArmPattern::Single(p))
 }
@@ -1818,7 +1887,7 @@ mod tests {
             (policy "p"
               (when (command "cargo")
                 (sandbox
-                  (match proxy.domain
+                  (match ctx.http.domain
                     "github.com" :allow
                     "crates.io" :allow))))
         "#;
@@ -1838,7 +1907,7 @@ mod tests {
         };
         match &sandbox_body[0] {
             SandboxItem::Match(block) => {
-                assert_eq!(block.observable, Observable::ProxyDomain);
+                assert_eq!(block.observable, Observable::HttpDomain);
                 assert_eq!(block.arms.len(), 2);
                 assert_eq!(block.arms[0].effect, Effect::Allow);
                 assert!(
@@ -2062,7 +2131,7 @@ mod tests {
             (policy "p"
               (when (command "cargo")
                 (sandbox
-                  (match proxy.domain
+                  (match ctx.http.domain
                     "github.com" :ask))))
         "#;
         let err = parse(source).unwrap_err();
@@ -2080,7 +2149,7 @@ mod tests {
             (policy "p"
               (when (command "cargo")
                 (sandbox
-                  (match proxy.domain
+                  (match ctx.http.domain
                     "github.com" :allow
                     * :deny))))
         "#;
@@ -2117,7 +2186,7 @@ mod tests {
             (policy "p"
               (when (command "cargo")
                 (sandbox
-                  (match proxy.method
+                  (match ctx.http.method
                     (not "GET") :deny))))
         "#;
         let ast = parse(source).unwrap();
@@ -2135,7 +2204,7 @@ mod tests {
         };
         match &sandbox_body[0] {
             SandboxItem::Match(block) => {
-                assert_eq!(block.observable, Observable::ProxyMethod);
+                assert_eq!(block.observable, Observable::HttpMethod);
                 assert!(matches!(&block.arms[0].pattern,
                     ArmPattern::Single(Pattern::Not(inner)) if matches!(&**inner, Pattern::Literal(s) if s == "GET")));
             }
@@ -2199,7 +2268,7 @@ mod tests {
         // The def reference should have been spliced as a Match block
         match &when_body[0] {
             PolicyItem::Match(block) => {
-                assert!(matches!(block.observable, Observable::ProxyDomain));
+                assert!(matches!(block.observable, Observable::HttpDomain));
                 assert_eq!(block.arms.len(), 1);
                 assert_eq!(
                     block.arms[0].pattern,

--- a/clash/src/policy/print.rs
+++ b/clash/src/policy/print.rs
@@ -204,7 +204,7 @@ mod tests {
 (policy "main"
   (when (command "cargo")
     (sandbox
-      (match proxy.domain
+      (match ctx.http.domain
         "crates.io" :allow
         * :deny))))
 "#;

--- a/clash/src/policy/tree.rs
+++ b/clash/src/policy/tree.rs
@@ -94,16 +94,38 @@ pub enum Predicate {
 }
 
 /// An observable value for `Match` dispatch.
+///
+/// Mirrors `ast::Observable` with the `ctx.*` namespace from the v2 spec.
 #[derive(Debug, Clone)]
 pub enum Observable {
     /// Matches command execution (binary + args).
     Command,
     /// Matches tool invocations by name.
     Tool,
-    ProxyMethod,
-    ProxyDomain,
+    /// `ctx.http.domain` (formerly `proxy.domain`).
+    HttpDomain,
+    /// `ctx.http.method` (formerly `proxy.method`).
+    HttpMethod,
+    /// `ctx.http.port`
+    HttpPort,
+    /// `ctx.http.path`
+    HttpPath,
+    /// `ctx.fs.action` (formerly `fs.action`).
     FsAction,
+    /// `ctx.fs.path` (formerly `fs.path`).
     FsPath,
+    /// `ctx.fs.exists`
+    FsExists,
+    /// `ctx.process.command`
+    ProcessCommand,
+    /// `ctx.process.args`
+    ProcessArgs,
+    /// `ctx.tool.name`
+    ToolName,
+    /// `ctx.tool.args`
+    ToolArgs,
+    /// `ctx.state`
+    State,
     Tuple(Vec<Observable>),
 }
 
@@ -808,11 +830,16 @@ impl PolicyTree {
 /// Irrelevant observables are silently skipped, matching `Predicate::is_relevant`.
 fn observable_is_relevant(observable: &Observable, ctx: &QueryContext) -> bool {
     match observable {
-        Observable::Command => ctx.bin.is_some(),
-        Observable::Tool => ctx.bin.is_none() && ctx.fs_op.is_none() && ctx.net_domain.is_none(),
-        Observable::ProxyMethod => false, // deferred
-        Observable::ProxyDomain => ctx.net_domain.is_some(),
-        Observable::FsAction | Observable::FsPath => ctx.fs_op.is_some(),
+        Observable::Command | Observable::ProcessCommand | Observable::ProcessArgs => {
+            ctx.bin.is_some()
+        }
+        Observable::Tool | Observable::ToolName | Observable::ToolArgs => {
+            ctx.bin.is_none() && ctx.fs_op.is_none() && ctx.net_domain.is_none()
+        }
+        Observable::HttpMethod | Observable::HttpPort => false, // deferred
+        Observable::HttpDomain | Observable::HttpPath => ctx.net_domain.is_some(),
+        Observable::FsAction | Observable::FsPath | Observable::FsExists => ctx.fs_op.is_some(),
+        Observable::State => false, // deferred
         Observable::Tuple(obs) => obs.iter().all(|o| observable_is_relevant(o, ctx)),
     }
 }
@@ -854,12 +881,13 @@ fn match_arm_against_ctx(
 
 /// Resolve an observable to a list of concrete string values from the query context.
 ///
-/// Returns `None` if the observable cannot be resolved (e.g. `ProxyMethod` is deferred).
+/// Returns `None` if the observable cannot be resolved (e.g. `HttpMethod` is deferred).
 fn resolve_observable(observable: &Observable, ctx: &QueryContext) -> Option<Vec<String>> {
     match observable {
         Observable::Command | Observable::Tool => None, // handled by match_arm_against_ctx
-        Observable::ProxyMethod => None,                // deferred
-        Observable::ProxyDomain => ctx.net_domain.as_ref().map(|d| vec![d.clone()]),
+        Observable::HttpMethod | Observable::HttpPort => None, // deferred
+        Observable::HttpDomain => ctx.net_domain.as_ref().map(|d| vec![d.clone()]),
+        Observable::HttpPath => ctx.net_path.as_ref().map(|p| vec![p.clone()]),
         Observable::FsAction => ctx.fs_op.map(|op| {
             vec![match op {
                 FsOp::Read => "read".to_string(),
@@ -869,6 +897,24 @@ fn resolve_observable(observable: &Observable, ctx: &QueryContext) -> Option<Vec
             }]
         }),
         Observable::FsPath => ctx.fs_path.as_ref().map(|p| vec![p.clone()]),
+        Observable::FsExists => None, // deferred — requires runtime stat check
+        Observable::ProcessCommand => ctx.bin.as_ref().map(|b| vec![b.clone()]),
+        Observable::ProcessArgs => {
+            if ctx.bin.is_some() {
+                Some(ctx.args.clone())
+            } else {
+                None
+            }
+        }
+        Observable::ToolName => {
+            if ctx.bin.is_none() && ctx.fs_op.is_none() && ctx.net_domain.is_none() {
+                Some(vec![ctx.tool_name.clone()])
+            } else {
+                None
+            }
+        }
+        Observable::ToolArgs => None, // deferred — requires tool argument access
+        Observable::State => None,    // deferred
         Observable::Tuple(obs) => {
             let mut values = Vec::with_capacity(obs.len());
             for o in obs {

--- a/clash/src/policy/version.rs
+++ b/clash/src/policy/version.rs
@@ -74,12 +74,100 @@ pub fn validate_version(version: u32) -> anyhow::Result<()> {
 /// valid v2 syntax. The version bump is handled as a feature upgrade in
 /// `upgrade_policy()` instead.
 pub fn all_deprecations() -> Vec<Deprecation> {
-    vec![Deprecation {
-        deprecated_in: 2,
-        message: "`(default ...)` is deprecated in v2. Use `(use \"name\")` and a bare effect in the policy body.".into(),
-        check: |source| source.contains("(default "),
-        fix: Some(fix_default_to_use),
-    }]
+    vec![
+        Deprecation {
+            deprecated_in: 2,
+            message: "`(default ...)` is deprecated in v2. Use `(use \"name\")` and a bare effect in the policy body.".into(),
+            check: |source| source.contains("(default "),
+            fix: Some(fix_default_to_use),
+        },
+        Deprecation {
+            deprecated_in: 2,
+            message: "`proxy.domain` is deprecated. Use `ctx.http.domain`.".into(),
+            check: |source| has_deprecated_observable(source, "proxy.domain"),
+            fix: Some(|s| fix_observable_name(s, "proxy.domain", "ctx.http.domain")),
+        },
+        Deprecation {
+            deprecated_in: 2,
+            message: "`proxy.method` is deprecated. Use `ctx.http.method`.".into(),
+            check: |source| has_deprecated_observable(source, "proxy.method"),
+            fix: Some(|s| fix_observable_name(s, "proxy.method", "ctx.http.method")),
+        },
+        Deprecation {
+            deprecated_in: 2,
+            message: "`fs.action` is deprecated as an observable name. Use `ctx.fs.action`.".into(),
+            check: |source| has_deprecated_observable(source, "fs.action"),
+            fix: Some(|s| fix_observable_name(s, "fs.action", "ctx.fs.action")),
+        },
+        Deprecation {
+            deprecated_in: 2,
+            message: "`fs.path` is deprecated as an observable name. Use `ctx.fs.path`.".into(),
+            check: |source| has_deprecated_observable(source, "fs.path"),
+            fix: Some(|s| fix_observable_name(s, "fs.path", "ctx.fs.path")),
+        },
+    ]
+}
+
+/// Check whether a deprecated observable name appears as a bare atom in the source.
+///
+/// Looks for the name surrounded by s-expression delimiters (whitespace, parens, brackets)
+/// to avoid false positives inside string literals or unrelated identifiers.
+fn has_deprecated_observable(source: &str, name: &str) -> bool {
+    // Observable names appear as bare atoms, so they are delimited by
+    // whitespace, '(', ')', '[', ']', or start/end of string.
+    let is_delim = |c: char| c.is_whitespace() || matches!(c, '(' | ')' | '[' | ']');
+    let mut search_from = 0;
+    while let Some(pos) = source[search_from..].find(name) {
+        let abs_pos = search_from + pos;
+        let before_ok = abs_pos == 0 || source[..abs_pos]
+            .chars()
+            .next_back()
+            .is_some_and(|c| is_delim(c));
+        let after_pos = abs_pos + name.len();
+        let after_ok = after_pos >= source.len()
+            || source[after_pos..]
+                .chars()
+                .next()
+                .is_some_and(|c| is_delim(c));
+        if before_ok && after_ok {
+            return true;
+        }
+        search_from = abs_pos + name.len();
+    }
+    false
+}
+
+/// Replace a deprecated observable name with its `ctx.*` equivalent throughout source text.
+///
+/// Only replaces bare atoms (delimited by s-expression boundaries), not occurrences
+/// inside string literals or other identifiers.
+fn fix_observable_name(source: &str, old: &str, new: &str) -> String {
+    let is_delim = |c: char| c.is_whitespace() || matches!(c, '(' | ')' | '[' | ']');
+    let mut result = String::with_capacity(source.len());
+    let mut search_from = 0;
+    while let Some(pos) = source[search_from..].find(old) {
+        let abs_pos = search_from + pos;
+        let before_ok = abs_pos == 0 || source[..abs_pos]
+            .chars()
+            .next_back()
+            .is_some_and(|c| is_delim(c));
+        let after_pos = abs_pos + old.len();
+        let after_ok = after_pos >= source.len()
+            || source[after_pos..]
+                .chars()
+                .next()
+                .is_some_and(|c| is_delim(c));
+        if before_ok && after_ok {
+            result.push_str(&source[search_from..abs_pos]);
+            result.push_str(new);
+            search_from = after_pos;
+        } else {
+            result.push_str(&source[search_from..after_pos]);
+            search_from = after_pos;
+        }
+    }
+    result.push_str(&source[search_from..]);
+    result
 }
 
 /// Migrate `(default effect "name")` → `(use "name")` + bare effect in the entry policy body.

--- a/docs/policy-grammar.md
+++ b/docs/policy-grammar.md
@@ -447,7 +447,7 @@ when_block      = "(" "when" when_guard when_body+ ")"
 when_guard      = "(" "command" pattern? args_spec ")"
                 | "(" "tool" pattern? ")"
                 | "(" observable pattern ")"
-                | "(" observable path_filter ")"        ; for fs.path
+                | "(" observable path_filter ")"        ; for ctx.fs.path
 when_body       = effect_kw                             ; inline effect
                 | sandbox_block                         ; nested sandbox
                 | when_block                            ; nested when
@@ -461,8 +461,11 @@ sandbox_item    = rule                                  ; flat capability rule
 match_block     = "(" "match" observable match_arm+ ")"     ; policy level (allows :ask)
 sandbox_match_block = "(" "match" observable sandbox_match_arm+ ")"  ; sandbox level (no :ask)
 observable      = "command" | "tool"
-                | "proxy.method" | "proxy.domain"
-                | "fs.action" | "fs.path"
+                | "ctx.http.domain" | "ctx.http.method" | "ctx.http.port" | "ctx.http.path"
+                | "ctx.fs.action" | "ctx.fs.path" | "ctx.fs.exists"
+                | "ctx.process.command" | "ctx.process.args"
+                | "ctx.tool.name" | "ctx.tool.args"
+                | "ctx.state"
                 | "[" observable observable+ "]"         ; tuple
 match_arm       = arm_pattern effect_kw
 sandbox_match_arm = arm_pattern sandbox_effect_kw
@@ -500,14 +503,14 @@ The body contains one or more items: an effect keyword (`:allow`, `:deny`, `:ask
 ; Allow multiple tools
 (when (tool (or "Read" "Glob" "Grep")) :allow)
 
-; Guard on proxy domain
-(when (proxy.domain "github.com") :allow)
+; Guard on HTTP domain
+(when (ctx.http.domain "github.com") :allow)
 
 ; Guard on filesystem action
-(when (fs.action "read") :allow)
+(when (ctx.fs.action "read") :allow)
 
 ; Guard on filesystem path
-(when (fs.path (subpath (env PWD))) :allow)
+(when (ctx.fs.path (subpath (env PWD))) :allow)
 
 ; Allow with a sandbox
 (when (command "cargo" *)
@@ -531,7 +534,7 @@ Sandbox blocks can also contain `(match ...)` blocks for observable-based dispat
   (sandbox
     (allow (fs (or read write) (subpath (env PWD))))
     (allow (net "github.com"))
-    (match proxy.domain
+    (match ctx.http.domain
       "crates.io" :allow
       "github.com" :allow
       *           :deny)))
@@ -549,26 +552,34 @@ At **policy level**, match arms may use `:allow`, `:deny`, or `:ask` effects. In
 |-----------|------|-------------|
 | `command` | exec | Command execution (binary + args) |
 | `tool` | string | Agent tool name |
-| `proxy.domain` | string | Domain of an HTTP request (sandbox proxy) |
-| `proxy.method` | string | HTTP method (GET, POST, etc.) |
-| `fs.action` | string | Filesystem operation: `"read"`, `"write"`, `"create"`, `"delete"` |
-| `fs.path` | path | Filesystem path being accessed |
+| `ctx.http.domain` | string | Domain of an HTTP request |
+| `ctx.http.method` | string | HTTP method (GET, POST, etc.) |
+| `ctx.http.port` | int | Destination port |
+| `ctx.http.path` | string | URL path |
+| `ctx.fs.action` | string | Filesystem operation: `"read"`, `"write"`, `"create"`, `"delete"` |
+| `ctx.fs.path` | path | Filesystem path being accessed |
+| `ctx.fs.exists` | bool | Whether the target file exists |
+| `ctx.process.command` | string | Executable name |
+| `ctx.process.args` | [string] | Argument list |
+| `ctx.tool.name` | string | Tool name |
+| `ctx.tool.args` | {string?} | Tool arguments (dynamic, nullable) |
+| `ctx.state` | string | Agent state |
 
 #### Scalar match
 
 Match a single observable against patterns:
 
 ```
-(match proxy.domain
+(match ctx.http.domain
   "github.com" :allow
   "crates.io"  :allow
   *            :deny)
 
-(match fs.action
+(match ctx.fs.action
   "read"  :allow
   "write" :deny)
 
-(match fs.path
+(match ctx.fs.path
   (subpath (env PWD)) :allow
   *                   :deny)
 ```
@@ -603,7 +614,7 @@ Match agent tools by name:
 Match multiple observables simultaneously using bracket syntax:
 
 ```
-(match [fs.action fs.path]
+(match [ctx.fs.action ctx.fs.path]
   ["read"  (subpath (env PWD))]   :allow
   ["write" (subpath (env PWD))]   :allow
   ["read"  *]                     :deny
@@ -674,7 +685,7 @@ In v2 contexts (when bodies, match arms), effects use keyword syntax:
     :allow
     (sandbox
       (allow (fs (or read write) (subpath (env PWD))))
-      (match proxy.domain
+      (match ctx.http.domain
         "crates.io"  :allow
         "github.com" :allow
         *            :deny)))
@@ -685,8 +696,8 @@ In v2 contexts (when bodies, match arms), effects use keyword syntax:
     (or "WebFetch" "WebSearch")    :allow
     *                              :deny)
 
-  ; Guard on proxy domain
-  (when (proxy.domain "github.com") :allow)
+  ; Guard on HTTP domain
+  (when (ctx.http.domain "github.com") :allow)
 
   :deny)                             ; fallback for unmatched requests
 ```


### PR DESCRIPTION
## Summary

- Rename observable namespace from flat names to `ctx.*` hierarchy per the v2 language spec
- `proxy.domain` → `ctx.http.domain`, `proxy.method` → `ctx.http.method`, `fs.action` → `ctx.fs.action`, `fs.path` → `ctx.fs.path`
- Add 8 new observable fields: `ctx.http.port`, `ctx.http.path`, `ctx.fs.exists`, `ctx.process.command`, `ctx.process.args`, `ctx.tool.name`, `ctx.tool.args`, `ctx.state`
- Old names accepted with deprecation warnings; auto-fix via `clash policy upgrade`

## Changes

| File | What changed |
|------|-------------|
| `clash/src/policy/ast.rs` | Observable enum variants renamed/added, Display outputs `ctx.*` names |
| `clash/src/policy/parse.rs` | Parser accepts new `ctx.*` names + deprecated old names with warnings |
| `clash/src/policy/compile.rs` | Compiler handles renamed + new observable variants |
| `clash/src/policy/tree.rs` | IR Observable enum + evaluator updated for all variants |
| `clash/src/policy/version.rs` | 4 deprecation entries with boundary-aware auto-fix |
| `clash/src/policy/print.rs` | Test updated to new names |
| `docs/policy-grammar.md` | Grammar, observable table, and all examples updated |

## Test plan

- [x] All 780 unit tests pass (including property-based roundtrip tests)
- [x] Deprecated names still parse correctly (backwards compatibility)
- [x] Display impl outputs new `ctx.*` names
- [x] Deprecation auto-fix correctly replaces old names at s-expression boundaries

Closes #216