### PR TITLE
feat(cli): add clash uninstall command

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,7 @@
 * `clash` is an installed binary on the user's PATH. ALWAYS run it directly as `clash` (e.g., `clash status`, `clash policy list`).
 * NEVER use `cargo run --bin clash` to run clash. That is for building/testing the crate, not for invoking the tool.
 * Skills reference `clash` commands — execute them exactly as written.
-* Available CLI commands: `clash init`, `clash status`, `clash policy list`, `clash policy validate`, `clash policy show`, `clash explain`, `clash doctor`, `clash update`, `clash launch`, `clash sandbox`.
+* Available CLI commands: `clash init`, `clash uninstall`, `clash status`, `clash policy list`, `clash policy validate`, `clash policy show`, `clash explain`, `clash doctor`, `clash update`, `clash launch`, `clash sandbox`.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -325,25 +325,12 @@ Clash stays installed but becomes a complete pass-through — no policy enforcem
 ### Uninstall completely
 
 ```bash
-# 1. Remove the Claude Code plugin
-claude plugin uninstall clash
-
-# 2. Remove the binary
-cargo uninstall clash          # if installed via cargo
-rm -f ~/.local/bin/clash       # if installed via the install script
-
-# 3. (Optional) Remove the plugin marketplace entry
-claude plugin marketplace remove clash
-
-# 4. (Optional) Remove the status line — only needed if you skipped step 2
-clash statusline uninstall
-
-# 5. (Optional) Clean up configuration and logs
-rm -rf ~/.clash       # user-level policy and logs
-rm -rf .clash         # project-level policy (per repo)
+clash uninstall
 ```
 
-After removing the plugin, Claude Code reverts to its built-in permission model. Policy files are left in place so you can pick up where you left off if you reinstall.
+This removes bypass permissions, the Claude Code plugin, the status line, policy files (`~/.clash/`), and the binary itself — regardless of how clash was installed. Use `clash uninstall -y` to skip confirmation prompts.
+
+After uninstalling, Claude Code reverts to its built-in permission model.
 
 ---
 

--- a/clash/src/cli.rs
+++ b/clash/src/cli.rs
@@ -100,6 +100,13 @@ pub enum Commands {
         scope: Option<String>,
     },
 
