### PR TITLE
feat(policy): add eq predicate for when guards

### DIFF
--- a/clash/src/policy/ast.rs
+++ b/clash/src/policy/ast.rs
@@ -31,10 +31,12 @@ pub enum PolicyItem {
     /// A rule: `(effect (capability ...))`.
     Rule(Rule),
     /// `(when (observable pattern) body...)` — v2 conditional block.
+    /// When `is_eq` is true, the guard was written as `(eq observable pattern)`.
     When {
         observable: Observable,
         pattern: ArmPattern,
         body: Vec<PolicyItem>,
+        is_eq: bool,
     },
     /// `(match observable arms...)` — v2 dispatch block at policy level.
     Match(MatchBlock),
@@ -344,9 +346,10 @@ impl fmt::Display for PolicyItem {
                 observable,
                 pattern,
                 body,
+                is_eq,
             } => {
                 write!(f, "(when ")?;
-                display_when_guard(f, observable, pattern)?;
+                display_when_guard(f, observable, pattern, *is_eq)?;
                 // Single inline effect: render on one line
                 if body.len() == 1 && matches!(&body[0], PolicyItem::Effect(_)) {
                     write!(f, " {}", body[0])?;
@@ -371,11 +374,23 @@ impl fmt::Display for PolicyItem {
 }
 
 /// Write the when guard `(observable pattern)` combined form.
+///
+/// When `is_eq` is true, renders as `(eq observable pattern)` instead.
 fn display_when_guard(
     f: &mut fmt::Formatter<'_>,
     observable: &Observable,
     pattern: &ArmPattern,
+    is_eq: bool,
 ) -> fmt::Result {
+    if is_eq {
+        write!(f, "(eq {observable}")?;
+        match pattern {
+            ArmPattern::Single(pat) => write!(f, " {pat}")?,
+            ArmPattern::SinglePath(pf) => write!(f, " {pf}")?,
+            _ => {}
+        }
+        return write!(f, ")");
+    }
     match observable {
         Observable::Command => {
             write!(f, "(command")?;

--- a/clash/src/policy/compile.rs
+++ b/clash/src/policy/compile.rs
@@ -204,18 +204,16 @@ fn compile_tree_ast(top_levels: &[TopLevel], env: &dyn EnvResolver) -> Result<Po
 ///
 /// Internal policies (`__internal_*`) are exempt because they may legitimately
 /// use `:ask` under `command` guards (e.g. the internal clash policy).
-fn validate_ask_contexts(
-    node: &Node,
-    has_valid_invocation: bool,
-    meta: &[NodeMeta],
-) -> Result<()> {
+fn validate_ask_contexts(node: &Node, has_valid_invocation: bool, meta: &[NodeMeta]) -> Result<()> {
     match node {
         Node::Sequence { children, .. } | Node::DenyOverrides { children, .. } => {
             for child in children {
                 validate_ask_contexts(child, has_valid_invocation, meta)?;
             }
         }
-        Node::When { predicate, body, .. } => {
+        Node::When {
+            predicate, body, ..
+        } => {
             let valid = has_valid_invocation || predicate.allows_ask();
             validate_ask_contexts(body, valid, meta)?;
         }
@@ -351,6 +349,7 @@ fn compile_policy_item_to_node(
             observable,
             pattern,
             body,
+            ..
         } => {
             // Compile the when guard (observable + pattern) into a Predicate.
             let compiled_pred = compile_when_guard(observable, pattern, env)?;
@@ -1010,21 +1009,28 @@ fn compile_when_guard(
             Ok(Predicate::Fs(CompiledFs { op, path: None }))
         }
         Observable::FsPath => {
-            let pf = match pattern {
-                ArmPattern::SinglePath(pf) => pf,
-                ArmPattern::Single(Pattern::Any) => {
-                    return Ok(Predicate::Fs(CompiledFs {
+            match pattern {
+                ArmPattern::SinglePath(pf) => {
+                    let compiled_pf = compile_path_filter(pf, env)?;
+                    Ok(Predicate::Fs(CompiledFs {
                         op: OpPattern::Any,
-                        path: None,
-                    }));
+                        path: Some(compiled_pf),
+                    }))
                 }
-                _ => bail!("ctx.fs.path observable requires a path filter pattern"),
-            };
-            let compiled_pf = compile_path_filter(pf, env)?;
-            Ok(Predicate::Fs(CompiledFs {
-                op: OpPattern::Any,
-                path: Some(compiled_pf),
-            }))
+                ArmPattern::Single(Pattern::Any) => Ok(Predicate::Fs(CompiledFs {
+                    op: OpPattern::Any,
+                    path: None,
+                })),
+                // (eq ctx.fs.path "...") — literal/pattern equality on path
+                ArmPattern::Single(pat) => {
+                    let compiled = compile_pattern(pat)?;
+                    Ok(Predicate::Fs(CompiledFs {
+                        op: OpPattern::Any,
+                        path: Some(compiled_pattern_to_path_filter(compiled)),
+                    }))
+                }
+                _ => bail!("ctx.fs.path observable requires a path filter or pattern"),
+            }
         }
         Observable::FsExists => {
             // Deferred — always true for now
@@ -1237,7 +1243,9 @@ fn compile_observable_to_ir(obs: &Observable) -> Result<crate::policy::tree::Obs
         Observable::ToolArgs => Ok(ir::Observable::ToolArgs),
         Observable::Agent => Ok(ir::Observable::Agent),
         Observable::AgentName => Ok(ir::Observable::AgentName),
-        Observable::Mcp => bail!("mcp invocation type cannot be used as a match observable; use ctx.mcp.server or ctx.mcp.tool"),
+        Observable::Mcp => bail!(
+            "mcp invocation type cannot be used as a match observable; use ctx.mcp.server or ctx.mcp.tool"
+        ),
         Observable::McpServer => Ok(ir::Observable::McpServer),
         Observable::McpTool => Ok(ir::Observable::McpTool),
         Observable::ToolArgField(field) => Ok(ir::Observable::ToolArgField(field.clone())),
@@ -1949,6 +1957,7 @@ fn validate_sibling_dimensions(items: &[PolicyItem]) -> Result<()> {
                 observable,
                 pattern,
                 body,
+                ..
             } => Some((observable, pattern, body.as_slice())),
             _ => None,
         })
@@ -2174,6 +2183,30 @@ fn compile_pattern(pattern: &Pattern) -> Result<CompiledPattern> {
             let inner = compile_pattern(p)?;
             Ok(CompiledPattern::Not(Box::new(inner)))
         }
+    }
+}
+
+/// Convert a `CompiledPattern` to a `CompiledPathFilter`.
+///
+/// Used by `(eq ctx.fs.path ...)` where the pattern is parsed as a general
+/// pattern rather than a path filter.
+fn compiled_pattern_to_path_filter(cp: CompiledPattern) -> CompiledPathFilter {
+    match cp {
+        CompiledPattern::Any => {
+            // Any path — unreachable in practice (handled earlier as path: None)
+            CompiledPathFilter::Or(vec![])
+        }
+        CompiledPattern::Literal(s) => CompiledPathFilter::Literal(s),
+        CompiledPattern::Regex(r) => CompiledPathFilter::Regex(r),
+        CompiledPattern::Or(ps) => CompiledPathFilter::Or(
+            ps.into_iter()
+                .map(compiled_pattern_to_path_filter)
+                .collect(),
+        ),
+        CompiledPattern::Not(p) => {
+            CompiledPathFilter::Not(Box::new(compiled_pattern_to_path_filter(*p)))
+        }
+        CompiledPattern::Subpath(s) => CompiledPathFilter::Subpath(s),
     }
 }
 
@@ -3839,5 +3872,129 @@ mod tests {
   (when (command "rm" *) :deny))
 "#;
         assert!(compile_to_tree(source, &env).is_ok());
+    }
+
+    // ── eq predicate ────────────────────────────────────────────────────
+
+    #[test]
+    fn compile_to_tree_v2_eq_process_command() {
+        let source = r#"
+(version 2)
+(default deny "main")
+(policy "main"
+  (when (eq ctx.process.command "cargo") :allow))
+"#;
+        let env = TestEnv::new(&[("PWD", "/home/user")]);
+        let tree = compile_to_tree(source, &env).unwrap();
+
+        // "cargo build" should match the eq predicate → Allow.
+        let input = serde_json::json!({ "command": "cargo build" });
+        let decision = tree.evaluate("Bash", &input, "/home/user");
+        assert_eq!(
+            decision.effect,
+            Effect::Allow,
+            "cargo should be allowed via eq predicate"
+        );
+
+        // "git status" should not match → default deny.
+        let input = serde_json::json!({ "command": "git status" });
+        let decision = tree.evaluate("Bash", &input, "/home/user");
+        assert_eq!(decision.effect, Effect::Deny, "git should hit default deny");
+    }
+
+    #[test]
+    fn compile_to_tree_v2_eq_http_domain() {
+        let source = r#"
+(version 2)
+(default deny "main")
+(policy "main"
+  (when (eq ctx.http.domain "github.com") :allow))
+"#;
+        let env = TestEnv::new(&[("PWD", "/home/user")]);
+        let tree = compile_to_tree(source, &env).unwrap();
+
+        // WebFetch to github.com should match → Allow.
+        let input = serde_json::json!({ "url": "https://github.com/foo" });
+        let decision = tree.evaluate("WebFetch", &input, "/home/user");
+        assert_eq!(
+            decision.effect,
+            Effect::Allow,
+            "github.com should be allowed via eq"
+        );
+
+        // WebFetch to evil.com should not match → default deny.
+        let input = serde_json::json!({ "url": "https://evil.com/foo" });
+        let decision = tree.evaluate("WebFetch", &input, "/home/user");
+        assert_eq!(
+            decision.effect,
+            Effect::Deny,
+            "evil.com should hit default deny"
+        );
+    }
+
+    #[test]
+    fn compile_to_tree_v2_eq_tool_name() {
+        let source = r#"
+(version 2)
+(default deny "main")
+(policy "main"
+  (when (eq ctx.tool.name "Skill") :allow))
+"#;
+        let env = TestEnv::new(&[("PWD", "/home/user")]);
+        let tree = compile_to_tree(source, &env).unwrap();
+
+        // Skill tool (pure tool, no fs/exec/net query) should match → Allow.
+        let input = serde_json::json!({ "skill": "commit" });
+        let decision = tree.evaluate("Skill", &input, "/home/user");
+        assert_eq!(
+            decision.effect,
+            Effect::Allow,
+            "Skill should be allowed via eq ctx.tool.name"
+        );
+
+        // Different pure tool should not match → default deny.
+        let input = serde_json::json!({});
+        let decision = tree.evaluate("AskUserQuestion", &input, "/home/user");
+        assert_eq!(
+            decision.effect,
+            Effect::Deny,
+            "AskUserQuestion should hit default deny"
+        );
+    }
+
+    #[test]
+    fn compile_to_tree_v2_eq_with_or_pattern() {
+        let source = r#"
+(version 2)
+(default deny "main")
+(policy "main"
+  (when (eq ctx.process.command (or "cargo" "rustc")) :allow))
+"#;
+        let env = TestEnv::new(&[("PWD", "/home/user")]);
+        let tree = compile_to_tree(source, &env).unwrap();
+
+        let input = serde_json::json!({ "command": "cargo build" });
+        let decision = tree.evaluate("Bash", &input, "/home/user");
+        assert_eq!(
+            decision.effect,
+            Effect::Allow,
+            "cargo should match or-pattern"
+        );
+
+        let input = serde_json::json!({ "command": "rustc main.rs" });
+        let decision = tree.evaluate("Bash", &input, "/home/user");
+        assert_eq!(
+            decision.effect,
+            Effect::Allow,
+            "rustc should match or-pattern"
+        );
+
+        let input = serde_json::json!({ "command": "git status" });
+        let decision = tree.evaluate("Bash", &input, "/home/user");
+        assert_eq!(
+            decision.effect,
+            Effect::Deny,
+            "git should not match or-pattern"
+        );
     }
 }

--- a/clash/src/policy/parse.rs
+++ b/clash/src/policy/parse.rs
@@ -624,7 +624,7 @@ fn parse_when_block(list: &[SExpr], ctx: &ParseContext) -> Result<PolicyItem> {
         list.len() >= 3,
         "(when) expects a guard and at least one body item"
     );
-    let (observable, pattern) = parse_when_guard(&list[1], ctx)?;
+    let (observable, pattern, is_eq) = parse_when_guard(&list[1], ctx)?;
     let body = list[2..]
         .iter()
         .map(|e| parse_when_body_item(e, ctx))
@@ -633,6 +633,7 @@ fn parse_when_block(list: &[SExpr], ctx: &ParseContext) -> Result<PolicyItem> {
         observable,
         pattern,
         body,
+        is_eq,
     })
 }
 
@@ -657,20 +658,40 @@ fn parse_when_body_item(expr: &SExpr, ctx: &ParseContext) -> Result<PolicyItem> 
     parse_policy_item(expr, ctx)
 }
 
-/// Parse a when guard `(observable pattern)` → `(Observable, ArmPattern)`.
+/// Parse a when guard `(observable pattern)` → `(Observable, ArmPattern, is_eq)`.
 ///
-/// Handles invocation-type guards and ctx.* observable guards:
+/// Handles invocation-type guards, ctx.* observable guards, and `eq` predicates:
 /// - `(command ...)` → Observable::Command + ArmPattern::Exec
 /// - `(tool ...)` → Observable::Tool + ArmPattern::Single
 /// - `(ctx.http.domain ...)` → Observable::HttpDomain + ArmPattern::Single
 /// - `(ctx.fs.action ...)` → Observable::FsAction + ArmPattern::Single
 /// - `(ctx.fs.path ...)` → Observable::FsPath + ArmPattern::SinglePath
+/// - `(eq <ctx-ref> <expr>)` → resolved observable + ArmPattern::Single
 ///
 /// Deprecated flat names (`proxy.domain`, `fs.action`, etc.) are accepted with warnings.
-fn parse_when_guard(expr: &SExpr, ctx: &ParseContext) -> Result<(Observable, ArmPattern)> {
+fn parse_when_guard(expr: &SExpr, ctx: &ParseContext) -> Result<(Observable, ArmPattern, bool)> {
     let list = require_list(expr, "when guard")?;
     ensure!(!list.is_empty(), "empty when guard");
     let head = require_atom(&list[0], "guard keyword")?;
+
+    // Handle `(eq <ctx-ref> <expr>)` predicate form.
+    if head == "eq" {
+        ensure!(
+            list.len() == 3,
+            "(eq) expects exactly 2 arguments: (eq <ctx-ref> <expr>)"
+        );
+        let observable = parse_observable(&list[1])?;
+        ensure!(
+            !matches!(
+                observable,
+                Observable::Command | Observable::Tool | Observable::Agent
+            ),
+            "(eq) operates on ctx fields, not invocation types; \
+             use (command ...), (tool ...), or (agent ...) directly"
+        );
+        let pat = parse_pattern(&list[2], ctx)?;
+        return Ok((observable, ArmPattern::Single(pat), true));
+    }
 
     // Map deprecated names to their canonical ctx.* equivalents.
     let (canonical, deprecated) = match head {
@@ -698,19 +719,19 @@ fn parse_when_guard(expr: &SExpr, ctx: &ParseContext) -> Result<(Observable, Arm
         // Invocation-type guards
         "command" => {
             let m = parse_exec_matcher(&list[1..], ctx)?;
-            Ok((Observable::Command, ArmPattern::Exec(m)))
+            Ok((Observable::Command, ArmPattern::Exec(m), false))
         }
         "tool" => {
             let m = parse_tool_matcher(&list[1..], ctx)?;
-            Ok((Observable::Tool, ArmPattern::Single(m.name)))
+            Ok((Observable::Tool, ArmPattern::Single(m.name), false))
         }
         "agent" => {
             let m = parse_tool_matcher(&list[1..], ctx)?;
-            Ok((Observable::Agent, ArmPattern::Single(m.name)))
+            Ok((Observable::Agent, ArmPattern::Single(m.name), false))
         }
         "mcp" => {
             let m = parse_tool_matcher(&list[1..], ctx)?;
-            Ok((Observable::Mcp, ArmPattern::Single(m.name)))
+            Ok((Observable::Mcp, ArmPattern::Single(m.name), false))
         }
 
         // ctx.http guards
@@ -720,7 +741,7 @@ fn parse_when_guard(expr: &SExpr, ctx: &ParseContext) -> Result<(Observable, Arm
                 "(ctx.http.domain) guard expects exactly 1 pattern"
             );
             let pat = parse_pattern(&list[1], ctx)?;
-            Ok((Observable::HttpDomain, ArmPattern::Single(pat)))
+            Ok((Observable::HttpDomain, ArmPattern::Single(pat), false))
         }
         "ctx.http.method" => {
             ensure!(
@@ -728,7 +749,7 @@ fn parse_when_guard(expr: &SExpr, ctx: &ParseContext) -> Result<(Observable, Arm
                 "(ctx.http.method) guard expects exactly 1 pattern"
             );
             let pat = parse_pattern(&list[1], ctx)?;
-            Ok((Observable::HttpMethod, ArmPattern::Single(pat)))
+            Ok((Observable::HttpMethod, ArmPattern::Single(pat), false))
         }
 
         // ctx.fs guards
@@ -738,7 +759,7 @@ fn parse_when_guard(expr: &SExpr, ctx: &ParseContext) -> Result<(Observable, Arm
                 "(ctx.fs.action) guard expects exactly 1 pattern"
             );
             let pat = parse_pattern(&list[1], ctx)?;
-            Ok((Observable::FsAction, ArmPattern::Single(pat)))
+            Ok((Observable::FsAction, ArmPattern::Single(pat), false))
         }
         "ctx.fs.path" => {
             ensure!(
@@ -746,7 +767,7 @@ fn parse_when_guard(expr: &SExpr, ctx: &ParseContext) -> Result<(Observable, Arm
                 "(ctx.fs.path) guard expects exactly 1 path filter"
             );
             let pf = parse_path_filter(&list[1], ctx)?;
-            Ok((Observable::FsPath, ArmPattern::SinglePath(pf)))
+            Ok((Observable::FsPath, ArmPattern::SinglePath(pf), false))
         }
 
         // ctx.tool.args.<field>? — nullable dynamic field when guard
@@ -755,15 +776,15 @@ fn parse_when_guard(expr: &SExpr, ctx: &ParseContext) -> Result<(Observable, Arm
             ensure!(list.len() == 2, "({other}) guard expects exactly 1 pattern");
             // Try path filter first, fall back to general pattern
             if let Ok(pf) = try_parse_arm_path_filter(&list[1], ctx) {
-                Ok((observable, ArmPattern::SinglePath(pf)))
+                Ok((observable, ArmPattern::SinglePath(pf), false))
             } else {
                 let pat = parse_pattern(&list[1], ctx)?;
-                Ok((observable, ArmPattern::Single(pat)))
+                Ok((observable, ArmPattern::Single(pat), false))
             }
         }
 
         other => bail!(
-            "unknown when guard: {other} (expected 'command', 'tool', 'agent', 'mcp', \
+            "unknown when guard: {other} (expected 'eq', 'command', 'tool', 'agent', 'mcp', \
              'ctx.http.domain', 'ctx.http.method', 'ctx.fs.action', or 'ctx.fs.path')"
         ),
     }
@@ -1955,6 +1976,7 @@ mod tests {
                 observable,
                 pattern,
                 body,
+                ..
             } => {
                 assert!(matches!(observable, Observable::Command));
                 match pattern {
@@ -2035,6 +2057,7 @@ mod tests {
                 observable,
                 pattern,
                 body,
+                ..
             } => {
                 assert!(matches!(observable, Observable::Tool));
                 match pattern {
@@ -2067,11 +2090,46 @@ mod tests {
                 observable,
                 pattern,
                 body,
+                ..
             } => {
                 assert!(matches!(observable, Observable::Agent));
                 match pattern {
                     ArmPattern::Single(Pattern::Literal(s)) => assert_eq!(s, "Explore"),
                     _ => panic!("expected Single(Literal) pattern"),
+                }
+                assert_eq!(body.len(), 1);
+                assert!(matches!(&body[0], PolicyItem::Effect(Effect::Allow)));
+            }
+            other => panic!("expected When, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_when_eq_process_command() {
+        let source = r#"
+            (version 2)
+            (policy "p"
+              (when (eq ctx.process.command "cargo") :allow))
+        "#;
+        let ast = parse(source).unwrap();
+        let body = match &ast[1] {
+            TopLevel::Policy { body, .. } => body,
+            _ => panic!(),
+        };
+        match &body[0] {
+            PolicyItem::When {
+                observable,
+                pattern,
+                body,
+                is_eq,
+            } => {
+                assert!(matches!(observable, Observable::ProcessCommand));
+                assert!(*is_eq, "expected is_eq = true");
+                match pattern {
+                    ArmPattern::Single(pat) => {
+                        assert_eq!(*pat, Pattern::Literal("cargo".into()));
+                    }
+                    _ => panic!("expected Single pattern, got {pattern:?}"),
                 }
                 assert_eq!(body.len(), 1);
                 assert!(matches!(&body[0], PolicyItem::Effect(Effect::Allow)));
@@ -2097,6 +2155,7 @@ mod tests {
                 observable,
                 pattern,
                 body,
+                ..
             } => {
                 assert!(matches!(observable, Observable::Agent));
                 match pattern {
@@ -2107,6 +2166,35 @@ mod tests {
                 }
                 assert_eq!(body.len(), 1);
                 assert!(matches!(&body[0], PolicyItem::Effect(Effect::Ask)));
+            }
+            other => panic!("expected When, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_when_eq_http_domain() {
+        let source = r#"
+            (version 2)
+            (policy "p"
+              (when (eq ctx.http.domain "github.com") :deny))
+        "#;
+        let ast = parse(source).unwrap();
+        let body = match &ast[1] {
+            TopLevel::Policy { body, .. } => body,
+            _ => panic!(),
+        };
+        match &body[0] {
+            PolicyItem::When {
+                observable,
+                pattern,
+                is_eq,
+                ..
+            } => {
+                assert!(matches!(observable, Observable::HttpDomain));
+                assert!(*is_eq);
+                assert!(
+                    matches!(pattern, ArmPattern::Single(Pattern::Literal(s)) if s == "github.com")
+                );
             }
             other => panic!("expected When, got {other:?}"),
         }
@@ -2142,6 +2230,73 @@ mod tests {
             }
             other => panic!("expected Match, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn parse_when_eq_with_or_pattern() {
+        let source = r#"
+            (version 2)
+            (policy "p"
+              (when (eq ctx.tool.name (or "Read" "Write")) :allow))
+        "#;
+        let ast = parse(source).unwrap();
+        let body = match &ast[1] {
+            TopLevel::Policy { body, .. } => body,
+            _ => panic!(),
+        };
+        match &body[0] {
+            PolicyItem::When {
+                observable,
+                pattern,
+                is_eq,
+                ..
+            } => {
+                assert!(matches!(observable, Observable::ToolName));
+                assert!(*is_eq);
+                assert!(matches!(pattern, ArmPattern::Single(Pattern::Or(ps)) if ps.len() == 2));
+            }
+            other => panic!("expected When, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_when_eq_rejects_invocation_types() {
+        let source = r#"(version 2)(policy "p" (when (eq command "cargo") :allow))"#;
+        let err = parse(source).unwrap_err();
+        assert!(
+            err.to_string().contains("invocation types"),
+            "expected invocation type error, got: {err}"
+        );
+
+        let source = r#"(version 2)(policy "p" (when (eq tool "Read") :allow))"#;
+        let err = parse(source).unwrap_err();
+        assert!(
+            err.to_string().contains("invocation types"),
+            "expected invocation type error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn parse_when_eq_wrong_arity() {
+        let source = r#"(version 2)(policy "p" (when (eq ctx.process.command) :allow))"#;
+        let err = parse(source).unwrap_err();
+        assert!(
+            err.to_string().contains("exactly 2 arguments"),
+            "expected arity error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn round_trip_when_eq() {
+        let source = r#"(version 2)(policy "p" (when (eq ctx.process.command "cargo") :allow))"#;
+        let ast1 = parse(source).unwrap();
+        let printed: String = ast1
+            .iter()
+            .map(|tl| tl.to_string())
+            .collect::<Vec<_>>()
+            .join("\n");
+        let ast2 = parse(&printed).unwrap();
+        assert_eq!(ast1, ast2, "round-trip failed:\n{printed}");
     }
 
     #[test]
@@ -2313,6 +2468,7 @@ mod tests {
                 observable,
                 pattern,
                 body,
+                ..
             } => {
                 assert!(matches!(observable, Observable::Command));
                 match pattern {
@@ -2563,6 +2719,7 @@ mod tests {
                 observable,
                 pattern,
                 body,
+                ..
             } => {
                 assert!(matches!(observable, Observable::Command));
                 match pattern {

--- a/clash/src/policy/tree.rs
+++ b/clash/src/policy/tree.rs
@@ -118,7 +118,10 @@ impl Predicate {
     /// `command` does not — you cannot prompt a human about what a subprocess
     /// is doing in real time.
     pub fn allows_ask(&self) -> bool {
-        matches!(self, Predicate::Tool(_) | Predicate::Mcp(_) | Predicate::Agent(_))
+        matches!(
+            self,
+            Predicate::Tool(_) | Predicate::Mcp(_) | Predicate::Agent(_)
+        )
     }
 }
 

--- a/clash/src/policy/version.rs
+++ b/clash/src/policy/version.rs
@@ -284,11 +284,13 @@ fn lift_sandbox_items(items: &[PolicyItem]) -> Vec<PolicyItem> {
                 observable,
                 pattern,
                 body,
+                ..
             } => {
                 result.push(PolicyItem::When {
                     observable: observable.clone(),
                     pattern: pattern.clone(),
                     body: lift_sandbox_items(body),
+                    is_eq: false,
                 });
             }
             other => result.push(other.clone()),
@@ -450,6 +452,7 @@ fn transform_policy_body(body: &[PolicyItem]) -> Vec<PolicyItem> {
                 has_args: vec![],
             }),
             body: vec![PolicyItem::Sandbox { body: sandbox_body }],
+            is_eq: false,
         });
     }
 
@@ -486,6 +489,7 @@ fn transform_rule(
                 observable: Observable::Command,
                 pattern: ArmPattern::Exec(exec_matcher.clone()),
                 body: when_body,
+                is_eq: false,
             });
         }
         CapMatcher::Tool(tool_matcher) => {
@@ -493,6 +497,7 @@ fn transform_rule(
                 observable: Observable::Tool,
                 pattern: ArmPattern::Single(tool_matcher.name.clone()),
                 body: vec![PolicyItem::Effect(rule.effect)],
+                is_eq: false,
             });
         }
         CapMatcher::Fs(fs_matcher) => {
@@ -502,6 +507,7 @@ fn transform_rule(
                 observable: Observable::Tool,
                 pattern: ArmPattern::Single(tool_pattern),
                 body: vec![PolicyItem::Effect(rule.effect)],
+                is_eq: false,
             });
 
             // For allow effects, also collect the fs rule as a sandbox item
@@ -520,6 +526,7 @@ fn transform_rule(
                 observable: Observable::Tool,
                 pattern: ArmPattern::Single(tool_pattern),
                 body: vec![PolicyItem::Effect(rule.effect)],
+                is_eq: false,
             });
 
             // For allow effects, also collect the net rule as a sandbox item.

--- a/clester/tests/scripts/v2_eq_predicate.yaml
+++ b/clester/tests/scripts/v2_eq_predicate.yaml
@@ -1,0 +1,48 @@
+meta:
+  name: v2 eq predicate — equality test in when guards
+  description: >
+    Test that the (eq ctx.field value) predicate form works in when guards,
+    matching tool invocations by ctx field equality.
+
+clash:
+  policy_sexpr: |
+    (version 2)
+    (default deny "main")
+    (policy "main"
+      (when (eq ctx.process.command "cargo") :allow)
+      (when (eq ctx.http.domain "github.com") :allow))
+
+steps:
+  - name: cargo allowed by eq ctx.process.command
+    hook: pre-tool-use
+    tool_name: Bash
+    tool_input:
+      command: cargo build
+    expect:
+      decision: allow
+
+  - name: git denied — does not match eq predicate
+    hook: pre-tool-use
+    tool_name: Bash
+    tool_input:
+      command: git status
+    expect:
+      decision: deny
+
+  - name: github.com allowed by eq ctx.http.domain
+    hook: pre-tool-use
+    tool_name: WebFetch
+    tool_input:
+      url: "https://github.com/empathic/clash"
+      prompt: read the readme
+    expect:
+      decision: allow
+
+  - name: evil.com denied — does not match eq predicate
+    hook: pre-tool-use
+    tool_name: WebFetch
+    tool_input:
+      url: "https://evil.com/exploit"
+      prompt: bad
+    expect:
+      decision: deny

--- a/docs/policy-grammar.md
+++ b/docs/policy-grammar.md
@@ -418,6 +418,7 @@ when_guard      = "(" "command" pattern? args_spec ")"
                 | "(" "mcp" pattern? ")"
                 | "(" observable pattern ")"
                 | "(" observable path_filter ")"        ; for ctx.fs.path
+                | "(" "eq" ctx_ref pattern ")"          ; equality predicate
 when_body       = effect_kw                             ; inline effect
                 | match_block                           ; nested match (constraint source)
                 | when_block                            ; nested when
@@ -486,6 +487,12 @@ The body contains one or more items: an effect keyword (`:allow`, `:deny`, `:ask
 
 ; Guard on filesystem path
 (when (ctx.fs.path (subpath (env PWD))) :allow)
+
+; Equality predicate on ctx field
+(when (eq ctx.process.command "cargo") :allow)
+
+; Equality predicate with or-pattern
+(when (eq ctx.http.domain (or "github.com" "crates.io")) :allow)
 
 ; Allow cargo with network constraints
 (when (command "cargo" *)


### PR DESCRIPTION
## Summary

- Add `(eq <ctx-ref> <expr>)` as a predicate form in `when` guards, enabling explicit equality tests on ctx fields
- `(eq ctx.process.command "cargo")` is semantically equivalent to `(ctx.process.command "cargo")` — both compile to the same IR predicate
- Supports all ctx observables: `ctx.process.command`, `ctx.http.domain`, `ctx.tool.name`, `ctx.fs.action`, `ctx.fs.path`, etc.
- Supports compound patterns: `(eq ctx.process.command (or "cargo" "rustc"))`
- Rejects invocation types (`command`, `tool`) — these have their own guard syntax
- Round-trip preserves `eq` syntax in AST display

## Test plan

- [x] Parse tests: basic eq, eq with or-pattern, eq with http domain, reject invocation types, wrong arity
- [x] Round-trip test: `(eq ctx.process.command "cargo")` → display → parse → identical AST
- [x] Compile/eval tests: eq with process command, http domain, tool name, or-pattern
- [x] E2E test: `v2_eq_predicate.yaml` with cargo allow + git deny + domain matching
- [x] `just check` passes (802 unit tests)
- [x] `just clester` passes (168 e2e steps)

Closes #219