### PR TITLE
refactor(policy): unify compact and sort into Node::compact

### DIFF
--- a/clash/src/policy/compile.rs
+++ b/clash/src/policy/compile.rs
@@ -6,7 +6,7 @@
 
 use anyhow::{Result, bail};
 
-use crate::policy::match_tree::{CompiledPolicy, sort_by_specificity};
+use crate::policy::match_tree::{CompiledPolicy, Node};
 
 /// Environment variable resolver used during compilation to expand `(env NAME)`.
 pub trait EnvResolver {
@@ -86,7 +86,7 @@ pub fn compile_multi_level_to_tree(
         bail!("match tree validation errors: {}", errors.join("; "));
     }
 
-    sort_by_specificity(&mut merged.tree);
+    merged.tree = Node::compact(merged.tree);
 
     Ok(merged)
 }
@@ -101,7 +101,7 @@ fn compile_policy(source: &str) -> Result<CompiledPolicy> {
         bail!("match tree validation errors: {}", errors.join("; "));
     }
 
-    sort_by_specificity(&mut policy.tree);
+    policy.tree = Node::compact(policy.tree);
 
     Ok(policy)
 }

--- a/clash/src/policy/match_tree.rs
+++ b/clash/src/policy/match_tree.rs
@@ -118,7 +118,7 @@ impl Pattern {
             Pattern::AnyOf(_) => 1,
             Pattern::Regex(_) => 2,
             Pattern::Prefix(_) => 3,
-            Pattern::Literal(_) => 3,
+            Pattern::Literal(_) => 4,
         }
     }
 }
@@ -861,28 +861,67 @@ impl CompiledPolicy {
 }
 
 // ---------------------------------------------------------------------------
-// Specificity sorting
+// Compact: merge duplicate siblings + sort by specificity
 // ---------------------------------------------------------------------------
 
-/// Sort children by specificity (most specific first).
-/// Literal > Regex > AnyOf/Not > Wildcard.
-/// Ties broken by observable specificity.
-pub fn sort_by_specificity(nodes: &mut [Node]) {
-    nodes.sort_by(|a, b| node_specificity(b).cmp(&node_specificity(a)));
-    for node in nodes.iter_mut() {
-        if let Node::Condition { children, .. } = node {
-            sort_by_specificity(children);
-        }
-    }
-}
+impl Node {
+    /// Merge sibling `Condition` nodes that share the same `(observe, pattern)`,
+    /// combining their children, then sort by specificity. Recurses into children.
+    pub fn compact(nodes: Vec<Node>) -> Vec<Node> {
+        let mut out: Vec<Node> = Vec::new();
 
-fn node_specificity(node: &Node) -> (u8, u8) {
-    match node {
-        // Decisions are fallbacks — sort last so conditions are tried first.
-        Node::Decision(_) => (0, 0),
-        Node::Condition {
-            observe, pattern, ..
-        } => (pattern.specificity(), observe.specificity()),
+        // Merge duplicates via linear scan (no Hash needed, trees are small).
+        for node in nodes {
+            match node {
+                Node::Condition {
+                    observe,
+                    pattern,
+                    children,
+                } => {
+                    if let Some(existing) = out.iter_mut().find_map(|n| match n {
+                        Node::Condition {
+                            observe: o,
+                            pattern: p,
+                            children: c,
+                        } if *o == observe && *p == pattern => Some(c),
+                        _ => None,
+                    }) {
+                        existing.extend(children);
+                    } else {
+                        out.push(Node::Condition {
+                            observe,
+                            pattern,
+                            children,
+                        });
+                    }
+                }
+                decision => out.push(decision),
+            }
+        }
+
+        // Recurse into children.
+        for node in &mut out {
+            if let Node::Condition { children, .. } = node {
+                *children = Self::compact(std::mem::take(children));
+            }
+        }
+
+        // Sort: Conditions before Decisions, then by specificity (most specific first).
+        // TODO: unpack the nodes and do a direct comparison instead of a silly mapping to 8bit numbers
+        out.sort_by(|a, b| Self::sort_key(b).cmp(&Self::sort_key(a)));
+
+        out
+    }
+
+    /// Sort key: `(is_condition, pattern_specificity, observable_specificity)`.
+    /// Higher values sort first (via reverse comparison in `compact`).
+    fn sort_key(node: &Node) -> (u8, u8, u8) {
+        match node {
+            Node::Condition {
+                observe, pattern, ..
+            } => (1, pattern.specificity(), observe.specificity()),
+            Node::Decision(_) => (0, 0, 0),
+        }
     }
 }
 
@@ -1021,7 +1060,7 @@ mod tests {
     #[test]
     fn specificity_ordering() {
         // More specific (Literal) should come before less specific (Wildcard)
-        let mut nodes = vec![
+        let nodes = vec![
             Node::Condition {
                 observe: Observable::ToolName,
                 pattern: Pattern::Wildcard,
@@ -1033,7 +1072,7 @@ mod tests {
                 children: vec![Node::Decision(Decision::Allow(None))],
             },
         ];
-        sort_by_specificity(&mut nodes);
+        let nodes = Node::compact(nodes);
         // Literal should be first after sorting
         let ctx = make_ctx("Bash", "echo hello");
         assert_eq!(eval(&nodes, &ctx), Some(Decision::Allow(None)));


### PR DESCRIPTION
## Summary
- Replaces the separate `sort_by_specificity` free function with `Node::compact`, which merges duplicate sibling `Condition` nodes (same `observe` + `pattern`), recurses into children, and sorts by specificity — all in one pass
- Fixes `Pattern::Literal` specificity to rank above `Prefix` (was equal at 3, now 4)
- Updates compile.rs call sites to use the single `Node::compact` entry point

## Test plan
- [x] All 25 policy::match_tree and policy::compile tests pass
- [x] `just check` passes in CI