### PR TITLE
feat(policy): add agent invocation type and ctx.agent.name observable

### DIFF
--- a/clash/src/audit.rs
+++ b/clash/src/audit.rs
@@ -442,6 +442,9 @@ fn deny_hint(tool_name: &str, tool_input: &serde_json::Value, cwd: &str) -> Resu
         CapQuery::Tool { name } => {
             format!("(tool \"{}\")", name)
         }
+        CapQuery::Agent { name } => {
+            format!("(agent \"{}\")", name)
+        }
     };
 
     Ok(format!("clash allow '{}'", rule))
@@ -466,6 +469,7 @@ fn tool_input_summary(tool_name: &str, input: &serde_json::Value, cwd: &str) -> 
             None => domain.clone(),
         },
         Some(CapQuery::Tool { name }) => name.clone(),
+        Some(CapQuery::Agent { name }) => format!("agent:{name}"),
         None => String::new(),
     };
 

--- a/clash/src/debug/replay.rs
+++ b/clash/src/debug/replay.rs
@@ -184,6 +184,7 @@ impl ReplayResult {
                 None => format!("(net \"{}\")", domain),
             },
             Some(CapQuery::Tool { name }) => format!("(tool \"{}\")", name),
+            Some(CapQuery::Agent { name }) => format!("(agent \"{}\")", name),
             None => return format!("clash allow '{}'", self.tool_name.to_lowercase()),
         };
 

--- a/clash/src/policy/ast.rs
+++ b/clash/src/policy/ast.rs
@@ -203,6 +203,8 @@ pub enum Observable {
     Command,
     /// `tool` — invocation-type predicate matching tool queries by name.
     Tool,
+    /// `agent` — invocation-type predicate matching subagent spawning by name.
+    Agent,
 
     // -- ctx.http namespace --------------------------------------------------
     /// `ctx.http.domain` — destination domain (formerly `proxy.domain`).
@@ -233,6 +235,10 @@ pub enum Observable {
     ToolName,
     /// `ctx.tool.args` — tool arguments (dynamic, nullable accessors).
     ToolArgs,
+
+    // -- ctx.agent namespace -------------------------------------------------
+    /// `ctx.agent.name` — subagent name.
+    AgentName,
 
     // -- ctx.state -----------------------------------------------------------
     /// `ctx.state` — agent state.
@@ -387,6 +393,15 @@ fn display_when_guard(
             }
             write!(f, ")")
         }
+        Observable::Agent => {
+            write!(f, "(agent")?;
+            if let ArmPattern::Single(pat) = pattern {
+                if *pat != Pattern::Any {
+                    write!(f, " {pat}")?;
+                }
+            }
+            write!(f, ")")
+        }
         _ => {
             // proxy.domain, fs.action, fs.path — render as (observable pattern)
             write!(f, "({observable}")?;
@@ -405,6 +420,7 @@ impl fmt::Display for Observable {
         match self {
             Observable::Command => write!(f, "command"),
             Observable::Tool => write!(f, "tool"),
+            Observable::Agent => write!(f, "agent"),
             Observable::HttpDomain => write!(f, "ctx.http.domain"),
             Observable::HttpMethod => write!(f, "ctx.http.method"),
             Observable::HttpPort => write!(f, "ctx.http.port"),
@@ -416,6 +432,7 @@ impl fmt::Display for Observable {
             Observable::ProcessArgs => write!(f, "ctx.process.args"),
             Observable::ToolName => write!(f, "ctx.tool.name"),
             Observable::ToolArgs => write!(f, "ctx.tool.args"),
+            Observable::AgentName => write!(f, "ctx.agent.name"),
             Observable::State => write!(f, "ctx.state"),
             Observable::Tuple(obs) => {
                 write!(f, "[")?;

--- a/clash/src/policy/compile.rs
+++ b/clash/src/policy/compile.rs
@@ -622,7 +622,9 @@ fn compile_match_to_sandbox(
                             });
                         }
                         other => {
-                            bail!("expected tuple pattern for [ctx.fs.action ctx.fs.path], got: {other:?}")
+                            bail!(
+                                "expected tuple pattern for [ctx.fs.action ctx.fs.path], got: {other:?}"
+                            )
                         }
                     }
                 }
@@ -639,11 +641,14 @@ fn compile_match_to_sandbox(
         Observable::ToolName | Observable::ToolArgs => {
             // Tool context observables don't apply to sandbox rules.
         }
+        Observable::AgentName => {
+            // Agent context observables don't apply to sandbox rules.
+        }
         Observable::State => {
             // State observable doesn't apply to sandbox rules.
         }
-        Observable::Command | Observable::Tool => {
-            // Command/tool observables don't apply to sandbox rules (sandbox restricts fs/net only).
+        Observable::Command | Observable::Tool | Observable::Agent => {
+            // Command/tool/agent observables don't apply to sandbox rules (sandbox restricts fs/net only).
         }
     }
     Ok(())
@@ -909,6 +914,15 @@ fn compile_when_guard(
                 name: pat.clone(),
             })?))
         }
