### PR TITLE
refactor(starlark): unify sandbox args and move DSL to pure Starlark

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -564,6 +564,7 @@ dependencies = [
  "anyhow",
  "include_dir",
  "regex",
+ "serde",
  "serde_json",
  "starlark",
  "tempfile",

--- a/clash/src/cmd/uninstall.rs
+++ b/clash/src/cmd/uninstall.rs
@@ -19,7 +19,9 @@ pub fn run(yes: bool) -> Result<()> {
 
     if !yes
         && !dialoguer::Confirm::new()
-            .with_prompt("Uninstall clash? This will remove all clash configuration from Claude Code")
+            .with_prompt(
+                "Uninstall clash? This will remove all clash configuration from Claude Code",
+            )
             .default(true)
             .interact()
             .unwrap_or(false)
@@ -53,7 +55,9 @@ pub fn run(yes: bool) -> Result<()> {
     );
     println!(
         "  {}",
-        style::dim("curl -fsSL https://raw.githubusercontent.com/empathic/clash/main/install.sh | bash")
+        style::dim(
+            "curl -fsSL https://raw.githubusercontent.com/empathic/clash/main/install.sh | bash"
+        )
     );
     println!(
         "  {}",
@@ -121,17 +125,11 @@ fn remove_status_line() {
             );
         }
         Ok(false) => {
-            println!(
-                "{} No clash status line configured.",
-                style::dim("·"),
-            );
+            println!("{} No clash status line configured.", style::dim("·"),);
         }
         Err(e) => {
             warn!(error = %e, "failed to remove status line");
-            eprintln!(
-                "  {} Could not remove status line: {e}",
-                style::yellow("!"),
-            );
+            eprintln!("  {} Could not remove status line: {e}", style::yellow("!"),);
         }
     }
 }
@@ -156,8 +154,7 @@ fn disable_plugin() {
         return;
     }
 
