### PR TITLE
fix(sandbox): allow AF_UNIX IPC in advisory seccomp filter

### DIFF
--- a/clash/src/sandbox/linux.rs
+++ b/clash/src/sandbox/linux.rs
@@ -261,24 +261,33 @@ fn install_seccomp_network_filter() -> Result<(), SandboxError> {
     apply_seccomp_filter(rules, arch)
 }
 
-/// Install a permissive seccomp filter for `AllowDomains` on Linux.
+/// Install a permissive seccomp filter for `AllowDomains`/`Localhost` on Linux.
 ///
 /// Allows socket creation for AF_INET/AF_INET6 (needed for proxy connection)
-/// and outbound connections, but blocks bind/listen/accept to prevent the
-/// sandboxed process from running a server. Domain filtering is handled by
-/// the HTTP proxy, not seccomp.
+/// and outbound connections. Domain filtering is handled by the HTTP proxy,
+/// not seccomp.
+///
+/// We intentionally do NOT block bind/listen/accept here because seccomp can
+/// only inspect syscall arguments by position, and these syscalls take a file
+/// descriptor as their first argument — not the socket family. Blocking them
+/// unconditionally breaks AF_UNIX IPC used by tools like terraform (go-plugin),
+/// cargo, and other programs that communicate with child processes via Unix
+/// domain sockets. Since the proxy already controls outbound connections and
+/// Landlock restricts where socket files can be created, the security impact
+/// of allowing these syscalls is minimal.
 #[instrument(level = Level::TRACE)]
 fn install_seccomp_advisory_network_filter() -> Result<(), SandboxError> {
     let mut rules: BTreeMap<i64, Vec<SeccompRule>> = BTreeMap::new();
 
-    // Block server-side operations and ptrace
-    let deny_syscalls = [
-        libc::SYS_accept,
-        libc::SYS_accept4,
-        libc::SYS_bind,
-        libc::SYS_listen,
-        libc::SYS_ptrace,
-    ];
+    // Only block ptrace (prevents privilege escalation).
+    //
+    // We do not block bind/listen/accept because their first argument is a
+    // file descriptor, and seccomp cannot distinguish AF_UNIX fds from
+    // AF_INET fds. Blocking them breaks Unix domain socket IPC (go-plugin,
+    // cargo subprocess communication, etc.). The HTTP proxy handles domain
+    // filtering for outbound connections, and without inbound routing to
+    // the sandboxed process, server-side syscalls pose no real risk.
+    let deny_syscalls = [libc::SYS_ptrace];
 
     for &syscall in &deny_syscalls {
         rules.insert(syscall, vec![]);


### PR DESCRIPTION
- Remove bind, listen, accept, accept4 from the advisory seccomp network filter (install_seccomp_advisory_network_filter)
- Fixes Unix domain socket IPC breakage for tools like terraform (and supposedly anything using go-plugin gRPC)

**Problem**

The advisory seccomp filter (active when domain-specific (net ...) rules exist) unconditionally blocked bind, listen, accept, and accept4. These syscalls take a file descriptor as their first argument, not a socket family. Seccomp can only inspect arguments by position, so it cannot distinguish AF_UNIX calls from AF_INET calls.

This broke any tool that spawns child processes communicating via Unix domain sockets (Terraform):

plugin init error: error="listen unix /tmp/plugin219205137: bind: operation not permitted"
grpc server: error="accept unix /tmp/plugin2337733165: accept4: operation not permitted"

**Why this is safe**

- The HTTP proxy is the real enforcement layer in advisory mode, not seccomp
- socket(AF_INET) was already allowed in advisory mode (needed for proxy connections), so bind/listen/accept were already partially bypassable
- Landlock still controls where socket files can be created on the filesystem
- The full-deny filter (NetworkPolicy::Deny, used when there are zero net rules) is unchanged and still blocks everything
- Without inbound routing to the sandboxed process, accepting connections is a no-op

**Test plan**

- cargo build succeeds
- Existing tests pass (18 pre-existing failures in notifications/proxy tests, unrelated)
- terraform validate works inside clash sandbox with (net ...) domain rules active
- Manual: verify cargo build (which uses socketpair internally) still works in sandboxed mode
- Manual: verify full-deny mode (NetworkPolicy::Deny) still blocks all network syscalls

```sh
  ┌───────────────────┬─────────────────────────────────────┬────────────────────────────────────┐
  │     Scenario      │                Error                │             Mechanism              │
  ├───────────────────┼─────────────────────────────────────┼────────────────────────────────────┤
  │ With net rules    │ CONNECT tunnel failed, response 403 │ Proxy rejects unlisted domain      │
  ├───────────────────┼─────────────────────────────────────┼────────────────────────────────────┤
  │ Without net rules │ Could not resolve host: example.com │ Seccomp blocks DNS at kernel level │
  └───────────────────┴─────────────────────────────────────┴────────────────────────────────────┘
```