+        Observable::Agent => {
+            let pat = match pattern {
+                ArmPattern::Single(p) => p,
+                _ => bail!("agent observable requires a single pattern"),
+            };
+            Ok(Predicate::Agent(compile_tool_to_compiled(&ToolMatcher {
+                name: pat.clone(),
+            })?))
+        }
         Observable::HttpDomain => {
             let pat = match pattern {
                 ArmPattern::Single(p) => p,
@@ -973,6 +987,15 @@ fn compile_when_guard(
                 _ => bail!("ctx.tool.name observable requires a single pattern"),
             };
             Ok(Predicate::Tool(compile_tool_to_compiled(&ToolMatcher {
+                name: pat.clone(),
+            })?))
+        }
+        Observable::AgentName => {
+            let pat = match pattern {
+                ArmPattern::Single(p) => p,
+                _ => bail!("ctx.agent.name observable requires a single pattern"),
+            };
+            Ok(Predicate::Agent(compile_tool_to_compiled(&ToolMatcher {
                 name: pat.clone(),
             })?))
         }
@@ -1075,6 +1098,8 @@ fn compile_observable_to_ir(obs: &Observable) -> Result<crate::policy::tree::Obs
         Observable::ProcessArgs => Ok(ir::Observable::ProcessArgs),
         Observable::ToolName => Ok(ir::Observable::ToolName),
         Observable::ToolArgs => Ok(ir::Observable::ToolArgs),
+        Observable::Agent => Ok(ir::Observable::Agent),
+        Observable::AgentName => Ok(ir::Observable::AgentName),
         Observable::State => Ok(ir::Observable::State),
         Observable::Tuple(obs) => {
             let inner = obs
@@ -3056,5 +3081,106 @@ mod tests {
             Effect::Allow,
             "git status should be allowed"
         );
+    }
+
+    #[test]
+    fn compile_to_tree_v2_agent_when_allows() {
+        let source = r#"
+(version 2)
+(default deny "main")
+(policy "main"
+  (when (agent "Explore") :allow))
+"#;
+        let env = TestEnv::new(&[("PWD", "/home/user")]);
+        let tree = compile_to_tree(source, &env).unwrap();
+
+        let input = serde_json::json!({ "subagent_type": "Explore" });
+        let decision = tree.evaluate("Agent", &input, "/home/user");
+        assert_eq!(
+            decision.effect,
+            Effect::Allow,
+            "agent Explore should be allowed"
+        );
+    }
+
+    #[test]
+    fn compile_to_tree_v2_agent_when_denies_other() {
+        let source = r#"
+(version 2)
+(default deny "main")
+(policy "main"
+  (when (agent "Explore") :allow))
+"#;
+        let env = TestEnv::new(&[("PWD", "/home/user")]);
+        let tree = compile_to_tree(source, &env).unwrap();
+
+        let input = serde_json::json!({ "subagent_type": "Plan" });
+        let decision = tree.evaluate("Agent", &input, "/home/user");
+        assert_eq!(
+            decision.effect,
+            Effect::Deny,
+            "agent Plan should hit default deny"
+        );
+    }
+
+    #[test]
+    fn compile_to_tree_v2_agent_or_pattern() {
+        let source = r#"
+(version 2)
+(default deny "main")
+(policy "main"
+  (when (agent (or "Explore" "Verify")) :ask))
+"#;
+        let env = TestEnv::new(&[("PWD", "/home/user")]);
+        let tree = compile_to_tree(source, &env).unwrap();
+
+        let input = serde_json::json!({ "subagent_type": "Verify" });
+        let decision = tree.evaluate("Agent", &input, "/home/user");
+        assert_eq!(decision.effect, Effect::Ask, "agent Verify should be :ask");
+    }
+
+    #[test]
+    fn compile_to_tree_v2_agent_does_not_match_tool() {
+        let source = r#"
+(version 2)
+(default deny "main")
+(policy "main"
+  (when (agent "Explore") :allow))
+"#;
+        let env = TestEnv::new(&[("PWD", "/home/user")]);
+        let tree = compile_to_tree(source, &env).unwrap();
+
+        // A normal tool (not Agent) should not match the agent predicate.
+        let input = serde_json::json!({});
+        let decision = tree.evaluate("WebFetch", &input, "/home/user");
+        assert_eq!(
+            decision.effect,
+            Effect::Deny,
+            "non-agent tool should not match agent predicate"
+        );
+    }
+
+    #[test]
+    fn compile_to_tree_v2_ctx_agent_name_match() {
+        let source = r#"
+(version 2)
+(default deny "main")
+(policy "main"
+  (when (agent *)
+    (match ctx.agent.name
+      "Explore" :allow
+      "Plan" :allow
+      * :ask)))
+"#;
+        let env = TestEnv::new(&[("PWD", "/home/user")]);
+        let tree = compile_to_tree(source, &env).unwrap();
+
+        let input = serde_json::json!({ "subagent_type": "Explore" });
+        let decision = tree.evaluate("Agent", &input, "/home/user");
+        assert_eq!(decision.effect, Effect::Allow);
+
+        let input = serde_json::json!({ "subagent_type": "Unknown" });
+        let decision = tree.evaluate("Agent", &input, "/home/user");
+        assert_eq!(decision.effect, Effect::Ask);
     }
 }