-    if let Err(e) =
-        claude.set_plugin_enabled(claude_settings::SettingsLevel::User, "clash", false)
+    if let Err(e) = claude.set_plugin_enabled(claude_settings::SettingsLevel::User, "clash", false)
     {
         warn!(error = %e, "failed to disable plugin in settings");
         eprintln!(
@@ -243,11 +240,7 @@ fn remove_settings_dir(yes: bool) {
             .interact()
             .unwrap_or(false)
     {
-        println!(
-            "{} Kept {}.",
-            style::dim("·"),
-            dir.display(),
-        );
+        println!("{} Kept {}.", style::dim("·"), dir.display(),);
         return;
     }
 
@@ -261,11 +254,7 @@ fn remove_settings_dir(yes: bool) {
         return;
     }
 
-    println!(
-        "{} Removed {}.",
-        style::green_bold("✓"),
-        dir.display(),
-    );
+    println!("{} Removed {}.", style::green_bold("✓"), dir.display(),);
 }
 
 /// Find and remove the clash binary.
@@ -273,10 +262,7 @@ fn remove_binary(yes: bool) {
     let binary_path = match find_clash_binary() {
         Some(p) => p,
         None => {
-            println!(
-                "{} clash binary not found on PATH.",
-                style::dim("·"),
-            );
+            println!("{} clash binary not found on PATH.", style::dim("·"),);
             return;
         }
     };
@@ -299,11 +285,7 @@ fn remove_binary(yes: bool) {
             .interact()
             .unwrap_or(false)
     {
-        println!(
-            "{} Kept binary at {}.",
-            style::dim("·"),
-            binary_path,
-        );
+        println!("{} Kept binary at {}.", style::dim("·"), binary_path,);
         return;
     }
 
@@ -317,11 +299,7 @@ fn remove_binary(yes: bool) {
         return;
     }
 
-    println!(
-        "{} Removed {}.",
-        style::green_bold("✓"),
-        binary_path,
-    );
+    println!("{} Removed {}.", style::green_bold("✓"), binary_path,);
 }
 
 /// Locate the clash binary on PATH.

--- a/clash/src/policy/sandbox_types.rs
+++ b/clash/src/policy/sandbox_types.rs
@@ -72,8 +72,29 @@ impl Cap {
         Ok(result)
     }
 
+    /// Return capabilities as a list of name strings.
+    pub fn to_list(&self) -> Vec<&'static str> {
+        let mut names = Vec::new();
+        if self.contains(Cap::READ) {
+            names.push("read");
+        }
+        if self.contains(Cap::WRITE) {
+            names.push("write");
+        }
+        if self.contains(Cap::CREATE) {
+            names.push("create");
+        }
+        if self.contains(Cap::DELETE) {
+            names.push("delete");
+        }
+        if self.contains(Cap::EXECUTE) {
+            names.push("execute");
+        }
+        names
+    }
+
     /// Parse a single capability name.
-    fn parse_single(s: &str) -> Result<Cap, String> {
+    pub fn parse_single(s: &str) -> Result<Cap, String> {
         match s {
             "read" => Ok(Cap::READ),
             "write" => Ok(Cap::WRITE),
@@ -109,14 +130,47 @@ impl Cap {
 
 impl Serialize for Cap {
     fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        serializer.serialize_str(&self.display())
+        use serde::ser::SerializeSeq;
+        let names = self.to_list();
+        let mut seq = serializer.serialize_seq(Some(names.len()))?;
+        for name in &names {
+            seq.serialize_element(name)?;
+        }
+        seq.end()
     }
 }
 
 impl<'de> Deserialize<'de> for Cap {
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        let s = String::deserialize(deserializer)?;
-        Cap::parse(&s).map_err(serde::de::Error::custom)
+        use serde::de;
+
+        struct CapVisitor;
+
+        impl<'de> de::Visitor<'de> for CapVisitor {
+            type Value = Cap;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                formatter.write_str(r#"a list of capabilities like ["read", "write"] or a string like "read + write""#)
+            }
+
+            // TODO(0.4.1): remove legacy string format support (e.g. "read + write")
+            fn visit_str<E: de::Error>(self, value: &str) -> Result<Cap, E> {
+                Cap::parse(value).map_err(de::Error::custom)
+            }
+
+            fn visit_seq<A: de::SeqAccess<'de>>(self, mut seq: A) -> Result<Cap, A::Error> {
+                let mut caps = Cap::empty();
+                while let Some(name) = seq.next_element::<String>()? {
+                    caps |= Cap::parse_single(&name).map_err(de::Error::custom)?;
+                }
+                if caps.is_empty() {
+                    return Err(de::Error::custom("capability list must not be empty"));
+                }
+                Ok(caps)
+            }
+        }
+
+        deserializer.deserialize_any(CapVisitor)
     }
 }
 
@@ -427,9 +481,16 @@ mod tests {
     fn test_cap_serde_roundtrip() {
         let caps = Cap::READ | Cap::WRITE | Cap::CREATE;
         let json = serde_json::to_string(&caps).unwrap();
-        assert_eq!(json, r#""read + write + create""#);
+        assert_eq!(json, r#"["read","write","create"]"#);
         let deserialized: Cap = serde_json::from_str(&json).unwrap();
         assert_eq!(deserialized, caps);
+    }
+
+    #[test]
+    fn test_cap_deserialize_string_compat() {
+        // String format still accepted for backwards compat
+        let caps: Cap = serde_json::from_str(r#""read + write""#).unwrap();
+        assert_eq!(caps, Cap::READ | Cap::WRITE);
     }
 
     #[test]

--- a/clash_starlark/Cargo.toml
+++ b/clash_starlark/Cargo.toml
@@ -11,6 +11,7 @@ documentation.workspace = true
 [dependencies]
 starlark = { workspace = true }
 allocative = "0.3"
+serde = { workspace = true }
 serde_json = { workspace = true }
 anyhow = { workspace = true }
 regex = { workspace = true }

--- a/clash_starlark/src/builders/match_tree.rs
+++ b/clash_starlark/src/builders/match_tree.rs
@@ -11,7 +11,7 @@ use serde_json::{Value as JsonValue, json};
 use starlark::starlark_simple_value;
 use starlark::values::list::ListRef;
 use starlark::values::{
-    Heap, NoSerialize, ProvidesStaticType, StarlarkValue, Trace, Value, ValueLike, starlark_value,
+    Heap, ProvidesStaticType, StarlarkValue, Trace, Value, ValueLike, starlark_value,
 };
 
 // ---------------------------------------------------------------------------
@@ -19,10 +19,16 @@ use starlark::values::{
 // ---------------------------------------------------------------------------
 
 /// A match tree node value in Starlark — represents a Condition or Decision node.
-#[derive(Debug, Clone, ProvidesStaticType, NoSerialize, Allocative)]
+#[derive(Debug, Clone, ProvidesStaticType, Allocative)]
 pub struct MatchTreeNode {
     #[allocative(skip)]
     pub json: JsonValue,
+}
+
+impl serde::Serialize for MatchTreeNode {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        self.json.serialize(serializer)
+    }
 }
 
 unsafe impl Trace<'_> for MatchTreeNode {
@@ -140,8 +146,8 @@ fn set_children_on_deepest_leaf(json: &mut JsonValue, children: Vec<JsonValue>) 
 // Builder functions (registered as Starlark globals)
 // ---------------------------------------------------------------------------
 
-/// Create a condition node with a string observable.
-pub fn mt_condition(observe: &str, pattern: JsonValue) -> MatchTreeNode {
+/// Create a condition node. `observe` is JSON (string or structured).
+pub fn mt_condition(observe: JsonValue, pattern: JsonValue) -> MatchTreeNode {
     MatchTreeNode {
         json: json!({
             "condition": {
@@ -150,146 +156,6 @@ pub fn mt_condition(observe: &str, pattern: JsonValue) -> MatchTreeNode {
                 "children": []
             }
         }),
-    }
-}
-
-/// Create a condition node for tool name matching.
-pub fn mt_tool(pattern: JsonValue) -> MatchTreeNode {
-    MatchTreeNode {
-        json: json!({
-            "condition": {
-                "observe": "tool_name",
-                "pattern": pattern,
-                "children": []
-            }
-        }),
-    }
-}
-
-/// Create a condition node for exe (Bash command) matching.
-/// This expands to: ToolName="Bash" → PositionalArg(0)=pattern
-pub fn mt_exe(pattern: JsonValue) -> MatchTreeNode {
-    MatchTreeNode {
-        json: json!({
-            "condition": {
-                "observe": "tool_name",
-                "pattern": {"literal": {"literal": "Bash"}},
-                "children": [{
-                    "condition": {
-                        "observe": {"positional_arg": 0},
-                        "pattern": pattern,
-                        "children": []
-                    }
-                }]
-            }
-        }),
-    }
-}
-
-/// Create a condition node for hook type matching.
-pub fn mt_hook(pattern: JsonValue) -> MatchTreeNode {
-    MatchTreeNode {
-        json: json!({
-            "condition": {
-                "observe": "hook_type",
-                "pattern": pattern,
-                "children": []
-            }
-        }),
-    }
-}
-
-/// Create a condition node for agent name matching.
-pub fn mt_agent(pattern: JsonValue) -> MatchTreeNode {
-    MatchTreeNode {
-        json: json!({
-            "condition": {
-                "observe": "agent_name",
-                "pattern": pattern,
-                "children": []
-            }
-        }),
-    }
-}
-
-/// Create a condition node for positional arg matching.
-pub fn mt_arg(n: i32, pattern: JsonValue) -> MatchTreeNode {
-    MatchTreeNode {
-        json: json!({
-            "condition": {
-                "observe": {"positional_arg": n},
-                "pattern": pattern,
-                "children": []
-            }
-        }),
-    }
-}
-
-/// Create a condition node for has_arg matching.
-pub fn mt_has_arg(pattern: JsonValue) -> MatchTreeNode {
-    MatchTreeNode {
-        json: json!({
-            "condition": {
-                "observe": "has_arg",
-                "pattern": pattern,
-                "children": []
-            }
-        }),
-    }
-}
-
-/// Create a condition node for named arg matching.
-pub fn mt_named(name: &str, pattern: JsonValue) -> MatchTreeNode {
-    MatchTreeNode {
-        json: json!({
-            "condition": {
-                "observe": {"named_arg": name},
-                "pattern": pattern,
-                "children": []
-            }
-        }),
-    }
-}
-
-/// Create a condition node for nested field matching.
-pub fn mt_field(path: Vec<String>, pattern: JsonValue) -> MatchTreeNode {
-    MatchTreeNode {
-        json: json!({
-            "condition": {
-                "observe": {"nested_field": path},
-                "pattern": pattern,
-                "children": []
-            }
-        }),
-    }
-}
-
-/// Create a decision node.
-pub fn mt_decision_allow(sandbox: Option<&str>) -> MatchTreeNode {
-    let decision = if let Some(sb) = sandbox {
-        json!({"allow": sb})
-    } else {
-        json!({"allow": null})
-    };
-    MatchTreeNode {
-        json: json!({"decision": decision}),
-    }
-}
-
-pub fn mt_decision_deny() -> MatchTreeNode {
-    MatchTreeNode {
-        json: json!({"decision": "deny"}),
-    }
-}
-
-pub fn mt_decision_ask(sandbox: Option<&str>) -> MatchTreeNode {
-    let decision = if let Some(sb) = sandbox {
-        json!({"ask": sb})
-    } else {
-        json!({"ask": null})
-    };
-    MatchTreeNode {
-        json: json!({"decision": decision}),
     }
 }
 
@@ -343,14 +209,4 @@ pub fn path_value_to_json<'v>(value: Value<'v>, heap: &'v Heap) -> anyhow::Resul
         }
     }
     anyhow::bail!("cannot convert {} to a path value", value.get_type())
-}
-
-/// Convert a Starlark not() pattern value to JSON.
-pub fn not_pattern_to_json(inner: JsonValue) -> JsonValue {
-    json!({"not": inner})
-}
-
-/// Convert a Starlark or() pattern value to JSON.
-pub fn or_pattern_to_json(items: Vec<JsonValue>) -> JsonValue {
-    json!({"any_of": items})
 }

--- a/clash_starlark/src/globals.rs
+++ b/clash_starlark/src/globals.rs
@@ -8,10 +8,7 @@ use starlark::starlark_module;
 use starlark::values::{Value, ValueLike};
 
 use crate::builders::base::BasePolicyValue;
-use crate::builders::match_tree::{
-    self as mt, MatchTreeNode, not_pattern_to_json, or_pattern_to_json, path_value_to_json,
-    pattern_to_json,
-};
+use crate::builders::match_tree::{self as mt, MatchTreeNode, path_value_to_json, pattern_to_json};
 
 /// Build the globals environment with all Clash DSL functions and constants.
 pub fn clash_globals() -> starlark::environment::Globals {
@@ -33,8 +30,30 @@ fn register_globals(builder: &mut GlobalsBuilder) {
     const deny: &str = "deny";
     const ask: &str = "ask";
 
-    // -- Match tree primitives (used by @clash//std.star and @clash//match_tree.star) --
+    // -- Minimal Rust primitives (everything else is in @clash//std.star) --
 
+    /// Wrap an arbitrary dict/value as a MatchTreeNode.
+    /// This is the escape hatch that lets Starlark code build any node shape.
+    fn _mt_node<'v>(#[starlark(require = pos)] value: Value<'v>) -> anyhow::Result<MatchTreeNode> {
+        let json = starlark_to_json(value)?;
+        Ok(MatchTreeNode { json })
+    }
+
+    /// Generic condition builder. `observe` can be a string ("tool_name")
+    /// or a dict ({"positional_arg": 0}). `pattern` is a MatchTreeNode from _mt_pattern().
+    fn _mt_condition<'v>(
+        #[starlark(require = pos)] observe: Value<'v>,
+        #[starlark(require = pos)] pattern: &MatchTreeNode,
+    ) -> anyhow::Result<MatchTreeNode> {
+        let observe_json = starlark_to_json(observe)?;
+        Ok(mt::mt_condition(observe_json, pattern.json.clone()))
+    }
+
+    /// Convert a value to a matcher pattern (type dispatch in Rust).
+    /// - None          → wildcard
+    /// - "foo"         → literal
+    /// - ["a", "b"]    → any_of
+    /// - regex("...")  → regex
     fn _mt_pattern<'v>(
         #[starlark(require = pos)] value: Value<'v>,
         heap: &'v starlark::values::Heap,
@@ -43,68 +62,7 @@ fn register_globals(builder: &mut GlobalsBuilder) {
         Ok(MatchTreeNode { json: pat })
     }
 
-    fn _mt_exe<'v>(
-        #[starlark(require = pos)] pattern: &MatchTreeNode,
-    ) -> anyhow::Result<MatchTreeNode> {
-        Ok(mt::mt_exe(pattern.json.clone()))
-    }
-
-    fn _mt_tool<'v>(
-        #[starlark(require = pos)] pattern: &MatchTreeNode,
-    ) -> anyhow::Result<MatchTreeNode> {
-        Ok(mt::mt_tool(pattern.json.clone()))
-    }
-
-    fn _mt_hook<'v>(
-        #[starlark(require = pos)] pattern: &MatchTreeNode,
-    ) -> anyhow::Result<MatchTreeNode> {
-        Ok(mt::mt_hook(pattern.json.clone()))
-    }
-
-    fn _mt_agent<'v>(
-        #[starlark(require = pos)] pattern: &MatchTreeNode,
-    ) -> anyhow::Result<MatchTreeNode> {
-        Ok(mt::mt_agent(pattern.json.clone()))
-    }
-
-    fn _mt_arg(
-        #[starlark(require = pos)] n: i32,
-        #[starlark(require = pos)] pattern: &MatchTreeNode,
-    ) -> anyhow::Result<MatchTreeNode> {
-        Ok(mt::mt_arg(n, pattern.json.clone()))
-    }
-
-    fn _mt_has_arg<'v>(
-        #[starlark(require = pos)] pattern: &MatchTreeNode,
-    ) -> anyhow::Result<MatchTreeNode> {
-        Ok(mt::mt_has_arg(pattern.json.clone()))
-    }
-
-    fn _mt_named<'v>(
-        #[starlark(require = pos)] name: &str,
-        #[starlark(require = pos)] pattern: &MatchTreeNode,
-    ) -> anyhow::Result<MatchTreeNode> {
-        Ok(mt::mt_named(name, pattern.json.clone()))
-    }
-
-    fn _mt_fs_op<'v>(
-        #[starlark(require = pos)] pattern: &MatchTreeNode,
-    ) -> anyhow::Result<MatchTreeNode> {
-        Ok(mt::mt_condition("fs_op", pattern.json.clone()))
-    }
-
-    fn _mt_fs_path<'v>(
-        #[starlark(require = pos)] pattern: &MatchTreeNode,
-    ) -> anyhow::Result<MatchTreeNode> {
-        Ok(mt::mt_condition("fs_path", pattern.json.clone()))
-    }
-
-    fn _mt_net_domain<'v>(
-        #[starlark(require = pos)] pattern: &MatchTreeNode,
-    ) -> anyhow::Result<MatchTreeNode> {
-        Ok(mt::mt_condition("net_domain", pattern.json.clone()))
-    }
-
+    /// Convert a path value to a prefix pattern (needs Rust for env/join dispatch).
     fn _mt_prefix<'v>(
         #[starlark(require = pos)] value: Value<'v>,
         heap: &'v starlark::values::Heap,
