### PR TITLE
docs(plugin): rewrite skills to match current CLI

### DIFF
--- a/clash-plugin/README.md
+++ b/clash-plugin/README.md
@@ -49,15 +49,22 @@ Policies are written in Starlark (`.star` files), a Python-like configuration la
 load("@clash//std.star", "exe", "tool", "policy", "sandbox", "cwd", "home", "domains")
 
 def main():
-    return policy(default = deny, rules = [
+    fs_access = sandbox(fs=[
         cwd(follow_worktrees = True, read = allow, write = allow),
+        home().child(".ssh", read = allow),
+    ])
+
+    return policy(default = deny, rules = [
+        tool(["Read", "Glob", "Grep"]).sandbox(fs_access).allow(),
+        tool(["Write", "Edit"]).sandbox(fs_access).allow(),
         exe("git").allow(),
         exe("git", args = ["push"]).deny(),
-        home().child(".ssh", read = allow),
         tool().allow(),
         domains({"github.com": allow}),
     ])
 ```
+
+Note: Filesystem path entries (`cwd`, `home`, `tempdir`, `path`) cannot appear directly in the `rules = [...]` list. They must be wrapped in a `sandbox()` and attached to a `tool()` or `exe()` rule.
 
 ### Rule Syntax Quick Reference
 
@@ -67,9 +74,8 @@ def main():
 | Deny a subcommand | `exe("git", args = ["push"]).deny()` |
 | Ask for confirmation | `exe("git", args = ["commit"]).ask()` |
 | Multiple binaries | `exe(["cargo", "rustc"]).allow()` |
-| Filesystem (cwd) | `cwd(read = allow, write = allow)` |
-| Filesystem (home subdir) | `home().child(".ssh", read = allow)` |
-| Worktree-aware cwd | `cwd(follow_worktrees = True, read = allow, write = allow)` |
+| Filesystem (via sandbox) | `tool(["Read"]).sandbox(sandbox(fs=[cwd(read = allow)])).allow()` |
+| Home subdir (via sandbox) | `exe("ssh").sandbox(sandbox(fs=[home().child(".ssh", read = allow)])).allow()` |
 | Network domains | `domains({"github.com": allow})` |
 | Tool access | `tool().allow()` |
 | Sandbox on exec | `exe("cargo").sandbox(sb).allow()` |

--- a/clash-plugin/skills/allow/SKILL.md
+++ b/clash-plugin/skills/allow/SKILL.md
@@ -37,13 +37,16 @@ Help the user add an **allow** rule to their clash policy by editing the `.star`
      ```python
      exe(["cargo", "rustc"]).allow()
      ```
-   - Filesystem read/write under cwd:
+   - Filesystem access under cwd (via sandbox on a tool rule):
      ```python
-     cwd(follow_worktrees = True, read = allow, write = allow)
+     fs_sandbox = sandbox(fs=[cwd(follow_worktrees = True, read = allow, write = allow)])
+     tool(["Read", "Glob", "Grep"]).sandbox(fs_sandbox).allow()
+     tool(["Write", "Edit"]).sandbox(fs_sandbox).allow()
      ```
-   - Filesystem access under a specific path:
+   - Filesystem access under a specific path (via sandbox):
      ```python
-     home().child(".ssh", read = allow)
+     ssh_sandbox = sandbox(fs=[home().child(".ssh", read = allow)])
+     exe("ssh").sandbox(ssh_sandbox).allow()
      ```
    - Network access to a domain:
      ```python
@@ -53,6 +56,8 @@ Help the user add an **allow** rule to their clash policy by editing the `.star`
      ```python
      tool().allow()
      ```
+
+   **Important:** Filesystem path entries (`cwd`, `home`, `tempdir`, `path`) cannot appear directly in the `rules = [...]` list. They must be wrapped in a `sandbox()` and attached to a `tool()` or `exe()` rule.
 
    Make sure any new builders used are added to the `load()` statement at the top of the file, e.g.:
    ```python

--- a/clash-plugin/skills/amend/SKILL.md
+++ b/clash-plugin/skills/amend/SKILL.md
@@ -16,17 +16,24 @@ Help the user modify their clash policy by editing the `.star` policy file direc
 Policies are `.star` files defining a `main()` function that returns a `policy()` value. Rules go in the `rules = [...]` list:
 
 ```python
-load("@clash//std.star", "exe", "policy", "cwd", "home", "domains")
+load("@clash//std.star", "exe", "tool", "policy", "sandbox", "cwd", "home", "domains")
 
 def main():
-    return policy(default = deny, rules = [
-        exe("git").allow(),
-        exe("git", args = ["push"]).deny(),
+    fs_access = sandbox(fs=[
         cwd(follow_worktrees = True, read = allow, write = allow),
         home().child(".ssh", read = allow),
+    ])
+
+    return policy(default = deny, rules = [
+        tool(["Read", "Glob", "Grep"]).sandbox(fs_access).allow(),
+        tool(["Write", "Edit"]).sandbox(fs_access).allow(),
+        exe("git").allow(),
+        exe("git", args = ["push"]).deny(),
         domains({"github.com": allow}),
     ])
 ```
+
+**Important:** Filesystem path entries (`cwd`, `home`, `tempdir`, `path`) cannot appear directly in the `rules = [...]` list. They must be wrapped in a `sandbox()` and attached to a `tool()` or `exe()` rule.
 
 ## Steps
 
@@ -46,9 +53,10 @@ def main():
      ```python
      exe("git", args = ["push"]).deny()
      ```
-   - Allow reads under cwd:
+   - Allow filesystem access under cwd (via sandbox):
      ```python
-     cwd(follow_worktrees = True, read = allow)
+     fs_sandbox = sandbox(fs=[cwd(follow_worktrees = True, read = allow)])
+     tool(["Read", "Glob", "Grep"]).sandbox(fs_sandbox).allow()
      ```
    - Allow network access to a domain:
      ```python

--- a/clash-plugin/skills/audit/SKILL.md
+++ b/clash-plugin/skills/audit/SKILL.md
@@ -2,27 +2,29 @@
 name: audit
 description: View recent clash permission decisions from the audit log
 ---
-Check if the audit log exists:
+Use `clash debug log` to view recent permission decisions:
 
 ```bash
-test -f ~/.clash/audit.jsonl && echo "exists" || echo "missing"
+clash debug log
 ```
 
-If the file is missing, tell the user audit logging is not enabled. Check the clash documentation or run `clash doctor` for instructions on enabling audit logging.
-
-If the file exists, read the last 20 entries:
+The command supports filtering options:
 
 ```bash
-tail -20 ~/.clash/audit.jsonl
+clash debug log --since 5m            # entries from the last 5 minutes
+clash debug log --effect deny          # only denied actions
+clash debug log --tool Bash            # only Bash tool invocations
+clash debug log --limit 10             # show at most 10 entries
+clash debug log --session "abc"        # entries from sessions matching "abc"
+clash debug log --json                 # machine-readable output
 ```
 
-Parse the JSON Lines output and present a readable summary table. For each entry:
+Parse the output and present a readable summary. For each entry:
 
-1. **Timestamp** — convert the Unix timestamp (e.g. `1706123456.789`) to a human-readable local time
+1. **Timestamp** — when the decision was made
 2. **Decision** — show `ALLOW`, `DENY`, or `ASK`
-3. **Tool** — the `tool_name` value
-4. **Input** — the `tool_input_summary` (truncated to keep the table readable)
-5. **Reason** — show `reason` if present
-6. **Rules** — show matched/skipped rule counts if nonzero
+3. **Tool** — the tool name
+4. **Input** — what was invoked (truncated to keep output readable)
+5. **Reason** — the matched rule or reason for the decision
 
-If the user asks to filter by tool name, decision type, or time range, use `grep` or `jq` on `~/.clash/audit.jsonl` to narrow results before presenting them.
+If the user asks to filter by tool name, decision type, or time range, use the appropriate flags on `clash debug log`.

--- a/clash-plugin/skills/bug-report/SKILL.md
+++ b/clash-plugin/skills/bug-report/SKILL.md
@@ -20,7 +20,7 @@ Help the user file a bug report for clash. Gather a clear description of the pro
 3. **Preview the command.** Show the user the exact command that will be run before executing it:
 
    ```bash
-   clash bug "title here" --description "description here" --include-config --include-logs
+   clash bug --title "title here" --description "description here" --include-config --include-logs
    ```
 
    Get confirmation before proceeding.

--- a/clash-plugin/skills/deny/SKILL.md
+++ b/clash-plugin/skills/deny/SKILL.md
@@ -9,7 +9,6 @@ Help the user add a **deny** rule to their clash policy by editing the `.star` p
 1. **Determine the rule** from the conversation context. Consider what the user wants to block:
    - Exec: `exe("git", args = ["push"]).deny()` — block git push
    - Exec broad: `exe("sudo").deny()` — block sudo commands
-   - Fs: deny writes under home by not granting write access
    - Net: `domains({"evil.com": deny})` — block network access to a domain
    - If unsure, ask the user what they want to deny.
 

--- a/clash-plugin/skills/dogfood/SKILL.md
+++ b/clash-plugin/skills/dogfood/SKILL.md
@@ -17,10 +17,10 @@ Run the init command:
 clash init
 ```
 
-If clash is already configured, `init` will interactively ask whether to reconfigure from scratch or update the existing configuration.
+The user can choose `user` (global) or `project` (repo-scoped). If clash is already configured, `init` will create alongside the existing configuration.
 
 ## Explain what was created
 
 After initialization, run `clash status` and summarize briefly what Claude can and cannot do.
 
-Suggest they run `clash edit` in their terminal for interactive configuration, or use `/clash:edit` to customize individual rules.
+Suggest they run `clash policy edit` to open their policy in $EDITOR, or use `/clash:edit` to customize individual rules.

--- a/clash-plugin/skills/edit/SKILL.md
+++ b/clash-plugin/skills/edit/SKILL.md
@@ -41,22 +41,28 @@ Read the policy file, then insert the appropriate rule into the `rules = [...]` 
   ```python
   exe("git", args = ["push"]).deny()
   ```
-- Allow filesystem reads under cwd:
-  ```python
-  cwd(read = allow)
-  ```
-- Allow filesystem read/write/create under cwd:
-  ```python
-  cwd(follow_worktrees = True, read = allow, write = allow)
-  ```
 - Allow network access to a domain:
   ```python
   domains({"github.com": allow})
   ```
-- Access to a subdirectory of home:
+- Allow filesystem reads under cwd (via sandbox on a tool/exe rule):
   ```python
-  home().child(".ssh", read = allow)
+  fs_sandbox = sandbox(fs=[cwd(read = allow)])
+  tool(["Read", "Glob", "Grep"]).sandbox(fs_sandbox).allow()
   ```
+- Allow filesystem read/write/create under cwd:
+  ```python
+  fs_sandbox = sandbox(fs=[cwd(follow_worktrees = True, read = allow, write = allow)])
+  tool(["Read", "Glob", "Grep"]).sandbox(fs_sandbox).allow()
+  tool(["Write", "Edit"]).sandbox(fs_sandbox).allow()
+  ```
+- Access to a subdirectory of home (via sandbox):
+  ```python
+  ssh_sandbox = sandbox(fs=[home().child(".ssh", read = allow)])
+  exe("ssh").sandbox(ssh_sandbox).allow()
+  ```
+
+**Important:** Filesystem path entries (`cwd`, `home`, `tempdir`, `path`) cannot appear directly in the `rules = [...]` list. They must be wrapped in a `sandbox()` and attached to a `tool()` or `exe()` rule.
 
 Make sure any new builders are added to the `load()` statement at the top of the file.
 

--- a/clash-plugin/skills/explain/SKILL.md
+++ b/clash-plugin/skills/explain/SKILL.md
@@ -10,17 +10,17 @@ Ask the user what tool invocation they want to understand. Examples:
 Run the explain command with the tool type and the command/path:
 
 ```bash
-clash policy explain bash "git push"
-clash policy explain read "/etc/passwd"
-clash policy explain write "/tmp/output.txt"
-clash policy explain edit "src/main.rs"
-clash policy explain tool "ExitPlanMode"
+clash explain bash "git push"
+clash explain read "/etc/passwd"
+clash explain write "/tmp/output.txt"
+clash explain edit "src/main.rs"
+clash explain tool "ExitPlanMode"
 ```
 
 For machine-readable output (useful when chaining with other tools):
 
 ```bash
-clash policy explain bash "git push" --json
+clash explain bash "git push" --json
 ```
 
 Parse and present the results clearly:

--- a/clash-plugin/skills/onboard/SKILL.md
+++ b/clash-plugin/skills/onboard/SKILL.md
@@ -14,18 +14,18 @@ description: Interactively create your clash policy
 1. **Check current state.** Run `clash policy list 2>&1` to see if rules exist.
 
 2. **If no rules exist** (fresh install or empty policy):
-   - Tell the user: "You don't have any policy rules yet. The easiest way to set up clash is the interactive policy editor."
-   - Instruct them to run `clash edit` in their terminal (NOT inside this chat — the editor uses interactive terminal prompts with tab completion).
+   - Tell the user: "You don't have any policy rules yet. The easiest way to set up clash is the init command."
+   - Instruct them to run `clash init` in their terminal to create a policy with safe defaults. They can choose `user` (global) or `project` (repo-scoped).
    - If they can't run it right now, mention they can also use `/clash:edit` to add rules one at a time.
 
 3. **If rules already exist:**
    - Run `clash status 2>&1` and summarize what Claude can and cannot do in 2-3 plain-English sentences.
    - Ask: "Want to change anything?"
-   - If yes → point them to `clash edit` for a full reconfigure, or `/clash:allow` and `/clash:deny` for quick single-rule changes.
+   - If yes → point them to `clash policy edit` to open their policy in $EDITOR, or `/clash:allow` and `/clash:deny` for quick single-rule changes.
    - If no → "You're all set."
 
-4. **Done.** One sentence: "Use `/clash:edit` anytime to tweak rules, or `clash edit` to reconfigure from scratch."
+4. **Done.** One sentence: "Use `/clash:edit` anytime to tweak rules, or `clash init` to reconfigure from scratch."
 
 ## Important
 
-Do NOT ask configuration questions yourself. The CLI policy editor (`clash edit`) handles interactive configuration in the terminal with tab completion, inline help, and rule testing. This skill is a thin wrapper that checks state and directs the user to the right tool.
+Do NOT ask configuration questions yourself. The CLI init command (`clash init`) handles interactive configuration with safe defaults. This skill is a thin wrapper that checks state and directs the user to the right tool.

--- a/clash-plugin/skills/status/SKILL.md
+++ b/clash-plugin/skills/status/SKILL.md
@@ -19,4 +19,4 @@ Report the results to the user in plain English, including:
 For more detail, suggest:
 - `/clash:describe` for a full policy breakdown
 - `/clash:edit` to make changes
-- `clash edit` in the terminal for interactive reconfiguration
+- `clash policy edit` in the terminal to open the policy file in your editor

--- a/clash-plugin/skills/test/SKILL.md
+++ b/clash-plugin/skills/test/SKILL.md
@@ -8,13 +8,13 @@ Ask the user what tool use they want to test, or use what they already described
 - "Test `git push` to origin main"
 - "What if I write to `~/.ssh/config`?"
 
-Run each test through clash explain using the simple CLI syntax:
+Run each test through clash explain using the top-level command:
 
 ```bash
-clash policy explain bash "rm -rf /" --json
-clash policy explain read "/etc/passwd" --json
-clash policy explain bash "git push origin main" --json
-clash policy explain write "~/.ssh/config" --json
+clash explain bash "rm -rf /" --json
+clash explain read "/etc/passwd" --json
+clash explain bash "git push origin main" --json
+clash explain write "~/.ssh/config" --json
 ```
 
 Parse the JSON output and present results clearly with visual indicators:


### PR DESCRIPTION
## Summary

- Fix `clash policy explain` → `clash explain` (top-level command) in explain/test skills
- Fix `clash edit` (non-existent) → `clash policy edit` / `clash init` in status/onboard/dogfood skills
- Fix bare path entries in Starlark examples — must be wrapped in `sandbox()` and attached to `tool()`/`exe()` per current DSL (edit/allow/deny/amend skills + README)
- Fix `clash bug` positional title → `--title`/`--description` flags in bug-report skill
- Replace manual `~/.clash/audit.jsonl` file reading with `clash debug log` in audit skill
- Update README policy examples to match current sandbox-wrapped pattern

No Rust code changes — skills and docs only.

Closes #250

## Test plan

- [ ] Verify each skill's CLI commands match `clash commands --all` output
- [ ] Verify Starlark examples compile with `clash policy validate`
- [ ] Spot-check `/clash:explain`, `/clash:audit`, `/clash:bug-report` in a live session