### PR TITLE
feat(policy)!: derive sandbox constraints from decision tree

### DIFF
--- a/clash/src/policy/ast.rs
+++ b/clash/src/policy/ast.rs
@@ -263,6 +263,8 @@ pub enum SandboxItem {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MatchBlock {
     pub observable: Observable,
+    /// Optional default effect for unmatched arms: `(default :deny)`.
+    pub default: Option<Effect>,
     pub arms: Vec<MatchArmAst>,
 }
 
@@ -463,6 +465,9 @@ impl fmt::Display for SandboxItem {
 impl fmt::Display for MatchBlock {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "(match {}", self.observable)?;
+        if let Some(effect) = &self.default {
+            write!(f, "\n        (default :{effect})")?;
+        }
         for arm in &self.arms {
             write!(f, "\n        {} {}", arm.pattern, arm.effect_keyword())?;
         }

--- a/clash/src/policy/compile.rs
+++ b/clash/src/policy/compile.rs
@@ -326,13 +326,13 @@ fn compile_policy_item_to_node(
             let body_node = if child_nodes.len() == 1 {
                 child_nodes.pop().unwrap()
             } else {
-                let seq_id = ids.alloc(NodeMeta {
+                let body_id = ids.alloc(NodeMeta {
                     description: format!("when body ({} items)", child_nodes.len()),
                     origin_policy: Some(origin.to_string()),
                     ..Default::default()
                 });
-                Node::Sequence {
-                    id: seq_id,
+                Node::DenyOverrides {
+                    id: body_id,
                     children: child_nodes,
                 }
             };
@@ -353,7 +353,9 @@ fn compile_policy_item_to_node(
             compile_policy_match_to_node(block, origin, env, ids)
         }
         PolicyItem::Sandbox { body } => {
-            // Compile sandbox items into a SandboxPolicy.
+            // Compile sandbox items into a SandboxPolicy, then wrap it as
+            // a synthetic Node::Match with constraint_policy so the eval
+            // path can collect it via the standard constraint derivation.
             let policy = compile_sandbox_items(body, env)?;
 
             let sandbox_id = ids.alloc(NodeMeta {
@@ -361,9 +363,14 @@ fn compile_policy_item_to_node(
                 origin_policy: Some(origin.to_string()),
                 ..Default::default()
             });
-            Ok(Some(Node::Sandbox {
+            // Use a synthetic Match on HttpDomain with no arms and the
+            // full sandbox policy as constraint_policy.  At eval time the
+            // observable is irrelevant → constraint derivation fires.
+            Ok(Some(Node::Match {
                 id: sandbox_id,
-                policy,
+                observable: crate::policy::tree::Observable::HttpDomain,
+                arms: vec![],
+                constraint_policy: Some(policy),
             }))
         }
         PolicyItem::Effect(effect) => {
@@ -1051,6 +1058,10 @@ fn pattern_to_op_pattern(pat: &Pattern) -> Result<OpPattern> {
 }
 
 /// Compile a policy-level match block into a Node::Match.
+///
+/// When the observable is a constraint-derivable dimension (ctx.http.*,
+/// ctx.fs.*), also pre-compiles a `SandboxPolicy` from the arms so that
+/// the eval path can derive sandbox constraints from surviving match blocks.
 fn compile_policy_match_to_node(
     block: &MatchBlock,
     origin: &str,
@@ -1077,6 +1088,31 @@ fn compile_policy_match_to_node(
         });
     }
 
+    // Pre-compile constraint policy for constraint-derivable observables.
+    let constraint_policy = if is_constraint_observable(&block.observable) {
+        let mut sandbox_rules = Vec::new();
+        let mut network = NetworkPolicy::Deny;
+        compile_match_to_sandbox(block, env, &mut sandbox_rules, &mut network)?;
+
+        // Add temp directory rules.
+        for path in DecisionTree::temp_directory_paths() {
+            sandbox_rules.push(SandboxRule {
+                effect: RuleEffect::Allow,
+                caps: Cap::all(),
+                path,
+                path_match: PathMatch::Subpath,
+            });
+        }
+
+        Some(SandboxPolicy {
+            default: Cap::READ | Cap::EXECUTE,
+            rules: sandbox_rules,
+            network,
+        })
+    } else {
+        None
+    };
+
     let match_id = ids.alloc(NodeMeta {
         description: format!("(match {} ...)", block.observable),
         origin_policy: Some(origin.to_string()),
@@ -1087,7 +1123,22 @@ fn compile_policy_match_to_node(
         id: match_id,
         observable: ir_observable,
         arms: ir_arms,
+        constraint_policy,
     }))
+}
+
+/// Whether an observable is a constraint-derivable dimension (maps to sandbox enforcement).
+fn is_constraint_observable(obs: &Observable) -> bool {
+    matches!(
+        obs,
+        Observable::HttpDomain
+            | Observable::HttpMethod
+            | Observable::HttpPort
+            | Observable::HttpPath
+            | Observable::FsAction
+            | Observable::FsPath
+            | Observable::FsExists
+    ) || matches!(obs, Observable::Tuple(elems) if elems.iter().any(|e| is_constraint_observable(e)))
 }
 
 /// Compile an AST Observable to an IR Observable.

--- a/clash/src/policy/parse.rs
+++ b/clash/src/policy/parse.rs
@@ -246,6 +246,14 @@ fn parse_policy_item(expr: &SExpr, ctx: &ParseContext) -> Result<PolicyItem> {
         }
         "sandbox" => {
             require_v2(ctx, "sandbox")?;
+            if ctx.version >= 3 {
+                bail!(
+                    "(sandbox ...) is removed in version 3. \
+                     Use (match ctx.http.domain ...) and (match ctx.fs.path ...) instead; \
+                     constraints are derived automatically from the decision tree. \
+                     Run `clash policy upgrade` to migrate."
+                );
+            }
             parse_sandbox_block(list, ctx)
         }
         "allow" | "deny" | "ask" => {
@@ -807,8 +815,12 @@ fn parse_match_block_inner(
         "(match) expects an observable and at least one pattern/effect pair"
     );
     let observable = parse_observable(&list[1])?;
-    let arms = parse_match_arms(&list[2..], &observable, ctx, in_sandbox)?;
-    Ok(MatchBlock { observable, arms })
+    let (default, arms) = parse_match_arms(&list[2..], &observable, ctx, in_sandbox)?;
+    Ok(MatchBlock {
+        observable,
+        default,
+        arms,
+    })
 }
 
 /// Parse `(match ...)` at policy level (`:ask` allowed).
@@ -927,7 +939,7 @@ fn parse_tool_arg_field(atom: &str) -> Result<Observable> {
     }
 }
 
-/// Parse match arms: alternating pattern/effect pairs.
+/// Parse match arms: alternating pattern/effect pairs, with optional leading `(default :effect)`.
 ///
 /// Each arm is `pattern :effect` where pattern can be:
 /// - A simple pattern: `"github.com"`, `*`, `(or ...)`, `(not ...)`
@@ -935,24 +947,49 @@ fn parse_tool_arg_field(atom: &str) -> Result<Observable> {
 /// - An exec pattern (for command observable): `("git" *)`, `*`
 /// - A tuple pattern: `["read" (subpath $PWD)]`
 ///
+/// A leading `(default :effect)` form sets the fallthrough for unmatched arms.
 /// When `in_sandbox` is true, `:ask` is rejected in effect keywords.
 fn parse_match_arms(
     exprs: &[SExpr],
     observable: &Observable,
     ctx: &ParseContext,
     in_sandbox: bool,
-) -> Result<Vec<MatchArmAst>> {
+) -> Result<(Option<Effect>, Vec<MatchArmAst>)> {
+    // Check for leading (default :effect) form.
+    let (default, arm_exprs) = if let Some(first) = exprs.first() {
+        if let Some(list) = first.as_list() {
+            if !list.is_empty() {
+                if let Some("default") = list[0].as_str() {
+                    ensure!(
+                        list.len() == 2,
+                        "(default) inside match expects exactly 1 effect"
+                    );
+                    let effect = parse_match_effect_keyword(&list[1], in_sandbox)?;
+                    (Some(effect), &exprs[1..])
+                } else {
+                    (None, exprs)
+                }
+            } else {
+                (None, exprs)
+            }
+        } else {
+            (None, exprs)
+        }
+    } else {
+        (None, exprs)
+    };
+
     ensure!(
-        exprs.len() % 2 == 0,
+        arm_exprs.len() % 2 == 0,
         "match arms must be pattern/effect pairs (got odd number of elements)"
     );
     let mut arms = Vec::new();
-    for pair in exprs.chunks(2) {
+    for pair in arm_exprs.chunks(2) {
         let pattern = parse_arm_pattern(&pair[0], observable, ctx)?;
         let effect = parse_match_effect_keyword(&pair[1], in_sandbox)?;
         arms.push(MatchArmAst { pattern, effect });
     }
-    Ok(arms)
+    Ok((default, arms))
 }
 
 /// Parse a pattern in match-arm position, guided by the observable type.

--- a/clash/src/policy/print.rs
+++ b/clash/src/policy/print.rs
@@ -58,21 +58,21 @@ fn print_node(out: &mut String, node: &Node, tree: &PolicyTree, indent: usize) {
             print_node(out, body, tree, indent + 2);
         }
         Node::Match {
-            observable, arms, ..
+            observable,
+            arms,
+            constraint_policy,
+            ..
         } => {
-            out.push_str(&format!("{pad}Match {observable:?}:\n"));
+            let constraint_tag = if constraint_policy.is_some() {
+                " [constraint]"
+            } else {
+                ""
+            };
+            out.push_str(&format!("{pad}Match {observable:?}{constraint_tag}:\n"));
             for arm in arms {
                 out.push_str(&format!("{pad}  {:?} =>\n", arm.pattern));
                 print_node(out, &arm.body, tree, indent + 4);
             }
-        }
-        Node::Sandbox { .. } => {
-            let desc = if meta.description.is_empty() {
-                "...".to_string()
-            } else {
-                meta.description.clone()
-            };
-            out.push_str(&format!("{pad}Sandbox [{desc}]\n"));
         }
         Node::Leaf { effect, .. } => {
             let builtin_tag = if meta

--- a/clash/src/policy/tree.rs
+++ b/clash/src/policy/tree.rs
@@ -1,8 +1,13 @@
 //! Tree-shaped policy IR.
 //!
 //! Replaces the flat `DecisionTree` for evaluation. Old flat syntax compiles
-//! to degenerate linear trees via `from_decision_tree()`. The tree structure
-//! supports future `when`/`match`/`sandbox` syntax (Phase 2).
+//! to degenerate linear trees via `from_decision_tree()`. v2/v3 structured
+//! syntax compiles to When/Match/Leaf trees via `compile_tree_ast()`.
+//!
+//! **Constraint derivation**: Match blocks on `ctx.http.*` / `ctx.fs.*` that
+//! survive tree shaking carry a pre-compiled `SandboxPolicy`. When the
+//! observable is irrelevant (e.g. http.domain during a command query), the
+//! policy is merged into `sandbox_out` and implicit Allow is returned.
 
 use std::collections::HashMap;
 
@@ -16,7 +21,7 @@ use crate::policy::decision_tree::{
 };
 use crate::policy::eval::{CapQuery, tool_to_queries};
 use crate::policy::ir::{DecisionTrace, PolicyDecision, RuleMatch, RuleSkip};
-use crate::policy::sandbox_types::SandboxPolicy;
+use crate::policy::sandbox_types::{NetworkPolicy, SandboxPolicy};
 use crate::settings::PolicyLevel;
 
 /// Stable node identifier, used as index into `PolicyTree::node_meta`.
@@ -66,14 +71,23 @@ pub enum Node {
         predicate: Predicate,
         body: Box<Node>,
     },
-    /// Resolve observable, try arms in order; first match wins. (Phase 2)
+    /// Resolve observable, try arms in order; first match wins.
+    ///
+    /// When the observable is irrelevant (not in query context) and
+    /// `constraint_policy` is present, the pre-compiled policy is merged
+    /// into `sandbox_out` and implicit Allow is returned — this is how
+    /// surviving match blocks on `ctx.http.*` / `ctx.fs.*` derive sandbox
+    /// constraints from the decision tree.
     Match {
         id: NodeId,
         observable: Observable,
         arms: Vec<MatchArm>,
+        /// Pre-compiled sandbox policy derived from this match block's arms
+        /// when the observable is a constraint-derivable dimension
+        /// (ctx.http.*, ctx.fs.*). Set at compile time; collected at eval
+        /// time when the observable is irrelevant to the current query.
+        constraint_policy: Option<SandboxPolicy>,
     },
-    /// Return Allow + attached pre-compiled sandbox policy.
-    Sandbox { id: NodeId, policy: SandboxPolicy },
     /// Return the effect unconditionally.
     Leaf { id: NodeId, effect: Effect },
 }
@@ -182,7 +196,6 @@ impl Node {
             | Node::DenyOverrides { id, .. }
             | Node::When { id, .. }
             | Node::Match { id, .. }
-            | Node::Sandbox { id, .. }
             | Node::Leaf { id, .. } => *id,
         }
     }
@@ -193,7 +206,7 @@ impl Node {
 pub enum SandboxOut {
     /// v1: lookup by name from `sandbox_policies` map.
     Named(String),
-    /// v2: pre-compiled sandbox policy from a `Node::Sandbox`.
+    /// Pre-compiled sandbox policy derived from surviving constraint match blocks.
     Compiled(SandboxPolicy),
 }
 
@@ -498,7 +511,7 @@ fn renumber_node(node: &mut Node, offset: NodeId) {
                 renumber_node(&mut arm.body, offset);
             }
         }
-        Node::Sandbox { id, .. } | Node::Leaf { id, .. } => {
+        Node::Leaf { id, .. } => {
             *id += offset;
         }
     }
@@ -819,32 +832,40 @@ impl PolicyTree {
                 id,
                 observable,
                 arms,
+                constraint_policy,
             } => {
-                // Skip silently if observable is irrelevant to the query.
-                if !observable_is_relevant(observable, ctx) {
-                    return None;
-                }
-
-                for arm in arms {
-                    if match_arm_against_ctx(observable, &arm.pattern, ctx) {
-                        trace!(node_id = id, "match arm matched");
-                        return self.eval_node(&arm.body, ctx, matched, skipped, sandbox_out);
+                if observable_is_relevant(observable, ctx) {
+                    // Observable is in query context → normal first-match evaluation.
+                    for arm in arms {
+                        if match_arm_against_ctx(observable, &arm.pattern, ctx) {
+                            trace!(node_id = id, "match arm matched");
+                            return self.eval_node(&arm.body, ctx, matched, skipped, sandbox_out);
+                        }
                     }
+                    None
+                } else if let Some(policy) = constraint_policy {
+                    // Observable is irrelevant but this match block carries a
+                    // pre-compiled constraint policy.  Merge it into sandbox_out
+                    // and return implicit Allow — the surviving match block
+                    // defines what the invocation may access.
+                    trace!(
+                        node_id = id,
+                        "constraint derivation: merging sandbox policy from match block"
+                    );
+                    let meta = &self.node_meta[*id as usize];
+                    matched.push(RuleMatch {
+                        rule_index: 0,
+                        description: meta.description.clone(),
+                        effect: Effect::Allow,
+                        has_active_constraints: true,
+                        node_id: Some(*id),
+                    });
+                    merge_sandbox_out(sandbox_out, policy);
+                    Some(Effect::Allow)
+                } else {
+                    // Observable irrelevant, no constraints — skip silently.
+                    None
                 }
-                None
-            }
-
-            Node::Sandbox { id, policy } => {
-                let meta = &self.node_meta[*id as usize];
-                matched.push(RuleMatch {
-                    rule_index: 0,
-                    description: meta.description.clone(),
-                    effect: Effect::Allow,
-                    has_active_constraints: true,
-                    node_id: Some(*id),
-                });
-                *sandbox_out = Some(SandboxOut::Compiled(policy.clone()));
-                Some(Effect::Allow)
             }
         }
     }
@@ -993,6 +1014,38 @@ fn match_pattern_strings(pattern: &MatchPattern, values: &[String]) -> bool {
                 .all(|(pat, val)| pat.matches(val))
         }
         MatchPattern::Exec(_) => false, // exec patterns don't match string values
+    }
+}
+
+/// Merge a constraint policy into `sandbox_out`.
+///
+/// When multiple match blocks survive tree shaking, their constraint policies
+/// are merged: sandbox rules are concatenated and network policies are combined.
+fn merge_sandbox_out(sandbox_out: &mut Option<SandboxOut>, policy: &SandboxPolicy) {
+    match sandbox_out {
+        Some(SandboxOut::Compiled(existing)) => {
+            // Merge rules.
+            existing.rules.extend(policy.rules.iter().cloned());
+            // Merge network policy: allow > allow-domains > deny.
+            existing.network = match (&existing.network, &policy.network) {
+                (NetworkPolicy::Allow, _) | (_, NetworkPolicy::Allow) => NetworkPolicy::Allow,
+                (NetworkPolicy::AllowDomains(a), NetworkPolicy::AllowDomains(b)) => {
+                    let mut combined = a.clone();
+                    combined.extend(b.iter().cloned());
+                    NetworkPolicy::AllowDomains(combined)
+                }
+                (NetworkPolicy::AllowDomains(d), _) | (_, NetworkPolicy::AllowDomains(d)) => {
+                    NetworkPolicy::AllowDomains(d.clone())
+                }
+                (NetworkPolicy::Localhost, _) | (_, NetworkPolicy::Localhost) => {
+                    NetworkPolicy::Localhost
+                }
+                _ => NetworkPolicy::Deny,
+            };
+        }
+        _ => {
+            *sandbox_out = Some(SandboxOut::Compiled(policy.clone()));
+        }
     }
 }
 

--- a/clash/src/policy/version.rs
+++ b/clash/src/policy/version.rs
@@ -17,7 +17,7 @@ use super::ast::*;
 /// Bump this when making backwards-incompatible changes to the policy language.
 /// Every bump must be accompanied by deprecation entries that describe what changed
 /// and (ideally) an auto-fix function for `clash policy upgrade`.
-pub const CURRENT_VERSION: u32 = 2;
+pub const CURRENT_VERSION: u32 = 3;
 
 /// A deprecated feature in the policy language.
 pub struct Deprecation {
@@ -104,6 +104,14 @@ pub fn all_deprecations() -> Vec<Deprecation> {
             message: "`fs.path` is deprecated as an observable name. Use `ctx.fs.path`.".into(),
             check: |source| has_deprecated_observable(source, "fs.path"),
             fix: Some(|s| fix_observable_name(s, "fs.path", "ctx.fs.path")),
+        },
+        Deprecation {
+            deprecated_in: 3,
+            message: "`(sandbox ...)` is removed in v3. Constraints are now derived from match blocks in the decision tree. Run `clash policy upgrade` to migrate.".into(),
+            check: |source| source.contains("(sandbox"),
+            // Fix is handled at AST level in upgrade_policy (transform_v2_to_v3)
+            // because the v3 parser rejects (sandbox ...) so text-level re-parse fails.
+            fix: None,
         },
     ]
 }
@@ -229,6 +237,66 @@ fn fix_default_to_use(source: &str) -> String {
     super::edit::serialize_ast(&ast)
 }
 
+// ---------------------------------------------------------------------------
+// v2 → v3 AST transformation
+// ---------------------------------------------------------------------------
+
+/// Transform all `(sandbox ...)` blocks in policy bodies to inline match blocks.
+///
+/// Returns true if any transformation was performed.
+fn transform_v2_to_v3(ast: &mut [TopLevel]) -> bool {
+    let mut changed = false;
+    for tl in ast.iter_mut() {
+        if let TopLevel::Policy { body, .. } = tl {
+            let new_body = lift_sandbox_items(body);
+            if new_body != *body {
+                *body = new_body;
+                changed = true;
+            }
+        }
+    }
+    changed
+}
+
+/// Recursively lift sandbox items out of `(sandbox ...)` wrappers.
+///
+/// Each `SandboxItem::Match(block)` inside a sandbox becomes a `PolicyItem::Match(block)`.
+/// `SandboxItem::Rule(...)` entries (from v1 migration) are dropped since constraints
+/// are now derived from the decision tree in v3.
+fn lift_sandbox_items(items: &[PolicyItem]) -> Vec<PolicyItem> {
+    let mut result = Vec::new();
+    for item in items {
+        match item {
+            PolicyItem::Sandbox { body } => {
+                for si in body {
+                    match si {
+                        SandboxItem::Match(block) => {
+                            result.push(PolicyItem::Match(block.clone()));
+                        }
+                        SandboxItem::Rule(_) => {
+                            // v1 flat rules inside sandbox: drop them, constraints
+                            // are derived from the decision tree in v3.
+                        }
+                    }
+                }
+            }
+            PolicyItem::When {
+                observable,
+                pattern,
+                body,
+            } => {
+                result.push(PolicyItem::When {
+                    observable: observable.clone(),
+                    pattern: pattern.clone(),
+                    body: lift_sandbox_items(body),
+                });
+            }
+            other => result.push(other.clone()),
+        }
+    }
+    result
+}
+
 /// Check a policy source for deprecated features at the given version.
 ///
 /// Returns a list of warning messages for any deprecated patterns found.
@@ -291,9 +359,16 @@ pub fn upgrade_policy(source: &str) -> anyhow::Result<(String, Vec<String>)> {
     if version < 2 {
         let transformed = transform_v1_to_v2(&mut ast);
         if transformed {
-            changes.push(
-                "Transformed flat rules to v2 structured syntax (when/sandbox blocks).".into(),
-            );
+            changes
+                .push("Transformed flat rules to v2 structured syntax (when/match blocks).".into());
+        }
+    }
+
+    // Transform v2 sandbox blocks to inline match blocks (v3 removes sandbox).
+    if version < 3 {
+        let transformed = transform_v2_to_v3(&mut ast);
+        if transformed {
+            changes.push("Replaced (sandbox ...) blocks with inline (match ...) blocks.".into());
         }
     }
 

--- a/clester/tests/scripts/v2_policy_version.yaml
+++ b/clester/tests/scripts/v2_policy_version.yaml
@@ -34,7 +34,7 @@ steps:
     command: policy upgrade --dry-run
     expect:
       exit_code: 0
-      stdout_contains: "(version 2)"
+      stdout_contains: "(version 3)"
 
   # Policy still works after upgrade (rules unchanged)
   - name: actually upgrade the policy

--- a/docs/policy-grammar.md
+++ b/docs/policy-grammar.md
@@ -33,7 +33,8 @@ def_decl        = "(" "def" ATOM expression ")"                  ; v2 only, any 
 
 ; v1 policy items
 policy_item     = include | rule                                  ; v1
-                | include | when_block | sandbox_block | effect_kw ; v2
+                | include | when_block | match_block | effect_kw  ; v3
+                | include | when_block | sandbox_block | effect_kw ; v2 (sandbox removed in v3)
 
 include         = "(" "include" QUOTED_STRING ")"
 rule            = "(" effect cap_matcher keyword_args* ")"        ; v1 only
@@ -341,42 +342,9 @@ Keywords are atoms starting with `:`. They appear in three positions:
 - **Inside subpath filters:** `:worktree` (see [Worktree-Aware Subpath](#worktree-aware-subpath) above)
 - **After capability matchers:** `:sandbox` (see below)
 
-### `:sandbox`
+### `:sandbox` (v1 only, removed in v3)
 
-The `:sandbox` keyword on exec rules defines the kernel-level sandbox for matching commands. It accepts either a named policy reference or inline rules.
-
-#### Named sandbox
-
-Reference a named policy whose rules define the sandbox:
-
-```
-(policy "cargo-env"
-  (allow (fs read (subpath (env PWD))))
-  (allow (net)))
-
-(policy "main"
-  (allow (exec "cargo" *) :sandbox "cargo-env"))
-```
-
-#### Inline sandbox
-
-Define sandbox rules directly on the exec rule, without a separate named policy:
-
-```
-(allow (exec "clash" "bug" *) :sandbox (allow (net *)))
-```
-
-Multiple inline rules are supported:
-
-```
-(allow (exec "cargo" *) :sandbox
-  (allow (net *))
-  (allow (fs read (subpath (env PWD)))))
-```
-
-Inline sandbox rules cannot have nested `:sandbox` annotations.
-
-When the exec rule matches, the sandbox's fs/net rules are used to build a kernel-level sandbox for the spawned process. See the [sandbox section](./policy-guide.md#sandbox-policies) in the policy guide.
+> **Removed in v3:** The `:sandbox` keyword and `(sandbox ...)` blocks are removed. In v3, runtime constraints (filesystem, network) are derived automatically from surviving `(match ...)` blocks in the decision tree after tree shaking. Use `(match ctx.http.domain ...)`, `(match ctx.fs.path ...)`, etc. instead. Run `clash policy upgrade` to auto-migrate.
 
 ---
 
@@ -440,8 +408,8 @@ Use `clash policy upgrade` to automatically transform a v1 policy to v2 syntax.
 ### Grammar
 
 ```ebnf
-; v2 policy items (inside a policy body)
-policy_item_v2  = include | when_block | match_block | sandbox_block | effect_kw
+; v3 policy items (inside a policy body)
+policy_item_v3  = include | when_block | match_block | effect_kw
 
 when_block      = "(" "when" when_guard when_body+ ")"
 when_guard      = "(" "command" pattern? args_spec ")"
@@ -449,17 +417,12 @@ when_guard      = "(" "command" pattern? args_spec ")"
                 | "(" observable pattern ")"
                 | "(" observable path_filter ")"        ; for ctx.fs.path
 when_body       = effect_kw                             ; inline effect
-                | sandbox_block                         ; nested sandbox
+                | match_block                           ; nested match (constraint source)
                 | when_block                            ; nested when
 
 effect_kw       = ":allow" | ":deny" | ":ask"
 
-sandbox_block   = "(" "sandbox" sandbox_item+ ")"
-sandbox_item    = rule                                  ; flat capability rule
-                | sandbox_match_block                   ; observable dispatch
-
-match_block     = "(" "match" observable match_arm+ ")"     ; policy level (allows :ask)
-sandbox_match_block = "(" "match" observable sandbox_match_arm+ ")"  ; sandbox level (no :ask)
+match_block     = "(" "match" observable match_arm+ ")"
 observable      = "command" | "tool"
                 | "ctx.http.domain" | "ctx.http.method" | "ctx.http.port" | "ctx.http.path"
                 | "ctx.fs.action" | "ctx.fs.path" | "ctx.fs.exists"
@@ -469,8 +432,6 @@ observable      = "command" | "tool"
                 | "[" observable observable+ "]"         ; tuple
 ctx_tool_arg_field = "ctx.tool.args." FIELD_NAME "?"  ; nullable dynamic field accessor
 match_arm       = arm_pattern effect_kw
-sandbox_match_arm = arm_pattern sandbox_effect_kw
-sandbox_effect_kw = ":allow" | ":deny"
 arm_pattern     = pattern | path_filter                 ; scalar observable
                 | exec_arm_pattern                      ; command observable
                 | "[" arm_element+ "]"                  ; tuple observable
@@ -482,14 +443,17 @@ expression      = "[" QUOTED_STRING* "]"                 ; bracket list (expands
                 | pattern                                ; general pattern
                 | when_block                             ; compound when block
                 | match_block                            ; compound match block
-                | sandbox_block                          ; compound sandbox block
 ```
+
+> **v3 change:** `(sandbox ...)` blocks are removed. Runtime constraints are derived
+> automatically from `(match ...)` blocks on `ctx.http.*` and `ctx.fs.*` observables
+> that survive tree shaking. See [Constraint Derivation](#constraint-derivation) below.
 
 ### `when` blocks
 
 A `when` block gates its body on an observable guard. The guard tests a single observable value against a pattern. All observables are supported as guards.
 
-The body contains one or more items: an effect keyword (`:allow`, `:deny`, `:ask`), a `(sandbox ...)` block, or a nested `(when ...)` block.
+The body contains one or more items: an effect keyword (`:allow`, `:deny`, `:ask`), a `(match ...)` block, or a nested `(when ...)` block.
 
 ```
 ; Allow all git commands
@@ -513,32 +477,34 @@ The body contains one or more items: an effect keyword (`:allow`, `:deny`, `:ask
 ; Guard on filesystem path
 (when (ctx.fs.path (subpath (env PWD))) :allow)
 
-; Allow with a sandbox
+; Allow cargo with network constraints
 (when (command "cargo" *)
   :allow
-  (sandbox
-    (allow (fs read (subpath (env PWD))))
-    (allow (net))))
+  (match ctx.http.domain
+    "crates.io"  :allow
+    "github.com" :allow
+    *            :deny))
 ```
 
 When the body is a single effect keyword, it renders on one line: `(when (command "git" *) :allow)`. Multi-item bodies are indented.
 
-### `sandbox` blocks
+### Constraint Derivation
 
-A `sandbox` block defines kernel-level restrictions for commands matched by a parent `(when (command ...) ...)` block. Sandbox items are capability grants — they use the same `(allow (fs ...))` / `(allow (net ...))` syntax as v1 flat rules.
+In v3, runtime constraints (filesystem sandbox rules, network policies) are derived automatically from `(match ...)` blocks on `ctx.http.*` and `ctx.fs.*` observables that survive decision tree evaluation. There is no explicit `(sandbox ...)` form.
 
-Sandbox blocks can also contain `(match ...)` blocks for observable-based dispatch.
+When a `when` block fires (its guard matches), all match blocks in its body are evaluated. Match blocks on constraint-derivable observables (`ctx.http.domain`, `ctx.http.method`, `ctx.http.port`, `ctx.http.path`, `ctx.fs.action`, `ctx.fs.path`, `ctx.fs.exists`) are pre-compiled into a `SandboxPolicy` at compile time. At runtime, when the observable is irrelevant (e.g. an HTTP domain match on a non-HTTP request), the match block contributes its constraints and returns an implicit allow.
 
 ```
-(when (command *)
+(when (command "cargo" *)
   :allow
-  (sandbox
-    (allow (fs (or read write) (subpath (env PWD))))
-    (allow (net "github.com"))
-    (match ctx.http.domain
-      "crates.io" :allow
-      "github.com" :allow
-      *           :deny)))
+  (match ctx.http.domain
+    "crates.io"  :allow
+    "github.com" :allow
+    *            :deny)
+  (match [ctx.fs.action ctx.fs.path]
+    ["read"  (subpath (env PWD))]  :allow
+    ["write" (subpath (env PWD))]  :allow
+    [*       *]                    :deny))
 ```
 
 ### `match` blocks
@@ -649,7 +615,7 @@ Values may be bracket lists (backwards compatible), patterns, or compound forms 
 
 ; Compound match block — spliced into policy/when body
 (def github-net
-  (match proxy.domain
+  (match ctx.http.domain
     "github.com" :allow))
 
 (policy "main"
@@ -670,10 +636,10 @@ In v2 contexts (when bodies, match arms), effects use keyword syntax:
 | `:deny` | Block the action |
 | `:ask` | Prompt the user |
 
-### Complete v2 example
+### Complete v3 example
 
 ```
-(version 2)
+(version 3)
 (use "main")
 (def builders ["cargo" "make" "cmake"])
 
@@ -682,15 +648,17 @@ In v2 contexts (when bodies, match arms), effects use keyword syntax:
   (when (command "git" "push" :has "--force") :deny)
   (when (command "git" *) :allow)
 
-  ; Allow build tools with filesystem + network sandbox
+  ; Allow build tools with filesystem + network constraints
   (when (command builders *)
     :allow
-    (sandbox
-      (allow (fs (or read write) (subpath (env PWD))))
-      (match ctx.http.domain
-        "crates.io"  :allow
-        "github.com" :allow
-        *            :deny)))
+    (match [ctx.fs.action ctx.fs.path]
+      ["read"  (subpath (env PWD))]  :allow
+      ["write" (subpath (env PWD))]  :allow
+      [*       *]                    :deny)
+    (match ctx.http.domain
+      "crates.io"  :allow
+      "github.com" :allow
+      *            :deny))
 
   ; Dispatch on tool name at policy level
   (match tool
@@ -704,19 +672,18 @@ In v2 contexts (when bodies, match arms), effects use keyword syntax:
   :deny)                             ; fallback for unmatched requests
 ```
 
-### Upgrading from v1 to v2
+### Upgrading to v3
 
-Run `clash policy upgrade` to automatically transform v1 flat rules to v2 structured syntax. The transformation:
+Run `clash policy upgrade` to automatically transform older policies to v3 syntax. The transformation handles both v1 flat rules and v2 sandbox blocks:
 
-| v1 flat rule | v2 equivalent |
-|-------------|--------------|
+| v1/v2 form | v3 equivalent |
+|------------|--------------|
 | `(allow (exec "git" *))` | `(when (command "git" *) :allow)` |
 | `(deny (exec "git" "push" *))` | `(when (command "git" "push" *) :deny)` |
 | `(allow (tool "Agent"))` | `(when (tool "Agent") :allow)` |
-| `(allow (fs read (subpath X)))` | `(when (tool (or "Read" "Glob" "Grep")) :allow)` + sandbox |
-| `(allow (net "github.com"))` | `(when (tool (or "WebFetch" "WebSearch")) :allow)` + sandbox |
+| `(sandbox (match ctx.http.domain ...))` | `(match ctx.http.domain ...)` (inline) |
 
-Filesystem and network allow rules also generate sandbox entries inside a `(when (command *) (sandbox ...))` block, so that sandboxed commands inherit the appropriate kernel-level capabilities.
+In v3, `(sandbox ...)` blocks are replaced by inline `(match ...)` blocks. Runtime constraints are derived from the surviving match blocks in the decision tree.
 
 ---
 
@@ -728,7 +695,7 @@ ESCAPE          = '\\' ('"' | '\\')
 REGEX           = '/' (CHAR_NO_SLASH)* '/'
 INTEGER         = [0-9]+
 ENV_NAME        = [A-Z_][A-Z0-9_]*
-KEYWORD         = ':' ATOM                     ; e.g. :sandbox
+KEYWORD         = ':' ATOM                     ; e.g. :allow, :deny, :has
 COMMENT         = ';' (any char)* NEWLINE
 WHITESPACE      = ' ' | '\t' | '\n' | '\r'
 ```

--- a/docs/policy-semantics.md
+++ b/docs/policy-semantics.md
@@ -32,18 +32,21 @@ S-expression source text
 Vec<TopLevel> (AST)             ← parse.rs
     │
     ├── Version { number }
-    ├── Default { effect, policy }
-    └── Policy { name, body: [Rule | Include] }
+    ├── Use { policy_name }
+    └── Policy { name, body: [When | Match | Effect | Include] }
     │
     ▼
-DecisionTree (IR)               ← compile.rs
-    │
+PolicyTree (IR)                 ← compile.rs, tree.rs
+    │                             (v1 also compiles to flat DecisionTree)
     ├── default: Effect
     ├── policy_name: String
-    ├── exec_rules: Vec<CompiledRule>   (sorted by specificity)
-    ├── fs_rules: Vec<CompiledRule>     (sorted by specificity)
-    ├── net_rules: Vec<CompiledRule>    (sorted by specificity)
-    └── sandbox_policies: HashMap<String, Vec<CompiledRule>>
+    ├── root: Node               (tree-shaped decision structure)
+    │   ├── Sequence { children }
+    │   ├── DenyOverrides { children }
+    │   ├── When { predicate, body }
+    │   ├── Match { observable, arms, constraint_policy? }
+    │   └── Leaf { effect }
+    └── node_meta: Vec<NodeMeta>
 ```
 
 ### Compilation Steps
@@ -105,26 +108,21 @@ Conflicts are compile-time errors. This guarantees that specificity ordering is 
 
 ```
 evaluate(tool_name, tool_input, cwd):
-    1. Map tool invocation to capability queries
-       (e.g., Bash "git push" → Exec { bin: "git", args: ["push"] }, Bash "FOO=1 cargo build" → Exec { bin: "cargo", args: ["build"] })
+    1. Map tool invocation to EvalContext
+       (command, tool, http.domain, fs.action, fs.path, etc.)
 
-    2. For each query, select the rule list:
-       - Exec query → exec_rules
-       - Fs query → fs_rules
-       - Net query → net_rules
+    2. Walk the policy tree (root node):
+       - Sequence: evaluate children in order, return first match
+       - DenyOverrides: evaluate ALL children, deny > ask > allow
+       - When: test predicate against context, recurse into body if true
+       - Match: if observable is relevant, dispatch on arms (first-match);
+               if irrelevant and constraint_policy present,
+               merge constraints into SandboxOut, return implicit Allow
+       - Leaf: return effect
 
-    3. Walk the rule list (sorted most-specific-first):
-       - Test if the compiled matcher matches the query
-       - First match wins → record effect
-       - If the matching rule has :sandbox, note sandbox name in trace
-       - Non-matching rules are recorded as skipped
+    3. If tree walk produces no match → return default effect
 
-    4. If no queries produced matches → return default effect
-
-    5. If multiple domains matched (rare):
-       - deny > ask > allow (deny-overrides)
-
-    6. Build PolicyDecision with effect, reason, and trace
+    4. Build PolicyDecision with effect, sandbox_out, and trace
 ```
 
 > **Note:** This evaluation runs once per Claude Code tool call via the PreToolUse hook. It does not run for child processes spawned by allowed Bash commands. Child processes inherit kernel-level sandbox restrictions (fs/net) but are not checked against exec rules.
@@ -154,26 +152,31 @@ This enables the `clash explain` command and structured audit logging.
 
 ---
 
-## Sandbox Generation
+## Constraint Derivation (v3)
 
-When an exec allow rule matches with a `:sandbox` annotation, the sandbox rules define the filesystem and network permissions for the spawned process. Sandbox rules can be specified two ways:
+In v3, runtime constraints (filesystem and network sandbox policies) are derived from surviving `(match ...)` blocks in the decision tree, rather than from explicit `(sandbox ...)` annotations.
 
-- **Named**: `:sandbox "name"` references a `(policy "name" ...)` block whose rules are pre-compiled into `sandbox_policies`.
-- **Inline**: `:sandbox (allow (net *)) (allow (fs ...))` compiles the inline rules directly into `sandbox_policies` under a synthetic key.
+### How It Works
 
-Both forms produce the same compiled representation — downstream evaluation is identical.
+Match blocks on constraint-derivable observables (`ctx.http.domain`, `ctx.http.method`, `ctx.http.port`, `ctx.http.path`, `ctx.fs.action`, `ctx.fs.path`, `ctx.fs.exists`) are pre-compiled into a `SandboxPolicy` at compile time. The `constraint_policy` is attached to the `Node::Match` in the decision tree.
+
+At runtime, the decision tree is evaluated. When a match block's observable is **relevant** (e.g. the request involves HTTP), it dispatches normally (first-match on arms). When the observable is **irrelevant** (e.g. an `ctx.http.domain` match on a non-HTTP request), the match block contributes its pre-compiled constraints to the `SandboxOut` and returns an implicit `Allow`.
+
+### DenyOverrides for When Bodies
+
+When a `(when ...)` block has multiple body items (e.g. an effect + constraint match blocks), the body uses `DenyOverrides` semantics: all children are evaluated (not just the first match), allowing both the decision effect and constraints to be collected.
+
+### Enforcement
 
 The sandbox policy is enforced at the kernel level:
 - **Linux**: Landlock LSM restricts file and network access
 - **macOS**: Seatbelt sandbox profiles restrict file and network access
 
-Network enforcement in sandboxes has three tiers:
+Network enforcement has three tiers:
 
-- **Wildcard** `(allow (net))` — unrestricted network access
-- **Domain-specific** `(allow (net "crates.io"))` — a local HTTP proxy enforces domain filtering. The OS sandbox restricts the process to localhost-only connections; the proxy checks each request against the allowlist. On macOS, Seatbelt enforces the localhost restriction at the kernel level. On Linux, seccomp cannot filter `connect()` by destination (pointer argument), so proxy enforcement is advisory for programs that bypass `HTTP_PROXY`/`HTTPS_PROXY`.
-- **No net rule** — all network access denied at the kernel level
-
-When no `:sandbox` is specified on an exec allow, the spawned process gets a deny-all sandbox by default.
+- **Allow** — unrestricted network access
+- **AllowDomains** — a local HTTP proxy enforces domain filtering. The OS sandbox restricts the process to localhost-only connections; the proxy checks each request against the allowlist. On macOS, Seatbelt enforces the localhost restriction at the kernel level. On Linux, seccomp cannot filter `connect()` by destination (pointer argument), so proxy enforcement is advisory for programs that bypass `HTTP_PROXY`/`HTTPS_PROXY`.
+- **Deny** — all network access denied at the kernel level
 
 All sandbox policies automatically include read/write/create/delete/execute access to system temp directories, so sandboxed tools (compilers, package managers, etc.) can create temporary files without explicit policy rules. On macOS this covers `/private/tmp` and `/private/var/folders`; on Linux `/tmp` and `/var/tmp`; plus `$TMPDIR` if set to a non-standard location.
 
@@ -190,8 +193,6 @@ This ensures that git commands (commit, push, etc.) work correctly inside worktr
 When the path is not inside a worktree, `:worktree` has no effect — the filter compiles to a plain `subpath`. The default policy uses `(subpath :worktree (env PWD))` for CWD access rules.
 
 Sandbox enforcement covers filesystem and network access only. Exec-level argument matching (e.g., distinguishing `git push` from `git status`) is not enforced on child processes within the sandbox — only the top-level command is checked against exec rules. See [#136](https://github.com/empathic/clash/issues/136) for the tracking issue.
-
-*(Note: Kernel-level sandbox enforcement is a future PR. Currently the sandbox reference is validated and compiled but not yet enforced.)*
 
 ---
 


### PR DESCRIPTION
## Summary

Closes #222.

- **Remove `Node::Sandbox`** from the tree IR. Add `constraint_policy: Option<SandboxPolicy>` to `Node::Match` for match blocks on constraint-derivable observables (`ctx.http.*`, `ctx.fs.*`).
- **DenyOverrides for `when` bodies**: when a `when` block has multiple body items (effect + constraint match blocks), all children are evaluated so both the decision and constraints are collected.
- **Implicit Allow from constraints**: when a constraint-bearing match block survives on an irrelevant observable (e.g. `ctx.http.domain` match on a non-HTTP request), it merges its pre-compiled `SandboxPolicy` into `SandboxOut` and returns `Allow`.
- **Version 3**: bump `CURRENT_VERSION` to 3. Reject `(sandbox ...)` in the v3 parser with a clear migration message.
- **Auto-migration**: `clash policy upgrade` transforms v2 `(sandbox ...)` blocks into inline `(match ...)` blocks via AST-level `transform_v2_to_v3`.
- **Deprecation entry**: warns users with v2 sandbox blocks to migrate.
- **Documentation**: updated `policy-grammar.md` and `policy-semantics.md` for v3 constraint derivation.

## Files changed

| File | Change |
|------|--------|
| `clash/src/policy/tree.rs` | Remove `Node::Sandbox`, add `constraint_policy` to `Node::Match`, `merge_sandbox_out()` helper |
| `clash/src/policy/compile.rs` | Constraint pre-compilation, `is_constraint_observable()`, DenyOverrides for when bodies, sandbox→synthetic match |
| `clash/src/policy/parse.rs` | `(default :effect)` in match blocks, reject sandbox in v3+ |
| `clash/src/policy/ast.rs` | Add `default: Option<Effect>` to `MatchBlock` |
| `clash/src/policy/print.rs` | Remove Sandbox arm, add `[constraint]` tag for constraint match nodes |
| `clash/src/policy/version.rs` | Bump to v3, deprecation entry, `transform_v2_to_v3` + `lift_sandbox_items` |
| `docs/policy-grammar.md` | v3 grammar, constraint derivation section, updated examples |
| `docs/policy-semantics.md` | v3 evaluation algorithm, constraint derivation section |
| `clester/tests/scripts/v2_policy_version.yaml` | Update expected version in upgrade test |

## Test plan

- [x] `cargo test -p clash` — 792 tests pass
- [x] `just check` — all unit tests + clippy pass (pre-existing warnings only)
- [x] `just clester` — 164/164 integration test steps pass
- [ ] Manual: write a v2 policy with `(sandbox ...)`, run `clash policy upgrade`, verify it produces v3 with inline match blocks
- [ ] Manual: write a v3 policy with `(match ctx.http.domain ...)` inside a `when` block, verify constraint derivation works at runtime