@@ -112,69 +70,6 @@ fn register_globals(builder: &mut GlobalsBuilder) {
         let val_json = path_value_to_json(value, heap)?;
         Ok(MatchTreeNode {
             json: serde_json::json!({"prefix": val_json}),
-        })
-    }
-
-    fn _mt_field<'v>(
-        #[starlark(require = pos)] path: Value<'v>,
-        #[starlark(require = pos)] pattern: &MatchTreeNode,
-    ) -> anyhow::Result<MatchTreeNode> {
-        let list = starlark::values::list::ListRef::from_value(path)
-            .ok_or_else(|| anyhow::anyhow!("field() path must be a list of strings"))?;
-        let segments: Result<Vec<String>, _> = list
-            .iter()
-            .map(|v| {
-                v.unpack_str()
-                    .map(|s| s.to_string())
-                    .ok_or_else(|| anyhow::anyhow!("field() path segments must be strings"))
-            })
-            .collect();
-        Ok(mt::mt_field(segments?, pattern.json.clone()))
-    }
-
-    fn _mt_allow(#[starlark(require = pos)] sandbox: Value) -> anyhow::Result<MatchTreeNode> {
-        let sb = if sandbox.is_none() {
-            None
-        } else {
-            sandbox.unpack_str()
-        };
-        Ok(mt::mt_decision_allow(sb))
-    }
-
-    fn _mt_deny() -> anyhow::Result<MatchTreeNode> {
-        Ok(mt::mt_decision_deny())
-    }
-
-    fn _mt_ask(#[starlark(require = pos)] sandbox: Value) -> anyhow::Result<MatchTreeNode> {
-        let sb = if sandbox.is_none() {
-            None
-        } else {
-            sandbox.unpack_str()
-        };
-        Ok(mt::mt_decision_ask(sb))
-    }
-
-    fn _mt_not(
-        #[starlark(require = pos)] pattern: &MatchTreeNode,
-    ) -> anyhow::Result<MatchTreeNode> {
-        Ok(MatchTreeNode {
-            json: not_pattern_to_json(pattern.json.clone()),
-        })
-    }
-
-    fn _mt_or<'v>(#[starlark(require = pos)] patterns: Value<'v>) -> anyhow::Result<MatchTreeNode> {
-        let list = starlark::values::list::ListRef::from_value(patterns)
-            .ok_or_else(|| anyhow::anyhow!("_mt_or requires a list"))?;
-        let items: Result<Vec<_>, _> = list
-            .iter()
-            .map(|v| {
-                v.downcast_ref::<MatchTreeNode>()
-                    .map(|n| n.json.clone())
-                    .ok_or_else(|| anyhow::anyhow!("_mt_or items must be pattern nodes"))
-            })
-            .collect();
-        Ok(MatchTreeNode {
-            json: or_pattern_to_json(items?),
         })
     }
 

