### PR TITLE
feat(policy): validate ctx references against versioned schema

### DIFF
--- a/clash/src/policy/ast.rs
+++ b/clash/src/policy/ast.rs
@@ -469,10 +469,10 @@ impl fmt::Display for Observable {
             Observable::ProcessArgs => write!(f, "ctx.process.args"),
             Observable::ToolName => write!(f, "ctx.tool.name"),
             Observable::ToolArgs => write!(f, "ctx.tool.args"),
-            Observable::AgentName => write!(f, "ctx.agent.name"),
+            Observable::ToolArgField(field) => write!(f, "ctx.tool.args.{field}?"),
             Observable::McpServer => write!(f, "ctx.mcp.server"),
             Observable::McpTool => write!(f, "ctx.mcp.tool"),
-            Observable::ToolArgField(field) => write!(f, "ctx.tool.args.{field}?"),
+            Observable::AgentName => write!(f, "ctx.agent.name"),
             Observable::State => write!(f, "ctx.state"),
             Observable::Tuple(obs) => {
                 write!(f, "[")?;

--- a/clash/src/policy/compile.rs
+++ b/clash/src/policy/compile.rs
@@ -1243,13 +1243,10 @@ fn compile_observable_to_ir(obs: &Observable) -> Result<crate::policy::tree::Obs
         Observable::ToolName => Ok(ir::Observable::ToolName),
         Observable::ToolArgs => Ok(ir::Observable::ToolArgs),
         Observable::Agent => Ok(ir::Observable::Agent),
-        Observable::AgentName => Ok(ir::Observable::AgentName),
-        Observable::Mcp => bail!(
-            "mcp invocation type cannot be used as a match observable; use ctx.mcp.server or ctx.mcp.tool"
-        ),
+        Observable::ToolArgField(field) => Ok(ir::Observable::ToolArgField(field.clone())),
         Observable::McpServer => Ok(ir::Observable::McpServer),
         Observable::McpTool => Ok(ir::Observable::McpTool),
-        Observable::ToolArgField(field) => Ok(ir::Observable::ToolArgField(field.clone())),
+        Observable::AgentName => Ok(ir::Observable::AgentName),
         Observable::State => Ok(ir::Observable::State),
         Observable::Tuple(obs) => {
             let inner = obs

--- a/clash/src/policy/mod.rs
+++ b/clash/src/policy/mod.rs
@@ -16,6 +16,7 @@ pub mod ir;
 pub mod parse;
 pub mod print;
 pub mod sandbox_types;
+pub mod schema;
 pub mod sexpr;
 pub mod specificity;
 pub mod tree;

--- a/clash/src/policy/parse.rs
+++ b/clash/src/policy/parse.rs
@@ -660,13 +660,9 @@ fn parse_when_body_item(expr: &SExpr, ctx: &ParseContext) -> Result<PolicyItem> 
 
 /// Parse a when guard `(observable pattern)` → `(Observable, ArmPattern, is_eq)`.
 ///
-/// Handles invocation-type guards, ctx.* observable guards, and `eq` predicates:
-/// - `(command ...)` → Observable::Command + ArmPattern::Exec
-/// - `(tool ...)` → Observable::Tool + ArmPattern::Single
-/// - `(ctx.http.domain ...)` → Observable::HttpDomain + ArmPattern::Single
-/// - `(ctx.fs.action ...)` → Observable::FsAction + ArmPattern::Single
-/// - `(ctx.fs.path ...)` → Observable::FsPath + ArmPattern::SinglePath
-/// - `(eq <ctx-ref> <expr>)` → resolved observable + ArmPattern::Single
+/// Handles invocation-type guards, ctx.* observable guards, and `eq` predicates.
+/// For ctx paths, validates against the versioned schema and dispatches to the
+/// appropriate pattern parser based on the field kind (scalar vs path).
 ///
 /// Deprecated flat names (`proxy.domain`, `fs.action`, etc.) are accepted with warnings.
 fn parse_when_guard(expr: &SExpr, ctx: &ParseContext) -> Result<(Observable, ArmPattern, bool)> {
@@ -680,7 +676,7 @@ fn parse_when_guard(expr: &SExpr, ctx: &ParseContext) -> Result<(Observable, Arm
             list.len() == 3,
             "(eq) expects exactly 2 arguments: (eq <ctx-ref> <expr>)"
         );
-        let observable = parse_observable(&list[1])?;
+        let observable = parse_observable(&list[1], ctx.version)?;
         ensure!(
             !matches!(
                 observable,
@@ -694,26 +690,25 @@ fn parse_when_guard(expr: &SExpr, ctx: &ParseContext) -> Result<(Observable, Arm
     }
 
     // Map deprecated names to their canonical ctx.* equivalents.
-    let (canonical, deprecated) = match head {
+    let canonical = match head {
         "proxy.domain" => {
             tracing::warn!("deprecated when guard `proxy.domain`: use `ctx.http.domain`");
-            ("ctx.http.domain", true)
+            "ctx.http.domain"
         }
         "proxy.method" => {
             tracing::warn!("deprecated when guard `proxy.method`: use `ctx.http.method`");
-            ("ctx.http.method", true)
+            "ctx.http.method"
         }
         "fs.action" => {
             tracing::warn!("deprecated when guard `fs.action`: use `ctx.fs.action`");
-            ("ctx.fs.action", true)
+            "ctx.fs.action"
         }
         "fs.path" => {
             tracing::warn!("deprecated when guard `fs.path`: use `ctx.fs.path`");
-            ("ctx.fs.path", true)
+            "ctx.fs.path"
         }
-        other => (other, false),
+        other => other,
     };
-    let _ = deprecated; // suppress unused warning
 
     match canonical {
         // Invocation-type guards
@@ -734,59 +729,49 @@ fn parse_when_guard(expr: &SExpr, ctx: &ParseContext) -> Result<(Observable, Arm
             Ok((Observable::Mcp, ArmPattern::Single(m.name), false))
         }
 
-        // ctx.http guards
-        "ctx.http.domain" => {
-            ensure!(
-                list.len() == 2,
-                "(ctx.http.domain) guard expects exactly 1 pattern"
-            );
-            let pat = parse_pattern(&list[1], ctx)?;
-            Ok((Observable::HttpDomain, ArmPattern::Single(pat), false))
-        }
-        "ctx.http.method" => {
-            ensure!(
-                list.len() == 2,
-                "(ctx.http.method) guard expects exactly 1 pattern"
-            );
-            let pat = parse_pattern(&list[1], ctx)?;
-            Ok((Observable::HttpMethod, ArmPattern::Single(pat), false))
-        }
+        // ctx.* guards — schema-driven validation and dispatch
+        s if s.starts_with("ctx.") => {
+            use super::schema::{CtxFieldKind, ctx_schema};
 
-        // ctx.fs guards
-        "ctx.fs.action" => {
-            ensure!(
-                list.len() == 2,
-                "(ctx.fs.action) guard expects exactly 1 pattern"
-            );
-            let pat = parse_pattern(&list[1], ctx)?;
-            Ok((Observable::FsAction, ArmPattern::Single(pat), false))
-        }
-        "ctx.fs.path" => {
-            ensure!(
-                list.len() == 2,
-                "(ctx.fs.path) guard expects exactly 1 path filter"
-            );
-            let pf = parse_path_filter(&list[1], ctx)?;
-            Ok((Observable::FsPath, ArmPattern::SinglePath(pf), false))
-        }
+            let schema = ctx_schema(ctx.version);
+            let entry = schema.iter().find(|e| e.path == s);
 
-        // ctx.tool.args.<field>? — nullable dynamic field when guard
-        other if other.starts_with("ctx.tool.args.") => {
-            let observable = parse_tool_arg_field(other)?;
-            ensure!(list.len() == 2, "({other}) guard expects exactly 1 pattern");
-            // Try path filter first, fall back to general pattern
-            if let Ok(pf) = try_parse_arm_path_filter(&list[1], ctx) {
-                Ok((observable, ArmPattern::SinglePath(pf), false))
-            } else {
-                let pat = parse_pattern(&list[1], ctx)?;
-                Ok((observable, ArmPattern::Single(pat), false))
+            let Some(field) = entry else {
+                // ctx.tool.args.<field>? — nullable dynamic field accessor.
+                if s.starts_with("ctx.tool.args.") {
+                    let observable = parse_tool_arg_field(s)?;
+                    ensure!(list.len() == 2, "({s}) guard expects exactly 1 pattern");
+                    if let Ok(pf) = try_parse_arm_path_filter(&list[1], ctx) {
+                        return Ok((observable, ArmPattern::SinglePath(pf), false));
+                    }
+                    let pat = parse_pattern(&list[1], ctx)?;
+                    return Ok((observable, ArmPattern::Single(pat), false));
+                }
+                // Not found — delegate to resolve_ctx_observable for helpful error.
+                return super::schema::resolve_ctx_observable(s, ctx.version)
+                    .map(|obs| (obs, ArmPattern::Single(Pattern::Any), false));
+            };
+
+            ensure!(list.len() == 2, "({s}) guard expects exactly 1 pattern");
+
+            match field.kind {
+                CtxFieldKind::Path => {
+                    let pf = parse_path_filter(&list[1], ctx)?;
+                    Ok((field.observable.clone(), ArmPattern::SinglePath(pf), false))
+                }
+                CtxFieldKind::Scalar | CtxFieldKind::Dynamic => {
+                    let pat = parse_pattern(&list[1], ctx)?;
+                    Ok((field.observable.clone(), ArmPattern::Single(pat), false))
+                }
             }
         }
 
-        other => bail!(
-            "unknown when guard: {other} (expected 'eq', 'command', 'tool', 'agent', 'mcp', \
-             'ctx.http.domain', 'ctx.http.method', 'ctx.fs.action', or 'ctx.fs.path')"
-        ),
+        other => {
+            bail!(
+                "unknown when guard: `{other}` (expected `command`, `tool`, `agent`, `mcp`, \
+                 or a `ctx.*` observable)"
+            )
+        }
     }
 }
 
@@ -839,7 +824,7 @@ fn parse_match_block_inner(
         list.len() >= 4,
         "(match) expects an observable and at least one pattern/effect pair"
     );
-    let observable = parse_observable(&list[1])?;
+    let observable = parse_observable(&list[1], ctx.version)?;
     let (default, arms) = parse_match_arms(&list[2..], &observable, ctx, in_sandbox)?;
     Ok(MatchBlock {
         observable,
@@ -860,67 +845,53 @@ fn parse_sandbox_match_block(list: &[SExpr], ctx: &ParseContext) -> Result<Match
 
 /// Parse an observable reference: `command`, `tool`, or any `ctx.*` observable,
 /// plus deprecated flat names (`proxy.domain`, `fs.action`, etc.).
-fn parse_observable(expr: &SExpr) -> Result<Observable> {
+///
+/// For `ctx.*` paths, validates against the versioned schema and produces
+/// helpful error messages with did-you-mean suggestions for typos.
+fn parse_observable(expr: &SExpr, version: u32) -> Result<Observable> {
     match expr {
-        SExpr::Atom(s, _) => match s.as_str() {
-            // Invocation-type observables (unchanged)
-            "command" => Ok(Observable::Command),
-            "tool" => Ok(Observable::Tool),
-            "agent" => Ok(Observable::Agent),
-            "mcp" => Ok(Observable::Mcp),
-
-            // ctx.http namespace
-            "ctx.http.domain" => Ok(Observable::HttpDomain),
-            "ctx.http.method" => Ok(Observable::HttpMethod),
-            "ctx.http.port" => Ok(Observable::HttpPort),
-            "ctx.http.path" => Ok(Observable::HttpPath),
-
-            // ctx.fs namespace
-            "ctx.fs.action" => Ok(Observable::FsAction),
-            "ctx.fs.path" => Ok(Observable::FsPath),
-            "ctx.fs.exists" => Ok(Observable::FsExists),
-
-            // ctx.process namespace
-            "ctx.process.command" => Ok(Observable::ProcessCommand),
-            "ctx.process.args" => Ok(Observable::ProcessArgs),
-
-            // ctx.tool namespace
-            "ctx.tool.name" => Ok(Observable::ToolName),
-            "ctx.tool.args" => Ok(Observable::ToolArgs),
-
-            // ctx.agent namespace
-            "ctx.agent.name" => Ok(Observable::AgentName),
-
-            // ctx.mcp namespace
-            "ctx.mcp.server" => Ok(Observable::McpServer),
-            "ctx.mcp.tool" => Ok(Observable::McpTool),
-
-            // ctx.state
-            "ctx.state" => Ok(Observable::State),
-
-            // ctx.tool.args.<field>? — nullable dynamic field accessor
-            other if other.starts_with("ctx.tool.args.") => parse_tool_arg_field(other),
-
-            // Deprecated flat names — accept with warning
-            "proxy.domain" => {
-                tracing::warn!("deprecated observable `proxy.domain`: use `ctx.http.domain`");
-                Ok(Observable::HttpDomain)
-            }
-            "proxy.method" => {
-                tracing::warn!("deprecated observable `proxy.method`: use `ctx.http.method`");
-                Ok(Observable::HttpMethod)
-            }
-            "fs.action" => {
-                tracing::warn!("deprecated observable `fs.action`: use `ctx.fs.action`");
-                Ok(Observable::FsAction)
-            }
-            "fs.path" => {
-                tracing::warn!("deprecated observable `fs.path`: use `ctx.fs.path`");
-                Ok(Observable::FsPath)
+        SExpr::Atom(s, _) => {
+            // Invocation-type observables (not part of ctx namespace).
+            match s.as_str() {
+                "command" => return Ok(Observable::Command),
+                "tool" => return Ok(Observable::Tool),
+                "agent" => return Ok(Observable::Agent),
+                "mcp" => return Ok(Observable::Mcp),
+                _ => {}
             }
 
-            other => bail!("unknown observable: {other}"),
-        },
+            // Deprecated flat names — accept with warning.
+            match s.as_str() {
+                "proxy.domain" => {
+                    tracing::warn!("deprecated observable `proxy.domain`: use `ctx.http.domain`");
+                    return Ok(Observable::HttpDomain);
+                }
+                "proxy.method" => {
+                    tracing::warn!("deprecated observable `proxy.method`: use `ctx.http.method`");
+                    return Ok(Observable::HttpMethod);
+                }
+                "fs.action" => {
+                    tracing::warn!("deprecated observable `fs.action`: use `ctx.fs.action`");
+                    return Ok(Observable::FsAction);
+                }
+                "fs.path" => {
+                    tracing::warn!("deprecated observable `fs.path`: use `ctx.fs.path`");
+                    return Ok(Observable::FsPath);
+                }
+                _ => {}
+            }
+
+            // ctx.* paths — validate against versioned schema.
+            // ctx.tool.args.<field>? is handled by parse_tool_arg_field (nullable accessor).
+            if s.starts_with("ctx.") {
+                if s.starts_with("ctx.tool.args.") {
+                    return parse_tool_arg_field(s);
+                }
+                return super::schema::resolve_ctx_observable(s, version);
+            }
+
+            bail!("unknown observable: {s}")
+        }
         SExpr::List(children, _) => {
             // Bracket list: [fs.action fs.path] → Tuple
             ensure!(
@@ -934,7 +905,7 @@ fn parse_observable(expr: &SExpr) -> Result<Observable> {
             );
             let obs = children[1..]
                 .iter()
-                .map(parse_observable)
+                .map(|e| parse_observable(e, version))
                 .collect::<Result<_>>()?;
             Ok(Observable::Tuple(obs))
         }
@@ -3017,6 +2988,160 @@ mod tests {
                 ..
             } => {
                 assert_eq!(*observable, Observable::Mcp);
+                assert!(
+                    matches!(pattern, ArmPattern::Single(Pattern::Literal(s)) if s == "puppeteer")
+                );
+            }
+            other => panic!("expected When, got {other:?}"),
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // ctx schema validation (gh-223)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn parse_ctx_typo_suggests_closest() {
+        let source = r#"
+            (version 2)
+            (policy "p"
+              (when (command "cargo" *)
+                (match ctx.htttp.domain
+                  "crates.io" :allow)))
+        "#;
+        let err = parse(source).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("Did you mean `ctx.http.domain`?"),
+            "expected did-you-mean suggestion, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn parse_ctx_unknown_namespace_in_match() {
+        let source = r#"
+            (version 2)
+            (policy "p"
+              (when (command "cargo" *)
+                (match ctx.foo.bar
+                  "x" :allow)))
+        "#;
+        let err = parse(source).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("is not a valid observable in version 2"),
+            "expected schema error, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn parse_ctx_typo_in_when_guard() {
+        let source = r#"
+            (version 2)
+            (policy "p"
+              (when (ctx.htttp.domain "github.com") :allow))
+        "#;
+        let err = parse(source).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("Did you mean `ctx.http.domain`?"),
+            "expected did-you-mean suggestion, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn parse_ctx_static_subpath_rejected() {
+        let source = r#"
+            (version 2)
+            (policy "p"
+              (when (command "cargo" *)
+                (match ctx.http.domain.something
+                  "x" :allow)))
+        "#;
+        let err = parse(source).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("leaf field"),
+            "expected leaf field error, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn parse_ctx_dynamic_subpath_with_nullable_accepted() {
+        let source = r#"
+            (version 2)
+            (policy "p"
+              (when (command "cargo" *)
+                (match ctx.tool.args.file_path?
+                  "src/main.rs" :allow)))
+        "#;
+        let ast = parse(source).unwrap();
+        let body = match &ast[1] {
+            TopLevel::Policy { body, .. } => body,
+            _ => panic!(),
+        };
+        let when_body = match &body[0] {
+            PolicyItem::When { body, .. } => body,
+            _ => panic!(),
+        };
+        match &when_body[0] {
+            PolicyItem::Match(block) => {
+                // Nullable accessor resolves to ToolArgField.
+                assert_eq!(
+                    block.observable,
+                    Observable::ToolArgField("file_path".into())
+                );
+            }
+            other => panic!("expected Match, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_ctx_valid_paths_still_work() {
+        let source = r#"
+            (version 2)
+            (policy "p"
+              (when (command "cargo" *)
+                (match ctx.http.domain
+                  "github.com" :allow)
+                (match ctx.fs.path
+                  (subpath (env PWD)) :allow)
+                (match ctx.mcp.server
+                  "puppeteer" :allow)
+                (match ctx.agent.name
+                  "Explore" :allow)))
+        "#;
+        let ast = parse(source).unwrap();
+        let body = match &ast[1] {
+            TopLevel::Policy { body, .. } => body,
+            _ => panic!(),
+        };
+        let when_body = match &body[0] {
+            PolicyItem::When { body, .. } => body,
+            _ => panic!(),
+        };
+        assert_eq!(when_body.len(), 4);
+    }
+
+    #[test]
+    fn parse_ctx_when_guard_schema_driven() {
+        let source = r#"
+            (version 2)
+            (policy "p"
+              (when (ctx.mcp.server "puppeteer") :allow))
+        "#;
+        let ast = parse(source).unwrap();
+        let body = match &ast[1] {
+            TopLevel::Policy { body, .. } => body,
+            _ => panic!(),
+        };
+        match &body[0] {
+            PolicyItem::When {
+                observable,
+                pattern,
+                ..
+            } => {
+                assert_eq!(*observable, Observable::McpServer);
                 assert!(
                     matches!(pattern, ArmPattern::Single(Pattern::Literal(s)) if s == "puppeteer")
                 );

--- a/clash/src/policy/schema.rs
+++ b/clash/src/policy/schema.rs
@@ -1,0 +1,273 @@
+//! Versioned schema registry for `ctx.*` observable paths.
+//!
+//! Each policy version defines a fixed set of valid `ctx` paths. The schema
+//! drives parse-time validation: any `ctx` reference not in the schema for the
+//! declared version is a parse error with a did-you-mean suggestion.
+
+use super::ast::Observable;
+use crate::policy::error::suggest_closest;
+
+/// Describes how a `ctx` field behaves for sub-path access validation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CtxFieldKind {
+    /// Scalar field — no sub-path access allowed.
+    /// Used in when guards with `parse_pattern` → `ArmPattern::Single`.
+    Scalar,
+    /// Filesystem path field — no sub-path access allowed.
+    /// Used in when guards with `parse_path_filter` → `ArmPattern::SinglePath`.
+    Path,
+    /// Dynamic subtree — sub-path access requires `?` suffix.
+    /// e.g. `ctx.tool.args.file_path?`
+    Dynamic,
+}
+
+/// One entry in the versioned ctx schema.
+#[derive(Debug, Clone)]
+pub struct CtxField {
+    /// The full canonical path, e.g. `"ctx.http.domain"`.
+    pub path: &'static str,
+    /// The AST observable this path maps to.
+    pub observable: Observable,
+    /// Field kind for sub-path access validation.
+    pub kind: CtxFieldKind,
+}
+
+/// Return the ctx schema for a given policy version.
+///
+/// Version 1 has no ctx namespace (observables were flat names), so returns
+/// an empty slice. Version 2+ defines the full ctx tree from the spec.
+pub fn ctx_schema(version: u32) -> &'static [CtxField] {
+    match version {
+        0 | 1 => &[],
+        _ => &V2_SCHEMA,
+    }
+}
+
+/// All valid `ctx.*` paths as strings for a given version.
+pub fn ctx_paths(version: u32) -> Vec<&'static str> {
+    ctx_schema(version).iter().map(|f| f.path).collect()
+}
+
+/// Look up a `ctx.*` path in the schema for the given version.
+///
+/// Returns the corresponding `Observable` on success, or a helpful error
+/// with a did-you-mean suggestion when the path is invalid.
+pub fn resolve_ctx_observable(path: &str, version: u32) -> anyhow::Result<Observable> {
+    let schema = ctx_schema(version);
+
+    // Exact match in schema.
+    if let Some(entry) = schema.iter().find(|e| e.path == path) {
+        return Ok(entry.observable.clone());
+    }
+
+    // Check for sub-path access on a known field (e.g. ctx.tool.args.file_path).
+    let (base_path, has_nullable) = path
+        .strip_suffix('?')
+        .map(|stripped| (stripped, true))
+        .unwrap_or((path, false));
+
+    for entry in schema {
+        let prefix_with_dot = format!("{}.", entry.path);
+        if base_path.starts_with(&prefix_with_dot) {
+            return match entry.kind {
+                CtxFieldKind::Dynamic => {
+                    if has_nullable {
+                        // Valid dynamic field access with nullable suffix.
+                        // Map to the parent observable (runtime will handle the sub-path).
+                        Ok(entry.observable.clone())
+                    } else {
+                        anyhow::bail!(
+                            "`{path}` accesses a dynamic subtree (`{}`). \
+                             Use the `?` suffix for dynamic field access: `{path}?`",
+                            entry.path,
+                        )
+                    }
+                }
+                CtxFieldKind::Scalar | CtxFieldKind::Path => {
+                    anyhow::bail!(
+                        "`{}` is a leaf field and does not have sub-paths",
+                        entry.path,
+                    )
+                }
+            };
+        }
+    }
+
+    // No match — produce a did-you-mean suggestion.
+    let candidates = ctx_paths(version);
+    if let Some(suggestion) = suggest_closest(path, &candidates) {
+        anyhow::bail!(
+            "`{path}` is not a valid observable in version {version}. \
+             Did you mean `{suggestion}`?"
+        );
+    }
+    anyhow::bail!("`{path}` is not a valid observable in version {version}")
+}
+
+// ---------------------------------------------------------------------------
+// Version 2 schema
+// ---------------------------------------------------------------------------
+
+static V2_SCHEMA: [CtxField; 15] = [
+    // ctx.http namespace
+    CtxField {
+        path: "ctx.http.domain",
+        observable: Observable::HttpDomain,
+        kind: CtxFieldKind::Scalar,
+    },
+    CtxField {
+        path: "ctx.http.method",
+        observable: Observable::HttpMethod,
+        kind: CtxFieldKind::Scalar,
+    },
+    CtxField {
+        path: "ctx.http.port",
+        observable: Observable::HttpPort,
+        kind: CtxFieldKind::Scalar,
+    },
+    CtxField {
+        path: "ctx.http.path",
+        observable: Observable::HttpPath,
+        kind: CtxFieldKind::Scalar,
+    },
+    // ctx.fs namespace
+    CtxField {
+        path: "ctx.fs.action",
+        observable: Observable::FsAction,
+        kind: CtxFieldKind::Scalar,
+    },
+    CtxField {
+        path: "ctx.fs.path",
+        observable: Observable::FsPath,
+        kind: CtxFieldKind::Path,
+    },
+    CtxField {
+        path: "ctx.fs.exists",
+        observable: Observable::FsExists,
+        kind: CtxFieldKind::Scalar,
+    },
+    // ctx.process namespace
+    CtxField {
+        path: "ctx.process.command",
+        observable: Observable::ProcessCommand,
+        kind: CtxFieldKind::Scalar,
+    },
+    CtxField {
+        path: "ctx.process.args",
+        observable: Observable::ProcessArgs,
+        kind: CtxFieldKind::Dynamic,
+    },
+    // ctx.tool namespace
+    CtxField {
+        path: "ctx.tool.name",
+        observable: Observable::ToolName,
+        kind: CtxFieldKind::Scalar,
+    },
+    CtxField {
+        path: "ctx.tool.args",
+        observable: Observable::ToolArgs,
+        kind: CtxFieldKind::Dynamic,
+    },
+    // ctx.mcp namespace
+    CtxField {
+        path: "ctx.mcp.server",
+        observable: Observable::McpServer,
+        kind: CtxFieldKind::Scalar,
+    },
+    CtxField {
+        path: "ctx.mcp.tool",
+        observable: Observable::McpTool,
+        kind: CtxFieldKind::Scalar,
+    },
+    // ctx.agent namespace
+    CtxField {
+        path: "ctx.agent.name",
+        observable: Observable::AgentName,
+        kind: CtxFieldKind::Scalar,
+    },
+    // ctx.state
+    CtxField {
+        path: "ctx.state",
+        observable: Observable::State,
+        kind: CtxFieldKind::Scalar,
+    },
+];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn v1_schema_is_empty() {
+        assert!(ctx_schema(1).is_empty());
+    }
+
+    #[test]
+    fn v2_schema_has_all_paths() {
+        let paths = ctx_paths(2);
+        assert!(paths.contains(&"ctx.http.domain"));
+        assert!(paths.contains(&"ctx.fs.path"));
+        assert!(paths.contains(&"ctx.tool.args"));
+        assert!(paths.contains(&"ctx.mcp.server"));
+        assert!(paths.contains(&"ctx.agent.name"));
+        assert!(paths.contains(&"ctx.state"));
+    }
+
+    #[test]
+    fn resolve_exact_match() {
+        let obs = resolve_ctx_observable("ctx.http.domain", 2).unwrap();
+        assert_eq!(obs, Observable::HttpDomain);
+    }
+
+    #[test]
+    fn resolve_typo_suggests_closest() {
+        let err = resolve_ctx_observable("ctx.htttp.domain", 2).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("Did you mean `ctx.http.domain`?"),
+            "got: {msg}"
+        );
+    }
+
+    #[test]
+    fn resolve_unknown_namespace() {
+        let err = resolve_ctx_observable("ctx.foo.bar", 2).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("is not a valid observable in version 2"),
+            "got: {msg}"
+        );
+    }
+
+    #[test]
+    fn resolve_dynamic_subpath_without_nullable() {
+        let err = resolve_ctx_observable("ctx.tool.args.file_path", 2).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("dynamic subtree"), "got: {msg}");
+        assert!(msg.contains("?"), "should suggest ? suffix, got: {msg}");
+    }
+
+    #[test]
+    fn resolve_dynamic_subpath_with_nullable() {
+        let obs = resolve_ctx_observable("ctx.tool.args.file_path?", 2).unwrap();
+        assert_eq!(obs, Observable::ToolArgs);
+    }
+
+    #[test]
+    fn resolve_static_subpath_errors() {
+        let err = resolve_ctx_observable("ctx.http.domain.something", 2).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("leaf field"), "got: {msg}");
+    }
+
+    #[test]
+    fn v1_does_not_validate_ctx() {
+        // v1 schema is empty, so resolve fails generically.
+        let err = resolve_ctx_observable("ctx.http.domain", 1).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("is not a valid observable in version 1"),
+            "got: {msg}"
+        );
+    }
+}

--- a/clash/src/policy/tree.rs
+++ b/clash/src/policy/tree.rs
@@ -158,16 +158,16 @@ pub enum Observable {
     ToolName,
     /// `ctx.tool.args`
     ToolArgs,
-    /// `ctx.agent.name`
-    AgentName,
+    /// `ctx.tool.args.<field>?` — nullable tool argument field.
+    ToolArgField(String),
     /// `ctx.mcp.server`
     McpServer,
     /// `ctx.mcp.tool`
     McpTool,
-    /// `ctx.tool.args.<field>?` — nullable tool argument field.
-    ToolArgField(String),
     /// `mcp` — invocation-type predicate matching MCP tools by server name.
     Mcp,
+    /// `ctx.agent.name`
+    AgentName,
     /// `ctx.state`
     State,
     Tuple(Vec<Observable>),

--- a/docs/policy-grammar.md
+++ b/docs/policy-grammar.md
@@ -431,8 +431,8 @@ observable      = "command" | "tool" | "agent" | "mcp"
                 | "ctx.fs.action" | "ctx.fs.path" | "ctx.fs.exists"
                 | "ctx.process.command" | "ctx.process.args"
                 | "ctx.tool.name" | "ctx.tool.args" | ctx_tool_arg_field
-                | "ctx.agent.name"
                 | "ctx.mcp.server" | "ctx.mcp.tool"
+                | "ctx.agent.name"
                 | "ctx.state"
                 | "[" observable observable+ "]"         ; tuple
 ctx_tool_arg_field = "ctx.tool.args." FIELD_NAME "?"  ; nullable dynamic field accessor
@@ -552,9 +552,9 @@ At **policy level**, match arms may use `:allow`, `:deny`, or `:ask` effects. In
 | `ctx.tool.name` | string | Tool name |
 | `ctx.tool.args` | {string?} | Tool arguments (dynamic, nullable) |
 | `ctx.tool.args.<field>?` | string? | Nullable accessor for a specific tool argument field; absent field short-circuits the enclosing `match` |
-| `ctx.agent.name` | string | Subagent name |
 | `ctx.mcp.server` | string | MCP server name |
 | `ctx.mcp.tool` | string | MCP tool name |
+| `ctx.agent.name` | string | Subagent name |
 | `ctx.state` | string | Agent state |
 
 #### Scalar match


### PR DESCRIPTION
## Summary

Closes #223.

- **Schema registry** (`schema.rs`): versioned data structure defining all valid `ctx.*` paths, their Observable mapping, and field kind (scalar, path, dynamic). The v2 schema covers all 15 paths from the spec including `ctx.mcp.{server, tool}` and `ctx.agent.{name}`.
- **Parse-time validation**: `parse_observable()` and `parse_when_guard()` now validate `ctx.*` references against the schema for the declared policy version, replacing hardcoded match arms with schema-driven lookups.
- **Helpful error messages**: Invalid paths produce did-you-mean suggestions via Levenshtein distance (e.g., `ctx.htttp.domain is not a valid observable in version 2. Did you mean ctx.http.domain?`).
- **Static vs dynamic field distinction**: Sub-path access on static leaf fields (e.g., `ctx.http.domain.something`) is rejected. Dynamic subtrees (e.g., `ctx.tool.args`) require the `?` suffix for sub-field access (`ctx.tool.args.file_path?`).
- **New Observable variants**: `McpServer`, `McpTool`, `AgentName` added across ast.rs, tree.rs, compile.rs (deferred evaluation for now).

## Test plan

- [x] 8 new parse tests covering typo suggestions, unknown namespaces, static/dynamic sub-path validation, nullable accessor acceptance, and new observable variants in when guards
- [x] 9 new schema unit tests covering exact match, typo suggestion, unknown namespace, dynamic/static sub-path handling, and v1 vs v2 behavior
- [x] All 69 existing parse tests pass (no regressions)
- [x] `just ci` passes (809 unit tests + 164 e2e steps, all green)