+    /// Remove clash: undo bypass permissions, uninstall plugin, remove config and binary
+    Uninstall {
+        /// Skip confirmation prompts
+        #[arg(long, short = 'y')]
+        yes: bool,
+    },
+
     /// Show policy status: layers, rules with shadowing, and potential issues
     Status {
         /// Output as JSON instead of human-readable text

--- a/clash/src/cmd/mod.rs
+++ b/clash/src/cmd/mod.rs
@@ -10,4 +10,5 @@ pub mod policy;
 pub mod schema;
 pub mod status;
 pub mod statusline;
+pub mod uninstall;
 pub mod update;

--- a/clash/src/cmd/statusline.rs
+++ b/clash/src/cmd/statusline.rs
@@ -187,6 +187,35 @@ pub fn install() -> Result<()> {
     Ok(())
 }
 
+/// Remove the clash status line, returning whether it was removed.
+///
+/// Used by `clash uninstall` to integrate status line removal into the
+/// teardown flow without duplicate messaging.
+pub fn uninstall_for_teardown() -> Result<bool> {
+    let cs = claude_settings::ClaudeSettings::new();
+    let current = cs.read_or_default(claude_settings::SettingsLevel::User)?;
+
+    match current.extra.get("statusLine") {
+        None => Ok(false),
+        Some(val) => {
+            let is_clash = val
+                .get("command")
+                .and_then(|v| v.as_str())
+                .is_some_and(|c| c.contains("clash statusline"));
+
+            if !is_clash {
+                return Ok(false);
+            }
+
+            cs.update(claude_settings::SettingsLevel::User, |s| {
+                s.extra.remove("statusLine");
+            })?;
+
+            Ok(true)
+        }
+    }
+}
+
 /// Remove the clash status line from Claude Code user settings.
 fn uninstall() -> Result<()> {
     let cs = claude_settings::ClaudeSettings::new();

--- a/clash/src/cmd/uninstall.rs
+++ b/clash/src/cmd/uninstall.rs
@@ -1,0 +1,346 @@
+use anyhow::Result;
+use tracing::{Level, info, instrument, warn};
+
+use crate::settings::ClashSettings;
+use crate::style;
+
+/// Run the uninstall command.
+///
+/// Reverses everything `clash init` does: removes bypass permissions, disables
+/// the plugin, removes the status line, and optionally removes policy files
+/// and the binary itself.
+#[instrument(level = Level::TRACE)]
+pub fn run(yes: bool) -> Result<()> {
+    println!("{}", style::banner());
+    println!();
+    println!("{}", style::header("Uninstall"));
+    println!("{}", style::dim("──────────"));
+    println!();
+
+    if !yes
+        && !dialoguer::Confirm::new()
+            .with_prompt("Uninstall clash? This will remove all clash configuration from Claude Code")
+            .default(true)
+            .interact()
+            .unwrap_or(false)
+    {
+        println!("{} Cancelled.", style::dim("·"));
+        return Ok(());
+    }
+
+    // 1. Remove bypass permissions (the thing the user keeps forgetting).
+    remove_bypass_permissions();
+
+    // 2. Remove the status line.
+    remove_status_line();
+
+    // 3. Disable the plugin in Claude Code settings.
+    disable_plugin();
+
+    // 4. Uninstall the Claude Code plugin via CLI.
+    uninstall_plugin();
+
+    // 5. Remove ~/.clash/ directory.
+    remove_settings_dir(yes);
+
+    // 6. Remove the binary.
+    remove_binary(yes);
+
+    println!();
+    println!(
+        "{} Clash has been uninstalled. To reinstall, run:",
+        style::green_bold("✓"),
+    );
+    println!(
+        "  {}",
+        style::dim("curl -fsSL https://raw.githubusercontent.com/empathic/clash/main/install.sh | bash")
+    );
+    println!(
+        "  {}",
+        style::dim("# or: cargo install clash, or: just install")
+    );
+
+    Ok(())
+}
+
+/// Remove `bypassPermissions` and reset `permissions.defaultMode` in Claude Code settings.
+fn remove_bypass_permissions() {
+    let claude = claude_settings::ClaudeSettings::new();
+
+    // Check current state first.
+    let has_bypass = claude
+        .read(claude_settings::SettingsLevel::User)
+        .ok()
+        .flatten()
+        .is_some_and(|s| s.bypass_permissions == Some(true));
+
+    if !has_bypass {
+        println!(
+            "{} bypassPermissions is not set, nothing to remove.",
+            style::dim("·"),
+        );
+        return;
+    }
+
+    let mut ok = true;
+    if let Err(e) = claude.set_bypass_permissions(claude_settings::SettingsLevel::User, false) {
+        warn!(error = %e, "failed to unset bypassPermissions");
+        eprintln!(
+            "  {} Could not unset bypassPermissions: {e}",
+            style::yellow("!"),
+        );
+        ok = false;
+    }
+
+    if let Err(e) =
+        claude.set_default_permission_mode(claude_settings::SettingsLevel::User, "default")
+    {
+        warn!(error = %e, "failed to reset defaultMode");
+        eprintln!(
+            "  {} Could not reset permissions.defaultMode: {e}",
+            style::yellow("!"),
+        );
+        ok = false;
+    }
+
+    if ok {
+        println!(
+            "{} Removed bypassPermissions from Claude Code settings.",
+            style::green_bold("✓"),
+        );
+    }
+}
+
+/// Remove the clash status line from Claude Code settings.
+fn remove_status_line() {
+    match super::statusline::uninstall_for_teardown() {
+        Ok(true) => {
+            println!(
+                "{} Removed status line from Claude Code settings.",
+                style::green_bold("✓"),
+            );
+        }
+        Ok(false) => {
+            println!(
+                "{} No clash status line configured.",
+                style::dim("·"),
+            );
+        }
+        Err(e) => {
+            warn!(error = %e, "failed to remove status line");
+            eprintln!(
+                "  {} Could not remove status line: {e}",
+                style::yellow("!"),
+            );
+        }
+    }
+}
+
+/// Disable the clash plugin in Claude Code settings.
+fn disable_plugin() {
+    let claude = claude_settings::ClaudeSettings::new();
+
+    let is_enabled = claude
+        .read(claude_settings::SettingsLevel::User)
+        .ok()
+        .flatten()
+        .and_then(|s| s.enabled_plugins)
+        .and_then(|p| p.get("clash").copied())
+        .unwrap_or(false);
+
+    if !is_enabled {
+        println!(
+            "{} clash plugin is not enabled in settings.",
+            style::dim("·"),
+        );
+        return;
+    }
+
+    if let Err(e) =
+        claude.set_plugin_enabled(claude_settings::SettingsLevel::User, "clash", false)
+    {
+        warn!(error = %e, "failed to disable plugin in settings");
+        eprintln!(
+            "  {} Could not disable clash plugin: {e}",
+            style::yellow("!"),
+        );
+        return;
+    }
+
+    println!(
+        "{} Disabled clash plugin in Claude Code settings.",
+        style::green_bold("✓"),
+    );
+}
+
+/// Uninstall the Claude Code plugin via the `claude` CLI.
+fn uninstall_plugin() {
+    let output = std::process::Command::new("claude")
+        .args(["plugin", "uninstall", "clash"])
+        .output();
+
+    match output {
+        Ok(o) if o.status.success() => {
+            info!("claude plugin uninstall succeeded");
+            println!(
+                "{} Uninstalled clash plugin from Claude Code.",
+                style::green_bold("✓"),
+            );
+        }
+        Ok(o) => {
+            let stderr = String::from_utf8_lossy(&o.stderr);
+            // "not installed" / "not found" is fine — nothing to uninstall.
+            if stderr.contains("not") {
+                info!("plugin was not installed, skipping");
+                println!(
+                    "{} clash plugin was not installed in Claude Code.",
+                    style::dim("·"),
+                );
+            } else {
+                warn!(stderr = %stderr, "claude plugin uninstall failed");
+                eprintln!(
+                    "  {} Could not uninstall plugin: {stderr}",
+                    style::yellow("!"),
+                );
+            }
+        }
+        Err(e) => {
+            warn!(error = %e, "claude CLI not found");
+            eprintln!(
+                "  {} Could not run `claude plugin uninstall`: {e}",
+                style::yellow("!"),
+            );
+        }
+    }
+}
+
+/// Remove the `~/.clash/` settings directory.
+fn remove_settings_dir(yes: bool) {
+    let dir = match ClashSettings::settings_dir() {
+        Ok(d) => d,
+        Err(e) => {
+            warn!(error = %e, "could not determine settings directory");
+            return;
+        }
+    };
+
+    if !dir.exists() {
+        println!(
+            "{} {} does not exist, nothing to remove.",
+            style::dim("·"),
+            dir.display(),
+        );
+        return;
+    }
+
+    if !yes
+        && !dialoguer::Confirm::new()
+            .with_prompt(format!(
+                "Remove {}? (contains your policy files)",
+                dir.display()
+            ))
+            .default(true)
+            .interact()
+            .unwrap_or(false)
+    {
+        println!(
+            "{} Kept {}.",
+            style::dim("·"),
+            dir.display(),
+        );
+        return;
+    }
+
+    if let Err(e) = std::fs::remove_dir_all(&dir) {
+        warn!(error = %e, path = %dir.display(), "failed to remove settings directory");
+        eprintln!(
+            "  {} Could not remove {}: {e}",
+            style::yellow("!"),
+            dir.display(),
+        );
+        return;
+    }
+
+    println!(
+        "{} Removed {}.",
+        style::green_bold("✓"),
+        dir.display(),
+    );
+}
+
+/// Find and remove the clash binary.
+fn remove_binary(yes: bool) {
+    let binary_path = match find_clash_binary() {
+        Some(p) => p,
+        None => {
+            println!(
+                "{} clash binary not found on PATH.",
+                style::dim("·"),
+            );
+            return;
+        }
+    };
+
+    // Don't remove the binary we're currently running from if it's a dev build
+    // (e.g., inside a cargo target directory).
+    if binary_path.contains("/target/") {
+        println!(
+            "{} Skipping binary removal (looks like a development build at {}).",
+            style::dim("·"),
+            binary_path,
+        );
+        return;
+    }
+
+    if !yes
+        && !dialoguer::Confirm::new()
+            .with_prompt(format!("Remove clash binary at {}?", binary_path))
+            .default(true)
+            .interact()
+            .unwrap_or(false)
+    {
+        println!(
+            "{} Kept binary at {}.",
+            style::dim("·"),
+            binary_path,
+        );
+        return;
+    }
+
+    if let Err(e) = std::fs::remove_file(&binary_path) {
+        warn!(error = %e, path = %binary_path, "failed to remove binary");
+        eprintln!(
+            "  {} Could not remove {}: {e}",
+            style::yellow("!"),
+            binary_path,
+        );
+        return;
+    }
+
+    println!(
+        "{} Removed {}.",
+        style::green_bold("✓"),
+        binary_path,
+    );
+}
+
+/// Locate the clash binary on PATH.
+fn find_clash_binary() -> Option<String> {
+    std::process::Command::new("which")
+        .arg("clash")
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+        .filter(|s| !s.is_empty())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn find_clash_binary_does_not_panic() {
+        let _ = find_clash_binary();
+    }
+}

--- a/clash/src/main.rs
+++ b/clash/src/main.rs
@@ -16,6 +16,7 @@ fn main() -> Result<()> {
     debug_span!("main", cmd = ?cli.command).in_scope(|| {
         let resp = match cli.command {
             Commands::Init { no_bypass, scope } => cmd::init::run(no_bypass, scope),
+            Commands::Uninstall { yes } => cmd::uninstall::run(yes),
             Commands::Status { json } => cmd::status::run(json, cli.verbose),
             Commands::ShowCommands { json, all } => cmd::commands::run(json, all),
             Commands::Explain { json, tool, args } => {


### PR DESCRIPTION
## Summary

- Adds `clash uninstall` command that reverses everything `clash init` does, regardless of installation method (`cargo install`, `curl | bash`, `just install`)
- Removes bypass permissions (`bypassPermissions` and `permissions.defaultMode`) from Claude Code settings — the thing that is easy to forget
- Uninstalls the Claude Code plugin, removes the status line, deletes `~/.clash/` config directory, and removes the binary itself
- Supports `-y` flag for non-interactive use

## Changes

- **`clash/src/cmd/uninstall.rs`** — new command implementation with step-by-step teardown
- **`clash/src/cmd/statusline.rs`** — added `uninstall_for_teardown()` helper that returns whether removal happened
- **`clash/src/cli.rs`** — added `Uninstall` variant to `Commands` enum
- **`clash/src/main.rs`** — dispatch for new command
- **`AGENTS.md`** — listed `clash uninstall` in available CLI commands
- **`README.md`** — simplified the uninstall section to just `clash uninstall`

## Test plan

- [x] `cargo build` — clean, no warnings
- [x] `cargo test -p clash --lib cmd::uninstall` — passes
- [ ] Manual: `clash uninstall` removes bypass permissions, plugin, status line, ~/.clash/, and binary
- [ ] Manual: `clash uninstall -y` skips all confirmation prompts
- [ ] Manual: `clash uninstall` on a fresh system (no clash config) completes gracefully

Closes #245