--- a/clash_starlark/stdlib/match_tree.star
+++ b/clash_starlark/stdlib/match_tree.star
@@ -1,8 +1,7 @@
 # Clash match tree DSL — tree-shaped policy builders.
 #
-# Rust globals available: _mt_exe, _mt_tool, _mt_hook, _mt_agent, _mt_arg,
-# _mt_has_arg, _mt_named, _mt_field, _mt_allow, _mt_deny, _mt_ask,
-# _mt_pattern, _mt_not, _mt_or, _mt_policy
+# Rust globals available: _mt_node, _mt_condition, _mt_pattern, _mt_prefix,
+# _mt_policy, allow, deny, ask
 
 # ---------------------------------------------------------------------------
 # Pattern helpers (reuse from std.star concepts)
@@ -36,7 +35,9 @@ def exe(name = None):
         ])
         exe("cargo").allow(sandbox="cwd_access")
     """
-    return _mt_exe(_mt_pat(name))
+    inner = _mt_condition({"positional_arg": 0}, _mt_pat(name))
+    bash_pat = _mt_pattern("Bash")
+    return _mt_condition("tool_name", bash_pat).on([inner])
 
 def tool(name = None):
     """Match a tool by name.
@@ -45,7 +46,7 @@ def tool(name = None):
         tool("Read").allow()
         tool().allow()
     """
-    return _mt_tool(_mt_pat(name))
+    return _mt_condition("tool_name", _mt_pat(name))
 
 def hook(name = None):
     """Match a hook type.
