### PR TITLE
feat(policy): add mcp invocation type and enforce :ask context restriction

### DIFF
--- a/clash/src/audit.rs
+++ b/clash/src/audit.rs
@@ -445,6 +445,9 @@ fn deny_hint(tool_name: &str, tool_input: &serde_json::Value, cwd: &str) -> Resu
         CapQuery::Agent { name } => {
             format!("(agent \"{}\")", name)
         }
+        CapQuery::Mcp { server, .. } => {
+            format!("(mcp \"{}\")", server)
+        }
     };
 
     Ok(format!("clash allow '{}'", rule))
@@ -470,6 +473,13 @@ fn tool_input_summary(tool_name: &str, input: &serde_json::Value, cwd: &str) -> 
         },
         Some(CapQuery::Tool { name }) => name.clone(),
         Some(CapQuery::Agent { name }) => format!("agent:{name}"),
+        Some(CapQuery::Mcp { server, tool }) => {
+            if tool.is_empty() {
+                format!("mcp:{server}")
+            } else {
+                format!("mcp:{server}/{tool}")
+            }
+        }
         None => String::new(),
     };
 

--- a/clash/src/debug/replay.rs
+++ b/clash/src/debug/replay.rs
@@ -185,6 +185,7 @@ impl ReplayResult {
             },
             Some(CapQuery::Tool { name }) => format!("(tool \"{}\")", name),
             Some(CapQuery::Agent { name }) => format!("(agent \"{}\")", name),
+            Some(CapQuery::Mcp { server, .. }) => format!("(mcp \"{}\")", server),
             None => return format!("clash allow '{}'", self.tool_name.to_lowercase()),
         };
 

