### PR TITLE
feat(policy): add mcp invocation type and ctx.mcp.* observables

### DIFF
--- a/clash/src/audit.rs
+++ b/clash/src/audit.rs
@@ -439,14 +439,17 @@ fn deny_hint(tool_name: &str, tool_input: &serde_json::Value, cwd: &str) -> Resu
             Some(p) => format!("(net \"{}\" (subpath \"{}\"))", domain, p),
             None => format!("(net \"{}\")", domain),
         },
+        CapQuery::Mcp { server, tool } => {
+            format!(
+                "(mcp \"{}\" \"{}\") ; server={}, tool={}",
+                server, tool, server, tool
+            )
+        }
         CapQuery::Tool { name } => {
             format!("(tool \"{}\")", name)
         }
         CapQuery::Agent { name } => {
             format!("(agent \"{}\")", name)
-        }
-        CapQuery::Mcp { server, .. } => {
-            format!("(mcp \"{}\")", server)
         }
     };
 
@@ -471,15 +474,9 @@ fn tool_input_summary(tool_name: &str, input: &serde_json::Value, cwd: &str) -> 
             Some(p) => format!("{domain}{p}"),
             None => domain.clone(),
         },
+        Some(CapQuery::Mcp { server, tool }) => format!("{server}/{tool}"),
         Some(CapQuery::Tool { name }) => name.clone(),
         Some(CapQuery::Agent { name }) => format!("agent:{name}"),
-        Some(CapQuery::Mcp { server, tool }) => {
-            if tool.is_empty() {
-                format!("mcp:{server}")
-            } else {
-                format!("mcp:{server}/{tool}")
-            }
-        }
         None => String::new(),
     };
 

--- a/clash/src/debug/replay.rs
+++ b/clash/src/debug/replay.rs
@@ -183,9 +183,9 @@ impl ReplayResult {
                 Some(p) => format!("(net \"{}\" (subpath \"{}\"))", domain, p),
                 None => format!("(net \"{}\")", domain),
             },
+            Some(CapQuery::Mcp { server, .. }) => format!("(mcp \"{}\")", server),
             Some(CapQuery::Tool { name }) => format!("(tool \"{}\")", name),
             Some(CapQuery::Agent { name }) => format!("(agent \"{}\")", name),
-            Some(CapQuery::Mcp { server, .. }) => format!("(mcp \"{}\")", server),
             None => return format!("clash allow '{}'", self.tool_name.to_lowercase()),
         };
 

--- a/clash/src/policy/compile.rs
+++ b/clash/src/policy/compile.rs
@@ -988,6 +988,15 @@ fn compile_when_guard(
                 name: pat.clone(),
             })?))
         }
+        Observable::Mcp => {
+            let pat = match pattern {
+                ArmPattern::Single(p) => p,
+                _ => bail!("mcp observable requires a single pattern"),
+            };
+            Ok(Predicate::Mcp(compile_tool_to_compiled(&ToolMatcher {
+                name: pat.clone(),
+            })?))
+        }
         Observable::HttpDomain => {
             let pat = match pattern {
                 ArmPattern::Single(p) => p,
@@ -1073,15 +1082,6 @@ fn compile_when_guard(
                 _ => bail!("ctx.agent.name observable requires a single pattern"),
             };
             Ok(Predicate::Agent(compile_tool_to_compiled(&ToolMatcher {
-                name: pat.clone(),
-            })?))
-        }
-        Observable::Mcp => {
-            let pat = match pattern {
-                ArmPattern::Single(p) => p,
-                _ => bail!("mcp observable requires a single pattern"),
-            };
-            Ok(Predicate::Mcp(compile_tool_to_compiled(&ToolMatcher {
                 name: pat.clone(),
             })?))
         }
@@ -1230,6 +1230,7 @@ fn compile_observable_to_ir(obs: &Observable) -> Result<crate::policy::tree::Obs
     match obs {
         Observable::Command => Ok(ir::Observable::Command),
         Observable::Tool => Ok(ir::Observable::Tool),
+        Observable::Mcp => Ok(ir::Observable::Mcp),
         Observable::HttpDomain => Ok(ir::Observable::HttpDomain),
         Observable::HttpMethod => Ok(ir::Observable::HttpMethod),
         Observable::HttpPort => Ok(ir::Observable::HttpPort),

--- a/clash/src/policy/eval.rs
+++ b/clash/src/policy/eval.rs
@@ -26,15 +26,15 @@ pub enum CapQuery {
         domain: String,
         path: Option<String>,
     },
+    Mcp {
+        server: String,
+        tool: String,
+    },
     Tool {
         name: String,
     },
     Agent {
         name: String,
-    },
-    Mcp {
-        server: String,
-        tool: String,
     },
 }
 
@@ -136,10 +136,19 @@ pub fn tool_to_queries(
             vec![CapQuery::Mcp { server, tool }]
         }
         _ => {
-            debug!(tool_name, "tool — using tool capability query");
-            vec![CapQuery::Tool {
-                name: tool_name.to_string(),
-            }]
+            // MCP tools use the naming convention mcp__<server>__<tool>.
+            if let Some(mcp) = parse_mcp_tool_name(tool_name) {
+                debug!(tool_name, server = %mcp.0, mcp_tool = %mcp.1, "MCP tool invocation");
+                vec![CapQuery::Mcp {
+                    server: mcp.0,
+                    tool: mcp.1,
+                }]
+            } else {
+                debug!(tool_name, "tool — using tool capability query");
+                vec![CapQuery::Tool {
+                    name: tool_name.to_string(),
+                }]
+            }
         }
     }
 }