@@ -53,7 +54,7 @@ def hook(name = None):
     Usage:
         hook("PreToolUse").on([...])
     """
-    return _mt_hook(_mt_pat(name))
+    return _mt_condition("hook_type", _mt_pat(name))
 
 def agent(name = None):
     """Match an agent by name.
@@ -61,7 +62,7 @@ def agent(name = None):
     Usage:
         agent("code-review").allow()
     """
-    return _mt_agent(_mt_pat(name))
+    return _mt_condition("agent_name", _mt_pat(name))
 
 def arg(n, pattern = None):
     """Match a positional argument.
@@ -69,7 +70,7 @@ def arg(n, pattern = None):
     Usage:
         arg(1, "push").deny()
     """
-    return _mt_arg(n, _mt_pat(pattern))
+    return _mt_condition({"positional_arg": n}, _mt_pat(pattern))
 
 def has_arg(pattern = None):
     """Match if any argument matches (orderless scan).
@@ -77,7 +78,7 @@ def has_arg(pattern = None):
     Usage:
         has_arg("--force").deny()
     """
-    return _mt_has_arg(_mt_pat(pattern))
+    return _mt_condition("has_arg", _mt_pat(pattern))
 
 def named(name, pattern = None):
     """Match a named tool argument.
@@ -85,7 +86,7 @@ def named(name, pattern = None):
     Usage:
         named("file_path", regex(".*\\.env")).deny()
     """
-    return _mt_named(name, _mt_pat(pattern))
+    return _mt_condition({"named_arg": name}, _mt_pat(pattern))
 
 def field(path, pattern = None):
     """Match a nested field in tool_input JSON.