--- a/clash/src/policy/ast.rs
+++ b/clash/src/policy/ast.rs
@@ -205,6 +205,8 @@ pub enum Observable {
     Tool,
     /// `agent` — invocation-type predicate matching subagent spawning by name.
     Agent,
+    /// `mcp` — invocation-type predicate matching MCP tool invocations by server name.
+    Mcp,
 
     // -- ctx.http namespace --------------------------------------------------
     /// `ctx.http.domain` — destination domain (formerly `proxy.domain`).
@@ -241,6 +243,12 @@ pub enum Observable {
     // -- ctx.agent namespace -------------------------------------------------
     /// `ctx.agent.name` — subagent name.
     AgentName,
+
+    // -- ctx.mcp namespace ---------------------------------------------------
+    /// `ctx.mcp.server` — MCP server name.
+    McpServer,
+    /// `ctx.mcp.tool` — MCP tool name.
+    McpTool,
 
     // -- ctx.state -----------------------------------------------------------
     /// `ctx.state` — agent state.
@@ -406,6 +414,15 @@ fn display_when_guard(
             }
             write!(f, ")")
         }
+        Observable::Mcp => {
+            write!(f, "(mcp")?;
+            if let ArmPattern::Single(pat) = pattern {
+                if *pat != Pattern::Any {
+                    write!(f, " {pat}")?;
+                }
+            }
+            write!(f, ")")
+        }
         _ => {
             // proxy.domain, fs.action, fs.path — render as (observable pattern)
             write!(f, "({observable}")?;
@@ -425,6 +442,7 @@ impl fmt::Display for Observable {
             Observable::Command => write!(f, "command"),
             Observable::Tool => write!(f, "tool"),
             Observable::Agent => write!(f, "agent"),
+            Observable::Mcp => write!(f, "mcp"),
             Observable::HttpDomain => write!(f, "ctx.http.domain"),
             Observable::HttpMethod => write!(f, "ctx.http.method"),
             Observable::HttpPort => write!(f, "ctx.http.port"),
@@ -437,6 +455,8 @@ impl fmt::Display for Observable {
             Observable::ToolName => write!(f, "ctx.tool.name"),
             Observable::ToolArgs => write!(f, "ctx.tool.args"),
             Observable::AgentName => write!(f, "ctx.agent.name"),
+            Observable::McpServer => write!(f, "ctx.mcp.server"),
+            Observable::McpTool => write!(f, "ctx.mcp.tool"),
             Observable::ToolArgField(field) => write!(f, "ctx.tool.args.{field}?"),
             Observable::State => write!(f, "ctx.state"),
             Observable::Tuple(obs) => {

--- a/clash/src/policy/compile.rs
+++ b/clash/src/policy/compile.rs
@@ -178,7 +178,7 @@ fn compile_tree_ast(top_levels: &[TopLevel], env: &dyn EnvResolver) -> Result<Po
         children: tree_children,
     };
 
-    Ok(PolicyTree {
+    let tree = PolicyTree {
         version,
         default: default_effect,
         policy_name: active_policy.to_string(),
@@ -189,7 +189,59 @@ fn compile_tree_ast(top_levels: &[TopLevel], env: &dyn EnvResolver) -> Result<Po
         net_rules,
         tool_rules,
         sandbox_policies: sandbox_policies_map,
-    })
+    };
+
+    validate_ask_contexts(&tree.root, false, &tree.node_meta)?;
+
+    Ok(tree)
+}
+
+/// Validate that `:ask` effects only appear inside `tool`, `mcp`, or `agent` guards.
+///
+/// This implements validation rule 6 from the spec: `:ask` may only appear in
+/// contexts reachable from `tool`, `mcp`, or `agent` invocation types — not from
+/// `command` or with no invocation guard at all.
+///
+/// Internal policies (`__internal_*`) are exempt because they may legitimately
+/// use `:ask` under `command` guards (e.g. the internal clash policy).
+fn validate_ask_contexts(
+    node: &Node,
+    has_valid_invocation: bool,
+    meta: &[NodeMeta],
+) -> Result<()> {
+    match node {
+        Node::Sequence { children, .. } | Node::DenyOverrides { children, .. } => {
+            for child in children {
+                validate_ask_contexts(child, has_valid_invocation, meta)?;
+            }
+        }
+        Node::When { predicate, body, .. } => {
+            let valid = has_valid_invocation || predicate.allows_ask();
+            validate_ask_contexts(body, valid, meta)?;
+        }
+        Node::Match { arms, .. } => {
+            for arm in arms {
+                validate_ask_contexts(&arm.body, has_valid_invocation, meta)?;
+            }
+        }
+        Node::Leaf {
+            id,
+            effect: Effect::Ask,
+        } => {
+            let is_internal = meta
+                .get(*id as usize)
+                .and_then(|m| m.origin_policy.as_deref())
+                .is_some_and(|p| p.starts_with("__internal_"));
+            if !has_valid_invocation && !is_internal {
+                bail!(
+                    ":ask may only appear inside a (when (tool ...) ...), \
+                     (when (mcp ...) ...), or (when (agent ...) ...) guard"
+                );
+            }
+        }
+        Node::Leaf { .. } => {}
+    }
+    Ok(())
 }
 
 /// Flatten a v2 policy, resolving includes while preserving When/Sandbox items.
@@ -655,10 +707,13 @@ fn compile_match_to_sandbox(
         Observable::AgentName => {
             // Agent context observables don't apply to sandbox rules.
         }
+        Observable::McpServer | Observable::McpTool => {
+            // MCP context observables don't apply to sandbox rules.
+        }
         Observable::State => {
             // State observable doesn't apply to sandbox rules.
         }
-        Observable::Command | Observable::Tool | Observable::Agent => {
+        Observable::Command | Observable::Tool | Observable::Agent | Observable::Mcp => {
             // Command/tool/agent observables don't apply to sandbox rules (sandbox restricts fs/net only).
         }
     }
@@ -1015,6 +1070,28 @@ fn compile_when_guard(
                 name: pat.clone(),
             })?))
         }