@@ -192,6 +201,19 @@ pub(crate) fn extract_domain_and_path(url: &str) -> (String, Option<String>) {
             .to_string()
     });
     (domain, clean_path)
+}
+
+/// Parse an MCP tool name in the `mcp__<server>__<tool>` format.
+///
+/// Returns `Some((server, tool))` if the name matches the MCP convention,
+/// `None` otherwise.
+fn parse_mcp_tool_name(tool_name: &str) -> Option<(String, String)> {
+    let rest = tool_name.strip_prefix("mcp__")?;
+    let (server, tool) = rest.split_once("__")?;
+    if server.is_empty() || tool.is_empty() {
+        return None;
+    }
+    Some((server.to_string(), tool.to_string()))
 }
 
 /// Check whether a token looks like a shell environment variable assignment (`KEY=value`).
@@ -374,9 +396,9 @@ impl DecisionTree {
                 CapQuery::Exec { .. } => &self.exec_rules,
                 CapQuery::Fs { .. } => &self.fs_rules,
                 CapQuery::Net { .. } => &self.net_rules,
+                CapQuery::Mcp { .. } => &self.tool_rules,
                 CapQuery::Tool { .. } => &self.tool_rules,
                 CapQuery::Agent { .. } => &self.tool_rules,
-                CapQuery::Mcp { .. } => &self.tool_rules,
             };
 
             for (idx, rule) in rules.iter().enumerate() {
@@ -505,6 +527,8 @@ mod tests {
     use crate::policy::compile::{EnvResolver, compile_policy_with_env};
     use crate::policy::sandbox_types::NetworkPolicy;
 
+    use super::{CapQuery, tool_to_queries};
+
     /// Test env resolver with fixed values.
     struct TestEnv(HashMap<String, String>);
 
@@ -531,6 +555,11 @@ mod tests {
     fn compile(source: &str) -> crate::policy::decision_tree::DecisionTree {
         let env = TestEnv::new(&[("PWD", "/home/user/project")]);
         compile_policy_with_env(source, &env).unwrap()
+    }
+
+    fn compile_v2(source: &str) -> crate::policy::tree::PolicyTree {
+        let env = TestEnv::new(&[("PWD", "/home/user/project")]);
+        crate::policy::compile::compile_to_tree(source, &env).unwrap()
     }
 
     #[test]
@@ -1797,5 +1826,179 @@ mod tests {
             super::CapQuery::Agent { name } => assert_eq!(name, "Explore"),
             other => panic!("expected Agent query, got {other:?}"),
         }
+    }
+
+    // -----------------------------------------------------------------------
+    // MCP tool name parsing
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn parse_mcp_tool_name_valid() {
+        let result = super::parse_mcp_tool_name("mcp__puppeteer__navigate");
+        assert_eq!(
+            result,
+            Some(("puppeteer".to_string(), "navigate".to_string()))
+        );
+    }
+
+    #[test]
+    fn parse_mcp_tool_name_with_underscores() {
+        let result = super::parse_mcp_tool_name("mcp__my_server__my_tool");
+        assert_eq!(
+            result,
+            Some(("my_server".to_string(), "my_tool".to_string()))
+        );
+    }
+
+    #[test]
+    fn parse_mcp_tool_name_not_mcp() {
+        assert_eq!(super::parse_mcp_tool_name("Read"), None);
+        assert_eq!(super::parse_mcp_tool_name("Bash"), None);
+        assert_eq!(super::parse_mcp_tool_name("WebFetch"), None);
+    }
+
+    #[test]
+    fn parse_mcp_tool_name_malformed() {
+        // Missing tool part
+        assert_eq!(super::parse_mcp_tool_name("mcp__puppeteer"), None);
+        // Empty server
+        assert_eq!(super::parse_mcp_tool_name("mcp____tool"), None);
+        // Empty tool
+        assert_eq!(super::parse_mcp_tool_name("mcp__server__"), None);
+    }
+
+    #[test]
+    fn mcp_tool_to_queries() {
+        let queries = tool_to_queries("mcp__puppeteer__navigate", &json!({}), "/tmp");
+        assert_eq!(queries.len(), 1);
+        match &queries[0] {
+            CapQuery::Mcp { server, tool } => {
+                assert_eq!(server, "puppeteer");
+                assert_eq!(tool, "navigate");
+            }
+            other => panic!("expected Mcp query, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn non_mcp_tool_to_queries() {
+        let queries = tool_to_queries("Skill", &json!({}), "/tmp");
+        assert_eq!(queries.len(), 1);
+        assert!(matches!(&queries[0], CapQuery::Tool { name } if name == "Skill"));
+    }
+
+    // -----------------------------------------------------------------------
+    // MCP tree evaluation
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn mcp_when_guard_matches_server() {
+        let tree = compile_v2(
+            r#"
+(version 2)
+(use "main")
+(policy "main"
+  (when (mcp "puppeteer") :allow)
+  :deny)
+"#,
+        );
+
+        let decision = tree.evaluate("mcp__puppeteer__navigate", &json!({}), "/tmp");
+        assert_eq!(decision.effect, Effect::Allow);
+
+        let decision = tree.evaluate("mcp__other_server__tool", &json!({}), "/tmp");
+        assert_eq!(decision.effect, Effect::Deny);
+    }
+
+    #[test]
+    fn mcp_match_ctx_mcp_tool() {
+        let tree = compile_v2(
+            r#"
+(version 2)
+(use "main")
+(policy "main"
+  (when (mcp "puppeteer")
+    (match ctx.mcp.tool
+      "puppeteer_navigate"   :ask
+      "puppeteer_screenshot" :allow))
+  :deny)
+"#,
+        );
+
+        let decision = tree.evaluate("mcp__puppeteer__puppeteer_navigate", &json!({}), "/tmp");
+        assert_eq!(decision.effect, Effect::Ask);
+
+        let decision = tree.evaluate("mcp__puppeteer__puppeteer_screenshot", &json!({}), "/tmp");
+        assert_eq!(decision.effect, Effect::Allow);
+
+        // Unmatched MCP tool falls through
+        let decision = tree.evaluate("mcp__puppeteer__puppeteer_click", &json!({}), "/tmp");
+        assert_eq!(decision.effect, Effect::Deny);
+    }
+
+    #[test]
+    fn mcp_regex_pattern() {
+        let tree = compile_v2(
+            r#"
+(version 2)
+(use "main")
+(policy "main"
+  (when (mcp /puppet.*/) :allow)
+  :deny)
+"#,
+        );
+
+        let decision = tree.evaluate("mcp__puppeteer__navigate", &json!({}), "/tmp");
+        assert_eq!(decision.effect, Effect::Allow);
+
+        let decision = tree.evaluate("mcp__github__issues", &json!({}), "/tmp");
+        assert_eq!(decision.effect, Effect::Deny);
+    }
+
+    #[test]
+    fn mcp_does_not_match_regular_tools() {
+        let tree = compile_v2(
+            r#"
+(version 2)
+(use "main")
+(policy "main"
+  (when (mcp "puppeteer") :allow)
+  (when (tool "Skill") :allow)
+  :deny)
+"#,
+        );
+
+        // MCP tool matches mcp guard, not tool guard
+        let decision = tree.evaluate("mcp__puppeteer__navigate", &json!({}), "/tmp");
+        assert_eq!(decision.effect, Effect::Allow);
+
+        // Regular tool matches tool guard, not mcp guard
+        let decision = tree.evaluate("Skill", &json!({}), "/tmp");
+        assert_eq!(decision.effect, Effect::Allow);
+
+        // Regular tool without matching guard denied
+        let decision = tree.evaluate("Agent", &json!({}), "/tmp");
+        assert_eq!(decision.effect, Effect::Deny);
+    }
+
+    #[test]
+    fn mcp_match_on_server_observable() {
+        let tree = compile_v2(
+            r#"
+(version 2)
+(use "main")
+(policy "main"
+  (match ctx.mcp.server
+    "puppeteer" :allow
+    * :deny)
+  :deny)
+"#,
+        );
+
+        let decision = tree.evaluate("mcp__puppeteer__navigate", &json!({}), "/tmp");
+        assert_eq!(decision.effect, Effect::Allow);
+
+        let decision = tree.evaluate("mcp__github__issues", &json!({}), "/tmp");
+        assert_eq!(decision.effect, Effect::Deny);
     }
 }

--- a/clash/src/policy/parse.rs
+++ b/clash/src/policy/parse.rs
@@ -2990,4 +2990,118 @@ mod tests {
         let obs = Observable::ToolArgField("file_path".into());
         assert_eq!(obs.to_string(), "ctx.tool.args.file_path?");
     }
+
+    // -----------------------------------------------------------------------
+    // MCP guard and observable tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn parse_v2_when_mcp_guard() {
+        let source = r#"
+            (version 2)
+            (use "main")
+            (policy "main"
+              (when (mcp "puppeteer") :allow))
+        "#;
+        let ast = parse(source).unwrap();
+        let policy = ast.iter().find_map(|tl| match tl {
+            TopLevel::Policy { body, .. } => Some(body),
+            _ => None,
+        });
+        let body = policy.unwrap();
+        assert_eq!(body.len(), 1);
+        match &body[0] {
+            PolicyItem::When {
+                observable,
+                pattern,
+                ..
+            } => {
+                assert_eq!(*observable, Observable::Mcp);
+                assert!(
+                    matches!(pattern, ArmPattern::Single(Pattern::Literal(s)) if s == "puppeteer")
+                );
+            }
+            other => panic!("expected When, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_v2_match_ctx_mcp_tool() {
+        let source = r#"
+            (version 2)
+            (use "main")
+            (policy "main"
+              (match ctx.mcp.tool
+                "puppeteer_navigate" :allow
+                "puppeteer_screenshot" :ask))
+        "#;
+        let ast = parse(source).unwrap();
+        let policy = ast.iter().find_map(|tl| match tl {
+            TopLevel::Policy { body, .. } => Some(body),
+            _ => None,
+        });
+        let body = policy.unwrap();
+        assert_eq!(body.len(), 1);
+        match &body[0] {
+            PolicyItem::Match(block) => {
+                assert_eq!(block.observable, Observable::McpTool);
+                assert_eq!(block.arms.len(), 2);
+            }
+            other => panic!("expected Match, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_v2_match_ctx_mcp_server() {
+        let source = r#"
+            (version 2)
+            (use "main")
+            (policy "main"
+              (match ctx.mcp.server
+                "puppeteer" :allow
+                * :deny))
+        "#;
+        let ast = parse(source).unwrap();
+        let policy = ast.iter().find_map(|tl| match tl {
+            TopLevel::Policy { body, .. } => Some(body),
+            _ => None,
+        });
+        let body = policy.unwrap();
+        match &body[0] {
+            PolicyItem::Match(block) => {
+                assert_eq!(block.observable, Observable::McpServer);
+                assert_eq!(block.arms.len(), 2);
+            }
+            other => panic!("expected Match, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_v2_mcp_regex_pattern() {
+        let source = r#"
+            (version 2)
+            (use "main")
+            (policy "main"
+              (when (mcp /puppeteer.*/) :allow))
+        "#;
+        let ast = parse(source).unwrap();
+        let policy = ast.iter().find_map(|tl| match tl {
+            TopLevel::Policy { body, .. } => Some(body),
+            _ => None,
+        });
+        let body = policy.unwrap();
+        match &body[0] {
+            PolicyItem::When {
+                observable,
+                pattern,
+                ..
+            } => {
+                assert_eq!(*observable, Observable::Mcp);
+                assert!(
+                    matches!(pattern, ArmPattern::Single(Pattern::Regex(r)) if r == "puppeteer.*")
+                );
+            }
+            other => panic!("expected When, got {other:?}"),
+        }
+    }
 }

--- a/clash/src/policy/tree.rs
+++ b/clash/src/policy/tree.rs
@@ -166,6 +166,8 @@ pub enum Observable {
     McpTool,
     /// `ctx.tool.args.<field>?` — nullable tool argument field.
     ToolArgField(String),
+    /// `mcp` — invocation-type predicate matching MCP tools by server name.
+    Mcp,
     /// `ctx.state`
     State,
     Tuple(Vec<Observable>),
@@ -288,6 +290,7 @@ impl Predicate {
             Predicate::Command(_) => ctx.bin.is_some(),
             Predicate::Fs(_) => ctx.fs_op.is_some(),
             Predicate::Net(_) => ctx.net_domain.is_some(),
+            Predicate::Mcp(_) => ctx.mcp_server.is_some(),
             // Tool predicates are relevant only when no other domain matched,
             // matching the old `_ =>` fallthrough in tool_to_queries.
             Predicate::Tool(_) => {
@@ -295,9 +298,9 @@ impl Predicate {
                     && ctx.fs_op.is_none()
                     && ctx.net_domain.is_none()
                     && ctx.agent_name.is_none()
+                    && ctx.mcp_server.is_none()
             }
             Predicate::Agent(_) => ctx.agent_name.is_some(),
-            Predicate::Mcp(_) => ctx.mcp_server.is_some(),
             Predicate::True => true,
         }
     }
@@ -378,15 +381,15 @@ impl QueryContext {
                     ctx.net_domain = Some(domain.clone());
                     ctx.net_path = path.clone();
                 }
+                CapQuery::Mcp { server, tool } => {
+                    ctx.mcp_server = Some(server.clone());
+                    ctx.mcp_tool = Some(tool.clone());
+                }
                 CapQuery::Tool { .. } => {
                     // tool_name is already set from the parameter
                 }
                 CapQuery::Agent { name } => {
                     ctx.agent_name = Some(name.clone());
-                }
-                CapQuery::Mcp { server, tool } => {
-                    ctx.mcp_server = Some(server.clone());
-                    ctx.mcp_tool = Some(tool.clone());
                 }
             }
         }
@@ -869,10 +872,26 @@ impl PolicyTree {
             } => {
                 if observable_is_relevant(observable, ctx) {
                     // Observable is in query context → normal first-match evaluation.
+                    let meta = &self.node_meta[*id as usize];
                     for arm in arms {
                         if match_arm_against_ctx(observable, &arm.pattern, ctx) {
                             trace!(node_id = id, "match arm matched");
-                            return self.eval_node(&arm.body, ctx, matched, skipped, sandbox_out);
+                            let pre_len = matched.len();
+                            let result =
+                                self.eval_node(&arm.body, ctx, matched, skipped, sandbox_out);
+                            // Record a match if the body didn't already.
+                            if let Some(effect) = result {
+                                if matched.len() == pre_len {
+                                    matched.push(RuleMatch {
+                                        rule_index: 0,
+                                        description: meta.description.clone(),
+                                        effect,
+                                        has_active_constraints: sandbox_out.is_some(),
+                                        node_id: Some(*id),
+                                    });
+                                }
+                            }
+                            return result;
                         }
                     }
                     None
@@ -924,9 +943,10 @@ fn observable_is_relevant(observable: &Observable, ctx: &QueryContext) -> bool {
                 && ctx.fs_op.is_none()
                 && ctx.net_domain.is_none()
                 && ctx.agent_name.is_none()
+                && ctx.mcp_server.is_none()
         }
         Observable::Agent | Observable::AgentName => ctx.agent_name.is_some(),
-        Observable::McpServer | Observable::McpTool => ctx.mcp_server.is_some(),
+        Observable::Mcp | Observable::McpServer | Observable::McpTool => ctx.mcp_server.is_some(),
         Observable::HttpMethod | Observable::HttpPort => false, // deferred
         Observable::HttpDomain | Observable::HttpPath => ctx.net_domain.is_some(),
         Observable::FsAction | Observable::FsPath | Observable::FsExists => ctx.fs_op.is_some(),
@@ -965,6 +985,13 @@ fn match_arm_against_ctx(
             }
             _ => false,
         },
+        Observable::Mcp => match pattern {
+            MatchPattern::Single(cp) => ctx
+                .mcp_server
+                .as_ref()
+                .is_some_and(|server| cp.matches(server)),
+            _ => false,
+        },
         // For sandbox-style observables, use the string-resolve path.
         _ => {
             let values = resolve_observable(observable, ctx);
@@ -981,8 +1008,8 @@ fn match_arm_against_ctx(
 /// Returns `None` if the observable cannot be resolved (e.g. `HttpMethod` is deferred).
 fn resolve_observable(observable: &Observable, ctx: &QueryContext) -> Option<Vec<String>> {
     match observable {
-        Observable::Command | Observable::Tool | Observable::Agent => None, // handled by match_arm_against_ctx
-        Observable::HttpMethod | Observable::HttpPort => None,              // deferred
+        Observable::Command | Observable::Tool | Observable::Agent | Observable::Mcp => None, // handled by match_arm_against_ctx
+        Observable::HttpMethod | Observable::HttpPort => None, // deferred
         Observable::HttpDomain => ctx.net_domain.as_ref().map(|d| vec![d.clone()]),
         Observable::HttpPath => ctx.net_path.as_ref().map(|p| vec![p.clone()]),
         Observable::FsAction => ctx.fs_op.map(|op| {
@@ -1004,7 +1031,11 @@ fn resolve_observable(observable: &Observable, ctx: &QueryContext) -> Option<Vec
             }
         }
         Observable::ToolName => {
-            if ctx.bin.is_none() && ctx.fs_op.is_none() && ctx.net_domain.is_none() {
+            if ctx.bin.is_none()
+                && ctx.fs_op.is_none()
+                && ctx.net_domain.is_none()
+                && ctx.mcp_server.is_none()
+            {
                 Some(vec![ctx.tool_name.clone()])
             } else {
                 None

--- a/clash/src/shell_complete.rs
+++ b/clash/src/shell_complete.rs
@@ -51,7 +51,7 @@ const DOMAINS: &[(&str, &str)] = &[
     ("exec", "Command execution"),
     ("fs", "Filesystem access"),
     ("net", "Network access"),
-    ("tool", "MCP tool use"),
+    ("tool", "Agent tool use"),
 ];
 
 const FS_OPS: &[(&str, &str)] = &[

--- a/clester/tests/scripts/v2_mcp.yaml
+++ b/clester/tests/scripts/v2_mcp.yaml
@@ -1,0 +1,90 @@
+meta:
+  name: v2 policy — MCP invocation type and ctx.mcp.* observables
+  description: >
+    Test the mcp invocation type predicate and ctx.mcp.server / ctx.mcp.tool
+    observables for matching MCP tool invocations.
+
+clash:
+  policy_sexpr: |
+    (version 2)
+    (use "main")
+
+    (policy "puppeteer"
+      (when (mcp "puppeteer")
+        (match ctx.mcp.tool
+          "puppeteer_navigate"    :ask
+          "puppeteer_screenshot"  :allow)))
+
+    (policy "github-mcp"
+      (when (mcp "github")
+        :allow))
+
+    (policy "main"
+      (include "puppeteer")
+      (include "github-mcp")
+      :deny)
+
+steps:
+  # MCP puppeteer: navigate → ask
+  - name: puppeteer navigate is ask
+    hook: pre-tool-use
+    tool_name: mcp__puppeteer__puppeteer_navigate
+    tool_input: {}
+    expect:
+      decision: ask
+
+  # MCP puppeteer: screenshot → allow
+  - name: puppeteer screenshot is allow
+    hook: pre-tool-use
+    tool_name: mcp__puppeteer__puppeteer_screenshot
+    tool_input: {}
+    expect:
+      decision: allow
+
+  # MCP puppeteer: unmatched tool → deny (falls through match, then default)
+  - name: puppeteer click is denied (unmatched tool)
+    hook: pre-tool-use
+    tool_name: mcp__puppeteer__puppeteer_click
+    tool_input: {}
+    expect:
+      decision: deny
+
+  # MCP github: all tools → allow
+  - name: github create_issue is allowed
+    hook: pre-tool-use
+    tool_name: mcp__github__create_issue
+    tool_input: {}
+    expect:
+      decision: allow
+
+  - name: github list_prs is allowed
+    hook: pre-tool-use
+    tool_name: mcp__github__list_prs
+    tool_input: {}
+    expect:
+      decision: allow
+
+  # Unknown MCP server → deny
+  - name: unknown MCP server is denied
+    hook: pre-tool-use
+    tool_name: mcp__unknown_server__some_tool
+    tool_input: {}
+    expect:
+      decision: deny
+
+  # Non-MCP tools unaffected — Skill is allowed by internal (allow (tool)) catch-all;
+  # this confirms MCP guards don't interfere with non-MCP tool evaluation.
+  - name: regular tool is still allowed (internal policy)
+    hook: pre-tool-use
+    tool_name: Skill
+    tool_input: {}
+    expect:
+      decision: allow
+
+  - name: bash is denied by default
+    hook: pre-tool-use
+    tool_name: Bash
+    tool_input:
+      command: echo hello
+    expect:
+      decision: deny

--- a/docs/policy-grammar.md
+++ b/docs/policy-grammar.md
@@ -601,6 +601,25 @@ Match agent tools by name:
   *                          :deny)
 ```
 
+#### MCP match
+
+Match MCP tool invocations by server or tool name:
+
+```
+; Guard on MCP server, dispatch on tool
+(when (mcp "puppeteer")
+  (match ctx.mcp.tool
+    "puppeteer_navigate"    :ask
+    "puppeteer_screenshot"  :allow))
+
+; Match on MCP server name
+(match mcp
+  "puppeteer" :ask
+  *           :deny)
+```
+
+MCP tool names follow the `mcp__<server>__<tool>` naming convention from Claude Code. The `mcp` invocation-type predicate matches on the server name; `ctx.mcp.server` and `ctx.mcp.tool` provide fine-grained dispatch.
+
 #### Tuple match
 
 Match multiple observables simultaneously using bracket syntax:


### PR DESCRIPTION
## Summary

- Add `(mcp ...)` as an invocation-type predicate for matching MCP tool invocations by server name, with support for literal strings, globs, and regex patterns
- Add `ctx.mcp.server` and `ctx.mcp.tool` as observable fields for use in `(match ...)` dispatch
- MCP tools (named `mcp__<server>__<tool>`) are automatically parsed and routed to the new MCP capability domain, keeping them separate from regular `tool` domain evaluation
- Fix a bug where top-level `Match` nodes (not wrapped in `When`) failed to record matched rules in the evaluation trace

## Changes

- **ast.rs**: Add `Mcp`, `McpServer`, `McpTool` variants to `Observable` enum with Display
- **parse.rs**: Add `mcp` to `parse_when_guard` and `parse_observable`; add `ctx.mcp.server`/`ctx.mcp.tool` observable parsing
- **compile.rs**: Compile `mcp`/`ctx.mcp.*` observables to `Predicate::Mcp` and IR `Observable` variants
- **tree.rs**: Add MCP predicate matching, observable relevance, resolution, and match-arm dispatch; fix `Match` node rule recording
- **eval.rs**: Add `CapQuery::Mcp` variant; parse `mcp__<server>__<tool>` naming convention in `tool_to_queries`
- **audit.rs / replay.rs**: Handle `CapQuery::Mcp` in deny-hint and rule-suggestion formatting
- **docs/policy-grammar.md**: Document `mcp` guard, `ctx.mcp.*` observables, and MCP match examples

## Test plan

- [x] 4 new parser unit tests (when guard, match observables, regex pattern)
- [x] 3 new `parse_mcp_tool_name` unit tests (valid, edge cases, non-MCP)
- [x] 5 new evaluation unit tests (basic guard, ctx.mcp.tool match, regex, tool isolation, ctx.mcp.server match)
- [x] New clester e2e test (`v2_mcp.yaml`) — 9 steps covering server gating, tool dispatch, fallthrough, unknown servers, and non-MCP tool isolation
- [x] All 807 unit tests pass (`just check`)
- [x] All 172 clester e2e steps pass (`just clester`)

Closes #217