@@ -93,7 +94,7 @@ def field(path, pattern = None):
     Usage:
         field(["command", "args"], "sensitive").deny()
     """
-    return _mt_field(path, _mt_pat(pattern))
+    return _mt_condition({"nested_field": path}, _mt_pat(pattern))
 
 # ---------------------------------------------------------------------------
 # Decision nodes
@@ -106,11 +107,13 @@ def allow(sandbox = None):
         allow()
         allow(sandbox="cwd_access")
     """
-    return _mt_allow(sandbox)
+    if sandbox != None:
+        return _mt_node({"decision": {"allow": sandbox}})
+    return _mt_node({"decision": {"allow": None}})
 
 def deny():
     """Create a deny decision node."""
-    return _mt_deny()
+    return _mt_node({"decision": "deny"})
 
 def ask(sandbox = None):
     """Create an ask decision node.
@@ -119,7 +122,9 @@ def ask(sandbox = None):
         ask()
         ask(sandbox="cwd_access")
     """
-    return _mt_ask(sandbox)
+    if sandbox != None:
+        return _mt_node({"decision": {"ask": sandbox}})
+    return _mt_node({"decision": {"ask": None}})
 
 # ---------------------------------------------------------------------------
 # Pattern combinators
@@ -131,7 +136,7 @@ def or_pat(*args):
     Usage:
         exe(or_pat("cargo", "rustc")).allow()
     """
-    return _mt_or([_mt_pat(a) for a in args])
+    return _mt_node({"any_of": [_mt_pat(a) for a in args]})
 
 def not_pat(pattern):
     """Match if the pattern does NOT match.