+        Observable::Mcp => {
+            let pat = match pattern {
+                ArmPattern::Single(p) => p,
+                _ => bail!("mcp observable requires a single pattern"),
+            };
+            Ok(Predicate::Mcp(compile_tool_to_compiled(&ToolMatcher {
+                name: pat.clone(),
+            })?))
+        }
+        Observable::McpServer => {
+            let pat = match pattern {
+                ArmPattern::Single(p) => p,
+                _ => bail!("ctx.mcp.server observable requires a single pattern"),
+            };
+            Ok(Predicate::Mcp(compile_tool_to_compiled(&ToolMatcher {
+                name: pat.clone(),
+            })?))
+        }
+        Observable::McpTool => {
+            // ctx.mcp.tool as a when guard — deferred, always true for now
+            Ok(Predicate::True)
+        }
         Observable::Tuple(_) => {
             bail!("tuple observables are not supported in when guards")
         }
@@ -1160,6 +1237,9 @@ fn compile_observable_to_ir(obs: &Observable) -> Result<crate::policy::tree::Obs
         Observable::ToolArgs => Ok(ir::Observable::ToolArgs),
         Observable::Agent => Ok(ir::Observable::Agent),
         Observable::AgentName => Ok(ir::Observable::AgentName),
+        Observable::Mcp => bail!("mcp invocation type cannot be used as a match observable; use ctx.mcp.server or ctx.mcp.tool"),
+        Observable::McpServer => Ok(ir::Observable::McpServer),
+        Observable::McpTool => Ok(ir::Observable::McpTool),
         Observable::ToolArgField(field) => Ok(ir::Observable::ToolArgField(field.clone())),
         Observable::State => Ok(ir::Observable::State),
         Observable::Tuple(obs) => {
@@ -1994,6 +2074,7 @@ fn observable_domain(obs: &Observable) -> &'static str {
         | Observable::ToolArgs
         | Observable::ToolArgField(_) => "tool",
         Observable::Agent | Observable::AgentName => "agent",
+        Observable::Mcp | Observable::McpServer | Observable::McpTool => "mcp",
         Observable::HttpDomain
         | Observable::HttpMethod
         | Observable::HttpPort
@@ -3628,5 +3709,135 @@ mod tests {
             err.to_string().contains("sibling when blocks"),
             "expected nested overlap error, got: {err}",
         );
+    }
+
+    // -----------------------------------------------------------------------
+    // :ask context validation tests (validation rule 6)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn ask_under_tool_is_valid() {
+        let env = TestEnv::new(&[("PWD", "/home/user")]);
+        let source = r#"
+(version 2)
+(default deny "main")
+(policy "main"
+  (when (tool "Skill") :ask))
+"#;
+        assert!(compile_to_tree(source, &env).is_ok());
+    }
+
+    #[test]
+    fn ask_under_mcp_is_valid() {
+        let env = TestEnv::new(&[("PWD", "/home/user")]);
+        let source = r#"
+(version 2)
+(default deny "main")
+(policy "main"
+  (when (mcp "puppeteer") :ask))
+"#;
+        assert!(compile_to_tree(source, &env).is_ok());
+    }
+
+    #[test]
+    fn ask_under_agent_is_valid() {
+        let env = TestEnv::new(&[("PWD", "/home/user")]);
+        let source = r#"
+(version 2)
+(default deny "main")
+(policy "main"
+  (when (agent "Explore") :ask))
+"#;
+        assert!(compile_to_tree(source, &env).is_ok());
+    }
+
+    #[test]
+    fn ask_under_command_is_invalid() {
+        let env = TestEnv::new(&[("PWD", "/home/user")]);
+        let source = r#"
+(version 2)
+(default deny "main")
+(policy "main"
+  (when (command "git" *) :ask))
+"#;
+        let err = compile_to_tree(source, &env).unwrap_err();
+        assert!(
+            err.to_string().contains(":ask may only appear inside"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn ask_with_no_invocation_guard_is_invalid() {
+        let env = TestEnv::new(&[("PWD", "/home/user")]);
+        let source = r#"
+(version 2)
+(default deny "main")
+(policy "main"
+  :ask)
+"#;
+        let err = compile_to_tree(source, &env).unwrap_err();
+        assert!(
+            err.to_string().contains(":ask may only appear inside"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn ask_nested_command_then_tool_is_valid() {
+        let env = TestEnv::new(&[("PWD", "/home/user")]);
+        let source = r#"
+(version 2)
+(default deny "main")
+(policy "main"
+  (when (tool "Skill")
+    (when (command "git" *) :ask)))
+"#;
+        // The outer (when (tool ...)) makes the inner :ask valid.
+        assert!(compile_to_tree(source, &env).is_ok());
+    }
+
+    #[test]
+    fn ask_in_match_arm_under_mcp_is_valid() {
+        let env = TestEnv::new(&[("PWD", "/home/user")]);
+        let source = r#"
+(version 2)
+(default deny "main")
+(policy "main"
+  (when (mcp "puppeteer")
+    (match ctx.mcp.tool
+      "navigate" :allow
+      * :ask)))
+"#;
+        assert!(compile_to_tree(source, &env).is_ok());
+    }
+
+    #[test]
+    fn ask_in_when_without_invocation_guard_is_invalid() {
+        let env = TestEnv::new(&[("PWD", "/home/user")]);
+        let source = r#"
+(version 2)
+(default deny "main")
+(policy "main"
+  (when (ctx.http.domain "github.com") :ask))
+"#;
+        let err = compile_to_tree(source, &env).unwrap_err();
+        assert!(
+            err.to_string().contains(":ask may only appear inside"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn allow_and_deny_under_command_are_valid() {
+        let env = TestEnv::new(&[("PWD", "/home/user")]);
+        let source = r#"
+(version 2)
+(default deny "main")
+(policy "main"
+  (when (command "git" *) :allow)
+  (when (command "rm" *) :deny))
+"#;
+        assert!(compile_to_tree(source, &env).is_ok());
     }
 }

--- a/clash/src/policy/eval.rs
+++ b/clash/src/policy/eval.rs
@@ -32,6 +32,10 @@ pub enum CapQuery {
     Agent {
         name: String,
     },
+    Mcp {
+        server: String,
+        tool: String,
+    },
 }
 
 /// Map a tool invocation to capability queries.
@@ -120,6 +124,16 @@ pub fn tool_to_queries(
             vec![CapQuery::Agent {
                 name: subagent_type.to_string(),
             }]
+        }
+        _ if tool_name.starts_with("mcp__") => {
+            // MCP tools follow the pattern: mcp__<server>__<tool>
+            let rest = &tool_name["mcp__".len()..];
+            let (server, tool) = match rest.find("__") {
+                Some(pos) => (rest[..pos].to_string(), rest[pos + 2..].to_string()),
+                None => (rest.to_string(), String::new()),
+            };
+            debug!(tool_name, server = %server, tool = %tool, "mcp — using mcp capability query");
+            vec![CapQuery::Mcp { server, tool }]
         }
         _ => {
             debug!(tool_name, "tool — using tool capability query");
@@ -362,6 +376,7 @@ impl DecisionTree {
                 CapQuery::Net { .. } => &self.net_rules,
                 CapQuery::Tool { .. } => &self.tool_rules,
                 CapQuery::Agent { .. } => &self.tool_rules,
+                CapQuery::Mcp { .. } => &self.tool_rules,
             };
 
             for (idx, rule) in rules.iter().enumerate() {

--- a/clash/src/policy/parse.rs
+++ b/clash/src/policy/parse.rs
@@ -708,6 +708,10 @@ fn parse_when_guard(expr: &SExpr, ctx: &ParseContext) -> Result<(Observable, Arm
             let m = parse_tool_matcher(&list[1..], ctx)?;
             Ok((Observable::Agent, ArmPattern::Single(m.name)))
         }
+        "mcp" => {
+            let m = parse_tool_matcher(&list[1..], ctx)?;
+            Ok((Observable::Mcp, ArmPattern::Single(m.name)))
+        }
 
         // ctx.http guards
         "ctx.http.domain" => {
@@ -759,7 +763,7 @@ fn parse_when_guard(expr: &SExpr, ctx: &ParseContext) -> Result<(Observable, Arm
         }
 
         other => bail!(
-            "unknown when guard: {other} (expected 'command', 'tool', 'agent', \
+            "unknown when guard: {other} (expected 'command', 'tool', 'agent', 'mcp', \
              'ctx.http.domain', 'ctx.http.method', 'ctx.fs.action', or 'ctx.fs.path')"
         ),
     }
@@ -842,6 +846,7 @@ fn parse_observable(expr: &SExpr) -> Result<Observable> {
             "command" => Ok(Observable::Command),
             "tool" => Ok(Observable::Tool),
             "agent" => Ok(Observable::Agent),
+            "mcp" => Ok(Observable::Mcp),
 
             // ctx.http namespace
             "ctx.http.domain" => Ok(Observable::HttpDomain),
@@ -864,6 +869,10 @@ fn parse_observable(expr: &SExpr) -> Result<Observable> {
 
             // ctx.agent namespace
             "ctx.agent.name" => Ok(Observable::AgentName),
+
+            // ctx.mcp namespace
+            "ctx.mcp.server" => Ok(Observable::McpServer),
+            "ctx.mcp.tool" => Ok(Observable::McpTool),
 
             // ctx.state
             "ctx.state" => Ok(Observable::State),

--- a/clash/src/policy/tree.rs
+++ b/clash/src/policy/tree.rs
@@ -105,8 +105,21 @@ pub enum Predicate {
     Tool(CompiledTool),
     /// Matches agent queries (subagent name).
     Agent(CompiledTool),
+    /// Matches MCP tool invocations (server name).
+    Mcp(CompiledTool),
     /// Always matches.
     True,
+}
+
+impl Predicate {
+    /// Whether this predicate represents an invocation type that allows `:ask`.
+    ///
+    /// Only `tool`, `mcp`, and `agent` invocation types permit `:ask` effects.
+    /// `command` does not — you cannot prompt a human about what a subprocess
+    /// is doing in real time.
+    pub fn allows_ask(&self) -> bool {
+        matches!(self, Predicate::Tool(_) | Predicate::Mcp(_) | Predicate::Agent(_))
+    }
 }
 
 /// An observable value for `Match` dispatch.
@@ -144,6 +157,10 @@ pub enum Observable {
     ToolArgs,
     /// `ctx.agent.name`
     AgentName,
+    /// `ctx.mcp.server`
+    McpServer,
+    /// `ctx.mcp.tool`
+    McpTool,
     /// `ctx.tool.args.<field>?` — nullable tool argument field.
     ToolArgField(String),
     /// `ctx.state`
@@ -221,6 +238,8 @@ pub struct QueryContext {
     pub net_domain: Option<String>,
     pub net_path: Option<String>,
     pub agent_name: Option<String>,
+    pub mcp_server: Option<String>,
+    pub mcp_tool: Option<String>,
     pub cwd: String,
     /// Raw tool input JSON — used for nullable `ctx.tool.args.<field>?` accessors.
     pub tool_input: serde_json::Value,
@@ -275,6 +294,7 @@ impl Predicate {
                     && ctx.agent_name.is_none()
             }
             Predicate::Agent(_) => ctx.agent_name.is_some(),
+            Predicate::Mcp(_) => ctx.mcp_server.is_some(),
             Predicate::True => true,
         }
     }
@@ -309,6 +329,10 @@ impl Predicate {
                 .agent_name
                 .as_ref()
                 .is_some_and(|name| agent.matches(name)),
+            Predicate::Mcp(mcp) => ctx
+                .mcp_server
+                .as_ref()
+                .is_some_and(|server| mcp.matches(server)),
             Predicate::True => true,
         }
     }
@@ -331,6 +355,8 @@ impl QueryContext {
             net_domain: None,
             net_path: None,
             agent_name: None,
+            mcp_server: None,
+            mcp_tool: None,
             cwd: cwd.to_string(),
             tool_input: tool_input.clone(),
         };
@@ -354,6 +380,10 @@ impl QueryContext {
                 }
                 CapQuery::Agent { name } => {
                     ctx.agent_name = Some(name.clone());
+                }
+                CapQuery::Mcp { server, tool } => {
+                    ctx.mcp_server = Some(server.clone());
+                    ctx.mcp_tool = Some(tool.clone());
                 }
             }
         }
@@ -893,6 +923,7 @@ fn observable_is_relevant(observable: &Observable, ctx: &QueryContext) -> bool {
                 && ctx.agent_name.is_none()
         }
         Observable::Agent | Observable::AgentName => ctx.agent_name.is_some(),
+        Observable::McpServer | Observable::McpTool => ctx.mcp_server.is_some(),
         Observable::HttpMethod | Observable::HttpPort => false, // deferred
         Observable::HttpDomain | Observable::HttpPath => ctx.net_domain.is_some(),
         Observable::FsAction | Observable::FsPath | Observable::FsExists => ctx.fs_op.is_some(),
@@ -978,6 +1009,8 @@ fn resolve_observable(observable: &Observable, ctx: &QueryContext) -> Option<Vec
         }
         Observable::ToolArgs => None, // deferred — requires tool argument access
         Observable::AgentName => ctx.agent_name.as_ref().map(|n| vec![n.clone()]),
+        Observable::McpServer => ctx.mcp_server.as_ref().map(|s| vec![s.clone()]),
+        Observable::McpTool => ctx.mcp_tool.as_ref().map(|t| vec![t.clone()]),
         Observable::ToolArgField(field) => {
             // Look up the field in tool_input. Absent or null → None (short-circuit).
             match ctx.tool_input.get(field.as_str()) {
@@ -1610,11 +1643,11 @@ mod tests {
   (when (tool "Skill")
     (match ctx.tool.args.name?
       * :allow))
-  :ask)
+  :deny)
 "#;
         let tree = compile_v2_tree(source);
-        // null value → treated as absent → short-circuit → default :ask
+        // null value → treated as absent → short-circuit → default :deny
         let decision = tree.evaluate("Skill", &json!({"name": null}), "/home/user/project");
-        assert_eq!(decision.effect, Effect::Ask);
+        assert_eq!(decision.effect, Effect::Deny);
     }
 }

--- a/docs/policy-grammar.md
+++ b/docs/policy-grammar.md
@@ -414,20 +414,24 @@ policy_item_v3  = include | when_block | match_block | effect_kw
 when_block      = "(" "when" when_guard when_body+ ")"
 when_guard      = "(" "command" pattern? args_spec ")"
                 | "(" "tool" pattern? ")"
+                | "(" "agent" pattern? ")"
+                | "(" "mcp" pattern? ")"
                 | "(" observable pattern ")"
                 | "(" observable path_filter ")"        ; for ctx.fs.path
 when_body       = effect_kw                             ; inline effect
                 | match_block                           ; nested match (constraint source)
                 | when_block                            ; nested when
 
-effect_kw       = ":allow" | ":deny" | ":ask"
+effect_kw       = ":allow" | ":deny" | ":ask"      ; :ask requires tool/mcp/agent guard
 
 match_block     = "(" "match" observable match_arm+ ")"
-observable      = "command" | "tool"
+observable      = "command" | "tool" | "agent" | "mcp"
                 | "ctx.http.domain" | "ctx.http.method" | "ctx.http.port" | "ctx.http.path"
                 | "ctx.fs.action" | "ctx.fs.path" | "ctx.fs.exists"
                 | "ctx.process.command" | "ctx.process.args"
                 | "ctx.tool.name" | "ctx.tool.args" | ctx_tool_arg_field
+                | "ctx.agent.name"
+                | "ctx.mcp.server" | "ctx.mcp.tool"
                 | "ctx.state"
                 | "[" observable observable+ "]"         ; tuple
 ctx_tool_arg_field = "ctx.tool.args." FIELD_NAME "?"  ; nullable dynamic field accessor
@@ -468,6 +472,12 @@ The body contains one or more items: an effect keyword (`:allow`, `:deny`, `:ask
 ; Allow multiple tools
 (when (tool (or "Read" "Glob" "Grep")) :allow)
 
+; Allow a specific subagent
+(when (agent "Explore") :allow)
+
+; Allow an MCP server
+(when (mcp "puppeteer") :ask)
+
 ; Guard on HTTP domain
 (when (ctx.http.domain "github.com") :allow)
 
@@ -487,6 +497,8 @@ The body contains one or more items: an effect keyword (`:allow`, `:deny`, `:ask
 ```
 
 When the body is a single effect keyword, it renders on one line: `(when (command "git" *) :allow)`. Multi-item bodies are indented.
+
+> **`:ask` restriction:** The `:ask` effect may only appear inside a `(when (tool ...) ...)`, `(when (mcp ...) ...)`, or `(when (agent ...) ...)` guard. It is not valid under `(when (command ...) ...)` or with no invocation guard, because you cannot prompt a human about what a subprocess is doing in real time. This is enforced at compile time (validation rule 6).
 
 ### Constraint Derivation
 
@@ -519,6 +531,8 @@ At **policy level**, match arms may use `:allow`, `:deny`, or `:ask` effects. In
 |-----------|------|-------------|
 | `command` | exec | Command execution (binary + args) |
 | `tool` | string | Agent tool name |
+| `agent` | string | Subagent name |
+| `mcp` | string | MCP server name |
 | `ctx.http.domain` | string | Domain of an HTTP request |
 | `ctx.http.method` | string | HTTP method (GET, POST, etc.) |
 | `ctx.http.port` | int | Destination port |
@@ -531,6 +545,9 @@ At **policy level**, match arms may use `:allow`, `:deny`, or `:ask` effects. In
 | `ctx.tool.name` | string | Tool name |
 | `ctx.tool.args` | {string?} | Tool arguments (dynamic, nullable) |
 | `ctx.tool.args.<field>?` | string? | Nullable accessor for a specific tool argument field; absent field short-circuits the enclosing `match` |
+| `ctx.agent.name` | string | Subagent name |
+| `ctx.mcp.server` | string | MCP server name |
+| `ctx.mcp.tool` | string | MCP tool name |
 | `ctx.state` | string | Agent state |
 
 #### Scalar match


### PR DESCRIPTION
## Summary

- Add `(mcp ...)` as an invocation type predicate and `ctx.mcp.server` / `ctx.mcp.tool` as observable fields (closes #217)
- Enforce validation rule 6: `:ask` may only appear inside a `(when (tool ...) ...)`, `(when (mcp ...) ...)`, or `(when (agent ...) ...)` guard — not under `(when (command ...) ...)` or with no invocation guard (closes #224)
- MCP tool invocations (`mcp__<server>__<tool>`) are automatically detected and mapped to `CapQuery::Mcp`
- Internal policies (`__internal_*`) are exempt from the `:ask` restriction

## Changes

**New invocation type: `mcp`**
- `ast.rs`: `Observable::Mcp`, `Observable::McpServer`, `Observable::McpTool` + Display impls
- `parse.rs`: `"mcp"` when guard, `"ctx.mcp.server"` / `"ctx.mcp.tool"` observables
- `tree.rs`: `Predicate::Mcp(CompiledTool)`, `Observable::McpServer/McpTool`, `mcp_server`/`mcp_tool` in `QueryContext`
- `eval.rs`: `CapQuery::Mcp { server, tool }`, detection of `mcp__` prefix in `tool_to_queries`
- `compile.rs`: Mcp compilation in `compile_when_guard`, `compile_observable_to_ir`, `compile_match_to_sandbox`
- `audit.rs`, `replay.rs`: exhaustive match updates for `CapQuery::Mcp`

**`:ask` context validation**
- `compile.rs`: `validate_ask_contexts()` — post-compilation tree walk that verifies every `:ask` leaf is reachable from a `tool`/`mcp`/`agent` guard
- `tree.rs`: `Predicate::allows_ask()` method
- 9 dedicated tests covering valid/invalid scenarios

**Docs**
- `docs/policy-grammar.md`: updated `when_guard` and `observable` grammar, added `:ask` restriction note and mcp/agent examples

## Test plan

- [x] All 942 existing tests pass
- [x] 9 new tests for :ask validation (tool/mcp/agent valid, command/bare invalid, nested valid, match arm scenarios)
- [x] Pre-existing test fixed: `nullable_accessor_null_field_treated_as_absent` updated to use `:deny` instead of bare `:ask`