--- a/clash/src/policy/eval.rs
+++ b/clash/src/policy/eval.rs
@@ -29,6 +29,9 @@ pub enum CapQuery {
     Tool {
         name: String,
     },
+    Agent {
+        name: String,
+    },
 }
 
 /// Map a tool invocation to capability queries.
@@ -103,6 +106,19 @@ pub fn tool_to_queries(
             vec![CapQuery::Fs {
                 op: FsOp::Read,
                 path: resolve_path(path, cwd),
+            }]
+        }
+        "Agent" => {
+            let subagent_type = tool_input
+                .get("subagent_type")
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+            debug!(
+                tool_name,
+                subagent_type, "agent — using agent capability query"
+            );
+            vec![CapQuery::Agent {
+                name: subagent_type.to_string(),
             }]
         }
         _ => {
@@ -345,6 +361,7 @@ impl DecisionTree {
                 CapQuery::Fs { .. } => &self.fs_rules,
                 CapQuery::Net { .. } => &self.net_rules,
                 CapQuery::Tool { .. } => &self.tool_rules,
+                CapQuery::Agent { .. } => &self.tool_rules,
             };
 
             for (idx, rule) in rules.iter().enumerate() {
@@ -1751,5 +1768,19 @@ mod tests {
             "/home/user/project",
         );
         assert_eq!(decision.effect, Effect::Deny);
+    }
+
+    #[test]
+    fn agent_tool_produces_agent_query() {
+        let queries = super::tool_to_queries(
+            "Agent",
+            &json!({"subagent_type": "Explore", "prompt": "search code"}),
+            "/home/user",
+        );
+        assert_eq!(queries.len(), 1);
+        match &queries[0] {
+            super::CapQuery::Agent { name } => assert_eq!(name, "Explore"),
+            other => panic!("expected Agent query, got {other:?}"),
+        }
     }
 }

--- a/clash/src/policy/parse.rs
+++ b/clash/src/policy/parse.rs
@@ -696,6 +696,10 @@ fn parse_when_guard(expr: &SExpr, ctx: &ParseContext) -> Result<(Observable, Arm
             let m = parse_tool_matcher(&list[1..], ctx)?;
             Ok((Observable::Tool, ArmPattern::Single(m.name)))
         }
+        "agent" => {
+            let m = parse_tool_matcher(&list[1..], ctx)?;
+            Ok((Observable::Agent, ArmPattern::Single(m.name)))
+        }
 
         // ctx.http guards
         "ctx.http.domain" => {
@@ -734,7 +738,7 @@ fn parse_when_guard(expr: &SExpr, ctx: &ParseContext) -> Result<(Observable, Arm
         }
 
         other => bail!(
-            "unknown when guard: {other} (expected 'command', 'tool', \
+            "unknown when guard: {other} (expected 'command', 'tool', 'agent', \
              'ctx.http.domain', 'ctx.http.method', 'ctx.fs.action', or 'ctx.fs.path')"
         ),
     }