@@ -139,7 +144,7 @@ def not_pat(pattern):
     Usage:
         exe(not_pat("rm")).allow()
     """
-    return _mt_not(_mt_pat(pattern))
+    return _mt_node({"not": _mt_pat(pattern)})
 
 # ---------------------------------------------------------------------------
 # Policy wrapper

--- a/clash_starlark/stdlib/std.star
+++ b/clash_starlark/stdlib/std.star
@@ -1,10 +1,8 @@
 # Clash standard library — all DSL builders.
 #
-# Emits v5 match tree nodes using _mt_* Rust primitives.
-# Rust globals available: _mt_pattern, _mt_exe, _mt_tool, _mt_hook, _mt_agent,
-# _mt_arg, _mt_has_arg, _mt_named, _mt_field, _mt_allow, _mt_deny, _mt_ask,
-# _mt_not, _mt_or, _mt_policy, _mt_fs_op, _mt_fs_path, _mt_net_domain,
-# _mt_prefix, allow, deny, ask
+# Emits v5 match tree nodes using minimal Rust primitives.
+# Rust globals available: _mt_node, _mt_condition, _mt_pattern, _mt_prefix,
+# _mt_policy, allow, deny, ask
 
 # ---------------------------------------------------------------------------
 # Pattern helpers
@@ -25,6 +23,80 @@ def regex(pattern):
     return struct(_regex = pattern)
 
 # ---------------------------------------------------------------------------
+# Match tree node builders (pure Starlark over _mt_condition / _mt_node)
+# ---------------------------------------------------------------------------
+
+def _mt_exe(pattern):
+    """Build ToolName=Bash → PosArg(0)=pattern."""
+    inner = _mt_condition({"positional_arg": 0}, pattern)
+    bash_pat = _mt_pattern("Bash")
+    return _mt_condition("tool_name", bash_pat).on([inner])
+
+def _mt_tool(pattern):
+    """Build ToolName=pattern."""
+    return _mt_condition("tool_name", pattern)
+
+def _mt_hook(pattern):
+    """Build HookType=pattern."""
+    return _mt_condition("hook_type", pattern)
+
+def _mt_agent(pattern):
+    """Build AgentName=pattern."""
+    return _mt_condition("agent_name", pattern)
+
+def _mt_arg(n, pattern):
+    """Build PosArg(n)=pattern."""
+    return _mt_condition({"positional_arg": n}, pattern)
+
+def _mt_has_arg(pattern):
+    """Build HasArg=pattern."""
+    return _mt_condition("has_arg", pattern)
+
+def _mt_named(name, pattern):
+    """Build NamedArg(name)=pattern."""
+    return _mt_condition({"named_arg": name}, pattern)
+
+def _mt_field(path, pattern):
+    """Build NestedField(path)=pattern."""
+    return _mt_condition({"nested_field": path}, pattern)
+
+def _mt_fs_op(pattern):
+    """Build FsOp=pattern."""
+    return _mt_condition("fs_op", pattern)
+
+def _mt_fs_path(pattern):
+    """Build FsPath=pattern."""
+    return _mt_condition("fs_path", pattern)
+
+def _mt_net_domain(pattern):
+    """Build NetDomain=pattern."""
+    return _mt_condition("net_domain", pattern)
+
+def _mt_allow(sandbox):
+    """Build an allow decision node."""
+    if sandbox != None:
+        return _mt_node({"decision": {"allow": sandbox}})
+    return _mt_node({"decision": {"allow": None}})
+
+def _mt_deny():
+    """Build a deny decision node."""
+    return _mt_node({"decision": "deny"})
+
+def _mt_ask(sandbox):
+    """Build an ask decision node."""
+    if sandbox != None:
+        return _mt_node({"decision": {"ask": sandbox}})
+    return _mt_node({"decision": {"ask": None}})
+
+def _mt_not(pattern):
+    """Build a negated pattern."""
+    return _mt_node({"not": pattern})
+
+def _mt_or(patterns):
+    """Build an any_of pattern."""
+    return _mt_node({"any_of": patterns})
+
+# ---------------------------------------------------------------------------
 # Exec / tool builders
 # ---------------------------------------------------------------------------
 
@@ -41,48 +113,19 @@ def exe(name = None, args = None):
     node = _mt_exe(_pattern(name))
 
     if args != None:
-        # Chain positional arg conditions for each arg
-        def _wrap_with_args(base, arg_list):
-            """Wrap a condition node with nested positional arg conditions."""
-            inner = base
-            for i in range(len(arg_list) - 1, -1, -1):
-                inner = _mt_arg(i + 1, _pattern(arg_list[i])).on([inner])
-            return inner
-
-        # Create a placeholder that we'll attach args to
-        # The exe() node is ToolName=Bash → PosArg(0)=name → (args here)
-        # We need to modify the inner PosArg(0) node to add arg children
         node = _exe_with_args(name, args)
 
     return _with_sandbox_support(node)
 
 def _exe_with_args(name, args):
     """Build an exe node with positional args already nested."""
-    # Build from inside out: start with the deepest arg
-    # exe("git", args=["push"]) → ToolName=Bash → PosArg(0)=git → PosArg(1)=push → [children]
     pat = _pattern(name)
-    inner_node = _mt_exe(pat)
-    # The inner node is: {condition: {observe: tool_name, pattern: Bash, children: [{condition: {observe: pos_arg(0), pattern: name, children: []}}]}}
-    # We need to add arg conditions as children of the innermost node
-    arg_nodes = []
-    for i, a in enumerate(args):
-        arg_nodes.append(_mt_arg(i + 1, _pattern(a)))
-
-    # Chain the arg nodes: each wraps around the next
-    # For [push, --force]: pos_arg(1)=push → pos_arg(2)=--force → [decision]
-    # But we want them as flat siblings at the deepest level, not nested
-    # Actually for exe("git", args=["push"]).deny(), we want:
-    # ToolName=Bash → PosArg(0)=git → PosArg(1)=push → [decision]
-    # Build the chain from inside out
     result = _mt_exe(pat)
     if len(args) > 0:
         # Build nested chain: arg(n, ...) wrapping the innermost
-        # Start with the outermost exe node and add arg children
         innermost = _mt_arg(len(args), _pattern(args[len(args) - 1]))
         for i in range(len(args) - 2, -1, -1):
             innermost = _mt_arg(i + 1, _pattern(args[i])).on([innermost])
-        # Now we need to set innermost as child of the PosArg(0)=name node
-        # which is inside the exe node
         result = _mt_exe(pat).on([innermost])
     return result
 
@@ -152,10 +195,10 @@ def _effect_decision(effect):
     else:
         fail("unknown effect: " + str(effect))
 
-def _caps_string(read, write, execute, allow_all):
-    """Compute a sandbox caps string from permission kwargs."""
+def _caps_list(read, write, execute, allow_all):
+    """Compute a sandbox caps list from permission kwargs."""
     if allow_all:
-        return "read + write + create + delete + execute"
+        return ["read", "write", "create", "delete", "execute"]
     parts = []
     if read == allow:
         parts.append("read")
@@ -163,7 +206,7 @@ def _caps_string(read, write, execute, allow_all):
         parts.extend(["write", "create"])
     if execute == allow:
         parts.append("execute")
-    return " + ".join(parts) if parts else ""
+    return parts
 
 def _path_entry(path_value, worktree = False, read = None, write = None,
                 execute = None, allow_all = False, _children = None,
@@ -183,8 +226,8 @@ def _path_entry(path_value, worktree = False, read = None, write = None,
 
     # Build sandbox rules (path + caps pairs for sandbox-exec compilation).
     _sandbox_rules = list(_extra_sandbox_rules or [])
-    _caps = _caps_string(read, write, execute, allow_all)
-    if _caps:
+    _caps = _caps_list(read, write, execute, allow_all)
+    if len(_caps) > 0:
         _sandbox_rules.append({"path_value": path_value, "caps": _caps})
 
     def child(name, read = None, write = None, execute = None, allow_all = False):
@@ -192,9 +235,9 @@ def _path_entry(path_value, worktree = False, read = None, write = None,
         # We create a struct with the joined path info for _mt_prefix
         child_path = struct(_join = [path_value, name])
         child_nodes = _fs_nodes(child_path, read, write, execute, allow_all)
-        child_caps = _caps_string(read, write, execute, allow_all)
+        child_caps = _caps_list(read, write, execute, allow_all)
         child_sb_rules = list(_sandbox_rules)
-        if child_caps:
+        if len(child_caps) > 0:
             child_sb_rules.append({"path_value": child_path, "caps": child_caps})
         return _path_entry(
             path_value, worktree, _read, _write, _execute, _allow_all,
@@ -478,7 +521,7 @@ def _sandbox_to_json(sb):
     for r in sb._fs_rules:
         pv = r["path_value"]
         path_str = _resolve_path_value(pv)
-        caps = r.get("caps", "read + write + create")
+        caps = r.get("caps", ["read", "write", "create"])
         rules.append({
             "effect": "allow",
             "caps": caps,
@@ -501,9 +544,9 @@ def _sandbox_to_json(sb):
     # deny default = read-only (can read system files and execute binaries)
     # allow default = full access
     if sb._default == deny:
-        default_caps = "read + execute"
+        default_caps = ["read", "execute"]
     else:
-        default_caps = "read + write + create + delete + execute"
+        default_caps = ["read", "write", "create", "delete", "execute"]
 
     return {
         "name": sb._name,


### PR DESCRIPTION
## Summary

- **Replace 14 specific Rust `_mt_*` Starlark globals with 2 generic primitives**: `_mt_node(dict)` (wraps any dict as a MatchTreeNode) and `_mt_condition(observe, pattern)` (generic condition builder). All DSL helpers now live in pure Starlark — new condition types, decision variants, and pattern combinators no longer require touching Rust.
- **Change sandbox Cap serialization from `"read + write"` strings to `["read", "write"]` lists**. Deserialization still accepts both formats for backwards compat (legacy removal tracked in #264).
- Implement `serde::Serialize` for `MatchTreeNode` so nodes can be nested inside dicts passed to `_mt_node`.

Net result: -385 lines of Rust, +225 lines of Starlark.

## Test plan

- [x] All 27 clash_starlark tests pass
- [x] All 11 sandbox_types tests pass (including new string-compat test)
- [x] Full workspace compiles clean