@@ -812,6 +816,7 @@ fn parse_observable(expr: &SExpr) -> Result<Observable> {
             // Invocation-type observables (unchanged)
             "command" => Ok(Observable::Command),
             "tool" => Ok(Observable::Tool),
+            "agent" => Ok(Observable::Agent),
 
             // ctx.http namespace
             "ctx.http.domain" => Ok(Observable::HttpDomain),
@@ -831,6 +836,9 @@ fn parse_observable(expr: &SExpr) -> Result<Observable> {
             // ctx.tool namespace
             "ctx.tool.name" => Ok(Observable::ToolName),
             "ctx.tool.args" => Ok(Observable::ToolArgs),
+
+            // ctx.agent namespace
+            "ctx.agent.name" => Ok(Observable::AgentName),
 
             // ctx.state
             "ctx.state" => Ok(Observable::State),
@@ -1947,6 +1955,100 @@ mod tests {
                 assert!(matches!(&body[0], PolicyItem::Effect(Effect::Allow)));
             }
             other => panic!("expected When, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_when_agent_predicate() {
+        let source = r#"
+            (version 2)
+            (policy "p"
+              (when (agent "Explore") :allow))
+        "#;
+        let ast = parse(source).unwrap();
+        let body = match &ast[1] {
+            TopLevel::Policy { body, .. } => body,
+            _ => panic!(),
+        };
+        match &body[0] {
+            PolicyItem::When {
+                observable,
+                pattern,
+                body,
+            } => {
+                assert!(matches!(observable, Observable::Agent));
+                match pattern {
+                    ArmPattern::Single(Pattern::Literal(s)) => assert_eq!(s, "Explore"),
+                    _ => panic!("expected Single(Literal) pattern"),
+                }
+                assert_eq!(body.len(), 1);
+                assert!(matches!(&body[0], PolicyItem::Effect(Effect::Allow)));
+            }
+            other => panic!("expected When, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_when_agent_or_predicate() {
+        let source = r#"
+            (version 2)
+            (policy "p"
+              (when (agent (or "Explore" "Verify")) :ask))
+        "#;
+        let ast = parse(source).unwrap();
+        let body = match &ast[1] {
+            TopLevel::Policy { body, .. } => body,
+            _ => panic!(),
+        };
+        match &body[0] {
+            PolicyItem::When {
+                observable,
+                pattern,
+                body,
+            } => {
+                assert!(matches!(observable, Observable::Agent));
+                match pattern {
+                    ArmPattern::Single(pat) => {
+                        assert!(matches!(pat, Pattern::Or(ps) if ps.len() == 2));
+                    }
+                    _ => panic!("expected Single pattern"),
+                }
+                assert_eq!(body.len(), 1);
+                assert!(matches!(&body[0], PolicyItem::Effect(Effect::Ask)));
+            }
+            other => panic!("expected When, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_ctx_agent_name_observable() {
+        let source = r#"
+            (version 2)
+            (policy "p"
+              (when (agent *)
+                (match ctx.agent.name
+                  "Explore" :allow
+                  * :deny)))
+        "#;
+        let ast = parse(source).unwrap();
+        let body = match &ast[1] {
+            TopLevel::Policy { body, .. } => body,
+            _ => panic!(),
+        };
+        let when_body = match &body[0] {
+            PolicyItem::When { body, .. } => body,
+            other => panic!("expected When, got {other:?}"),
+        };
+        match &when_body[0] {
+            PolicyItem::Match(block) => {
+                assert_eq!(block.observable, Observable::AgentName);
+                assert_eq!(block.arms.len(), 2);
+                assert_eq!(block.arms[0].effect, Effect::Allow);
+                assert!(
+                    matches!(&block.arms[0].pattern, ArmPattern::Single(Pattern::Literal(s)) if s == "Explore")
+                );
+            }
+            other => panic!("expected Match, got {other:?}"),
         }
     }
 

--- a/clash/src/policy/tree.rs
+++ b/clash/src/policy/tree.rs
@@ -89,6 +89,8 @@ pub enum Predicate {
     Net(CompiledNet),
     /// Matches tool queries (tool name).
     Tool(CompiledTool),
+    /// Matches agent queries (subagent name).
+    Agent(CompiledTool),
     /// Always matches.
     True,
 }
@@ -102,6 +104,8 @@ pub enum Observable {
     Command,
     /// Matches tool invocations by name.
     Tool,
+    /// Matches subagent spawning by name.
+    Agent,
     /// `ctx.http.domain` (formerly `proxy.domain`).
     HttpDomain,
     /// `ctx.http.method` (formerly `proxy.method`).
@@ -124,6 +128,8 @@ pub enum Observable {
     ToolName,
     /// `ctx.tool.args`
     ToolArgs,
+    /// `ctx.agent.name`
+    AgentName,
     /// `ctx.state`
     State,
     Tuple(Vec<Observable>),
@@ -199,6 +205,7 @@ pub struct QueryContext {
     pub fs_path: Option<String>,
     pub net_domain: Option<String>,
     pub net_path: Option<String>,
+    pub agent_name: Option<String>,
     pub cwd: String,
 }
 
@@ -245,8 +252,12 @@ impl Predicate {
             // Tool predicates are relevant only when no other domain matched,
             // matching the old `_ =>` fallthrough in tool_to_queries.
             Predicate::Tool(_) => {
-                ctx.bin.is_none() && ctx.fs_op.is_none() && ctx.net_domain.is_none()
+                ctx.bin.is_none()
+                    && ctx.fs_op.is_none()
+                    && ctx.net_domain.is_none()
+                    && ctx.agent_name.is_none()
             }
+            Predicate::Agent(_) => ctx.agent_name.is_some(),
             Predicate::True => true,
         }
     }
@@ -277,6 +288,10 @@ impl Predicate {
                 }
             }
             Predicate::Tool(tool) => tool.matches(&ctx.tool_name),
+            Predicate::Agent(agent) => ctx
+                .agent_name
+                .as_ref()
+                .is_some_and(|name| agent.matches(name)),
             Predicate::True => true,
         }
     }
@@ -293,6 +308,7 @@ impl QueryContext {
             fs_path: None,
             net_domain: None,
             net_path: None,
+            agent_name: None,
             cwd: cwd.to_string(),
         };
 
@@ -312,6 +328,9 @@ impl QueryContext {
                 }
                 CapQuery::Tool { .. } => {
                     // tool_name is already set from the parameter
+                }
+                CapQuery::Agent { name } => {
+                    ctx.agent_name = Some(name.clone());
                 }
             }
         }
@@ -834,8 +853,12 @@ fn observable_is_relevant(observable: &Observable, ctx: &QueryContext) -> bool {
             ctx.bin.is_some()
         }
         Observable::Tool | Observable::ToolName | Observable::ToolArgs => {
-            ctx.bin.is_none() && ctx.fs_op.is_none() && ctx.net_domain.is_none()
+            ctx.bin.is_none()
+                && ctx.fs_op.is_none()
+                && ctx.net_domain.is_none()
+                && ctx.agent_name.is_none()
         }
+        Observable::Agent | Observable::AgentName => ctx.agent_name.is_some(),
         Observable::HttpMethod | Observable::HttpPort => false, // deferred
         Observable::HttpDomain | Observable::HttpPath => ctx.net_domain.is_some(),
         Observable::FsAction | Observable::FsPath | Observable::FsExists => ctx.fs_op.is_some(),
@@ -868,6 +891,12 @@ fn match_arm_against_ctx(
             MatchPattern::Single(cp) => cp.matches(&ctx.tool_name),
             _ => false,
         },
+        Observable::Agent => match pattern {
+            MatchPattern::Single(cp) => {
+                ctx.agent_name.as_ref().is_some_and(|name| cp.matches(name))
+            }
+            _ => false,
+        },
         // For sandbox-style observables, use the string-resolve path.
         _ => {
             let values = resolve_observable(observable, ctx);
@@ -884,8 +913,8 @@ fn match_arm_against_ctx(
 /// Returns `None` if the observable cannot be resolved (e.g. `HttpMethod` is deferred).
 fn resolve_observable(observable: &Observable, ctx: &QueryContext) -> Option<Vec<String>> {
     match observable {
-        Observable::Command | Observable::Tool => None, // handled by match_arm_against_ctx
-        Observable::HttpMethod | Observable::HttpPort => None, // deferred
+        Observable::Command | Observable::Tool | Observable::Agent => None, // handled by match_arm_against_ctx
+        Observable::HttpMethod | Observable::HttpPort => None,              // deferred
         Observable::HttpDomain => ctx.net_domain.as_ref().map(|d| vec![d.clone()]),
         Observable::HttpPath => ctx.net_path.as_ref().map(|p| vec![p.clone()]),
         Observable::FsAction => ctx.fs_op.map(|op| {
@@ -914,7 +943,8 @@ fn resolve_observable(observable: &Observable, ctx: &QueryContext) -> Option<Vec
             }
         }
         Observable::ToolArgs => None, // deferred — requires tool argument access
-        Observable::State => None,    // deferred
+        Observable::AgentName => ctx.agent_name.as_ref().map(|n| vec![n.clone()]),
+        Observable::State => None, // deferred
         Observable::Tuple(obs) => {
             let mut values = Vec::with_capacity(obs.len());
             for o in obs {

--- a/clash/src/policy/version.rs
+++ b/clash/src/policy/version.rs
@@ -119,10 +119,11 @@ fn has_deprecated_observable(source: &str, name: &str) -> bool {
     let mut search_from = 0;
     while let Some(pos) = source[search_from..].find(name) {
         let abs_pos = search_from + pos;
-        let before_ok = abs_pos == 0 || source[..abs_pos]
-            .chars()
-            .next_back()
-            .is_some_and(|c| is_delim(c));
+        let before_ok = abs_pos == 0
+            || source[..abs_pos]
+                .chars()
+                .next_back()
+                .is_some_and(|c| is_delim(c));
         let after_pos = abs_pos + name.len();
         let after_ok = after_pos >= source.len()
             || source[after_pos..]
@@ -147,10 +148,11 @@ fn fix_observable_name(source: &str, old: &str, new: &str) -> String {
     let mut search_from = 0;
     while let Some(pos) = source[search_from..].find(old) {
         let abs_pos = search_from + pos;
-        let before_ok = abs_pos == 0 || source[..abs_pos]
-            .chars()
-            .next_back()
-            .is_some_and(|c| is_delim(c));
+        let before_ok = abs_pos == 0
+            || source[..abs_pos]
+                .chars()
+                .next_back()
+                .is_some_and(|c| is_delim(c));
         let after_pos = abs_pos + old.len();
         let after_ok = after_pos >= source.len()
             || source[after_pos..]


### PR DESCRIPTION
## Summary

- Add `(agent ...)` as an invocation-type predicate for gating subagent spawning by name
- Add `ctx.agent.name` as a match-dispatch observable for fine-grained agent control
- Map the Claude Code `Agent` tool's `subagent_type` field to `CapQuery::Agent`

## Syntax

```scheme
(when (agent "Explore") :allow)
(when (agent (or "Explore" "Verify")) :ask)
(match ctx.agent.name
  "Explore" :allow
  "Plan" :allow
  * :deny)
```

## Changes across the stack

| Layer | File | Change |
|-------|------|--------|
| AST | `ast.rs` | `Agent` + `AgentName` variants in `Observable` |
| Parser | `parse.rs` | `"agent"` in when guards + `"ctx.agent.name"` in observables |
| Tree IR | `tree.rs` | `Predicate::Agent`, `Observable::Agent/AgentName`, `QueryContext.agent_name` |
| Compiler | `compile.rs` | `compile_when_guard` for Agent, sandbox skip, observable-to-IR mapping |
| Evaluator | `eval.rs` | `CapQuery::Agent`, `Agent` tool → `subagent_type` extraction |
| Audit | `audit.rs` | Agent query formatting in rule suggestions and summaries |
| Replay | `replay.rs` | Agent query formatting in replay commands |

## Test plan

- [x] Parse `(when (agent "Explore") :allow)` — literal pattern
- [x] Parse `(when (agent (or "Explore" "Verify")) :ask)` — or pattern
- [x] Parse `(match ctx.agent.name ...)` — observable dispatch
- [x] Compile + evaluate: agent when guard allows matching agent
- [x] Compile + evaluate: agent when guard denies non-matching agent
- [x] Compile + evaluate: agent or-pattern matches alternatives
- [x] Compile + evaluate: agent predicate does not match non-Agent tools
- [x] Compile + evaluate: `ctx.agent.name` match dispatch
- [x] `tool_to_queries("Agent", ...)` produces `CapQuery::Agent`
- [x] All 925 existing tests pass (zero regressions)

Closes #218