### PR TITLE
refactor(starlark): consistent sandbox path API and tree display

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ load("@clash//std.star", "exe", "policy", "sandbox", "cwd")
 def main():
     cwd_access = sandbox(
         default = deny,
-        fs = [cwd(follow_worktrees = True, read = allow, write = allow)],
+        fs = [cwd(follow_worktrees = True).allow(read = True, write = True)],
     )
     return policy(
         default = ask,
@@ -164,7 +164,7 @@ def main():
         default = deny,
         rules = [
             exe(["rustc", "cargo"]).sandbox(rust_sandbox).allow(),
-            exe("git").sandbox(sandbox(default = deny, fs = [cwd(read = allow)])).allow(),
+            exe("git").sandbox(sandbox(default = deny, fs = [cwd().allow(read = True)])).allow(),
         ],
     )
 ```
@@ -182,9 +182,9 @@ def main():
     cargo_box = sandbox(
         default = deny,
         fs = [
-            cwd(read = allow),
-            path("./target", write = allow),
-            tempdir(allow_all = True),
+            cwd().allow(read = True),
+            path("./target").allow(write = True),
+            tempdir().allow(),
         ],
         net = allow,
     )

--- a/clash-plugin/README.md
+++ b/clash-plugin/README.md
@@ -50,8 +50,8 @@ load("@clash//std.star", "exe", "tool", "policy", "sandbox", "cwd", "home", "dom
 
 def main():
     fs_access = sandbox(fs=[
-        cwd(follow_worktrees = True, read = allow, write = allow),
-        home().child(".ssh", read = allow),
+        cwd(follow_worktrees = True).allow(read = True, write = True),
+        home().child(".ssh").allow(read = True),
     ])
 
     return policy(default = deny, rules = [
@@ -74,8 +74,8 @@ Note: Filesystem path entries (`cwd`, `home`, `tempdir`, `path`) cannot appear d
 | Deny a subcommand | `exe("git", args = ["push"]).deny()` |
 | Ask for confirmation | `exe("git", args = ["commit"]).ask()` |
 | Multiple binaries | `exe(["cargo", "rustc"]).allow()` |
-| Filesystem (via sandbox) | `tool(["Read"]).sandbox(sandbox(fs=[cwd(read = allow)])).allow()` |
-| Home subdir (via sandbox) | `exe("ssh").sandbox(sandbox(fs=[home().child(".ssh", read = allow)])).allow()` |
+| Filesystem (via sandbox) | `tool(["Read"]).sandbox(sandbox(fs=[cwd().allow(read = True)])).allow()` |
+| Home subdir (via sandbox) | `exe("ssh").sandbox(sandbox(fs=[home().child(".ssh").allow(read = True)])).allow()` |
 | Network domains | `domains({"github.com": allow})` |
 | Tool access | `tool().allow()` |
 | Sandbox on exec | `exe("cargo").sandbox(sb).allow()` |
@@ -85,7 +85,7 @@ Note: Filesystem path entries (`cwd`, `home`, `tempdir`, `path`) cannot appear d
 ```python
 sb = sandbox(
     default = deny,
-    fs = [cwd(follow_worktrees = True, read = allow, write = allow)],
+    fs = [cwd(follow_worktrees = True).allow(read = True, write = True)],
     net = allow,
 )
 exe("cargo").sandbox(sb).allow()
@@ -107,7 +107,7 @@ If a command fails because of sandbox restrictions, update the policy's sandbox 
 # If cargo needs network access, add net = allow to its sandbox
 cargo_env = sandbox(
     default = deny,
-    fs = [cwd(follow_worktrees = True, read = allow, write = allow)],
+    fs = [cwd(follow_worktrees = True).allow(read = True, write = True)],
     net = allow,
 )
 exe("cargo").sandbox(cargo_env).allow()

--- a/clash-plugin/skills/allow/SKILL.md
+++ b/clash-plugin/skills/allow/SKILL.md
@@ -39,13 +39,13 @@ Help the user add an **allow** rule to their clash policy by editing the `.star`
      ```
    - Filesystem access under cwd (via sandbox on a tool rule):
      ```python
-     fs_sandbox = sandbox(fs=[cwd(follow_worktrees = True, read = allow, write = allow)])
+     fs_sandbox = sandbox(fs=[cwd(follow_worktrees = True).allow(read = True, write = True)])
      tool(["Read", "Glob", "Grep"]).sandbox(fs_sandbox).allow()
      tool(["Write", "Edit"]).sandbox(fs_sandbox).allow()
      ```
    - Filesystem access under a specific path (via sandbox):
      ```python
-     ssh_sandbox = sandbox(fs=[home().child(".ssh", read = allow)])
+     ssh_sandbox = sandbox(fs=[home().child(".ssh").allow(read = True)])
      exe("ssh").sandbox(ssh_sandbox).allow()
      ```
    - Network access to a domain:

--- a/clash-plugin/skills/amend/SKILL.md
+++ b/clash-plugin/skills/amend/SKILL.md
@@ -20,8 +20,8 @@ load("@clash//std.star", "exe", "tool", "policy", "sandbox", "cwd", "home", "dom
 
 def main():
     fs_access = sandbox(fs=[
-        cwd(follow_worktrees = True, read = allow, write = allow),
-        home().child(".ssh", read = allow),
+        cwd(follow_worktrees = True).allow(read = True, write = True),
+        home().child(".ssh").allow(read = True),
     ])
 
     return policy(default = deny, rules = [
@@ -55,7 +55,7 @@ def main():
      ```
    - Allow filesystem access under cwd (via sandbox):
      ```python
-     fs_sandbox = sandbox(fs=[cwd(follow_worktrees = True, read = allow)])
+     fs_sandbox = sandbox(fs=[cwd(follow_worktrees = True).allow(read = True)])
      tool(["Read", "Glob", "Grep"]).sandbox(fs_sandbox).allow()
      ```
    - Allow network access to a domain:

--- a/clash-plugin/skills/edit/SKILL.md
+++ b/clash-plugin/skills/edit/SKILL.md
@@ -47,18 +47,18 @@ Read the policy file, then insert the appropriate rule into the `rules = [...]` 
   ```
 - Allow filesystem reads under cwd (via sandbox on a tool/exe rule):
   ```python
-  fs_sandbox = sandbox(fs=[cwd(read = allow)])
+  fs_sandbox = sandbox(fs=[cwd().allow(read = True)])
   tool(["Read", "Glob", "Grep"]).sandbox(fs_sandbox).allow()
   ```
 - Allow filesystem read/write/create under cwd:
   ```python
-  fs_sandbox = sandbox(fs=[cwd(follow_worktrees = True, read = allow, write = allow)])
+  fs_sandbox = sandbox(fs=[cwd(follow_worktrees = True).allow(read = True, write = True)])
   tool(["Read", "Glob", "Grep"]).sandbox(fs_sandbox).allow()
   tool(["Write", "Edit"]).sandbox(fs_sandbox).allow()
   ```
 - Access to a subdirectory of home (via sandbox):
   ```python
-  ssh_sandbox = sandbox(fs=[home().child(".ssh", read = allow)])
+  ssh_sandbox = sandbox(fs=[home().child(".ssh").allow(read = True)])
   exe("ssh").sandbox(ssh_sandbox).allow()
   ```
 

--- a/clash/src/cmd/policy.rs
+++ b/clash/src/cmd/policy.rs
@@ -44,9 +44,8 @@ fn handle_list(json: bool) -> Result<()> {
         }
     };
 
-    let rules = policy.format_rules();
-
     if json {
+        let rules = policy.format_rules();
         let entries: Vec<serde_json::Value> = rules
             .iter()
             .enumerate()
@@ -59,7 +58,8 @@ fn handle_list(json: bool) -> Result<()> {
             .collect();
         println!("{}", serde_json::to_string_pretty(&entries)?);
     } else {
-        if rules.is_empty() {
+        let lines = policy.format_tree();
+        if lines.is_empty() {
             println!(
                 "No rules in policy. {}",
                 style::dim(&format!("(default: {})", policy.default_effect))
@@ -69,13 +69,12 @@ fn handle_list(json: bool) -> Result<()> {
         println!(
             "Policy {}\n",
             style::dim(&format!(
-                "(default: {}, {} rules)",
+                "(default: {})",
                 style::effect(&policy.default_effect.to_string()),
-                rules.len()
             ))
         );
-        for rule in &rules {
-            println!("  {}", rule);
+        for line in &lines {
+            println!("  {}", line);
         }
     }
     Ok(())

--- a/clash/src/cmd/status.rs
+++ b/clash/src/cmd/status.rs
@@ -94,8 +94,8 @@ pub fn run(_json: bool, verbose: bool) -> Result<()> {
     );
     println!("{}", style::dim("─────────────────────────────────"));
 
-    let rules = policy.format_rules();
-    if rules.is_empty() {
+    let lines = policy.format_tree();
+    if lines.is_empty() {
         println!(
             "  {}",
             style::dim(&format!(
@@ -104,23 +104,8 @@ pub fn run(_json: bool, verbose: bool) -> Result<()> {
             ))
         );
     } else {
-        // TODO: the way we are doing color prefixing here is really gross. Create something more structured
-        for rule in &rules {
-            // Color the effect prefix
-            let colored = if rule.starts_with("allow") {
-                format!(
-                    "  {} {}",
-                    style::green("allow"),
-                    &rule["allow".len()..].trim()
-                )
-            } else if rule.starts_with("deny") {
-                format!("  {} {}", style::red("deny"), &rule["deny".len()..].trim())
-            } else if rule.starts_with("ask") {
-                format!("  {} {}", style::yellow("ask"), &rule["ask".len()..].trim())
-            } else {
-                format!("  {}", rule)
-            };
-            println!("{}", colored);
+        for line in &lines {
+            println!("  {}", colorize_tree_line(line));
         }
     }
 
@@ -185,4 +170,33 @@ pub fn run(_json: bool, verbose: bool) -> Result<()> {
     }
 
     Ok(())
+}
+
+/// Colorize a tree line by highlighting the effect after the `→` separator.
+fn colorize_tree_line(line: &str) -> String {
+    if let Some(idx) = line.rfind(" → ") {
+        let (prefix, rest) = line.split_at(idx);
+        let effect = &rest[" → ".len()..];
+        let colored_effect = if effect.starts_with("allow") {
+            format!("{}{}", style::green("allow"), &effect["allow".len()..])
+        } else if effect.starts_with("deny") {
+            format!("{}{}", style::red("deny"), &effect["deny".len()..])
+        } else if effect.starts_with("ask") {
+            format!("{}{}", style::yellow("ask"), &effect["ask".len()..])
+        } else {
+            effect.to_string()
+        };
+        format!("{} → {}", prefix, colored_effect)
+    } else if line.starts_with("allow") || line.starts_with("deny") || line.starts_with("ask") {
+        // Bare decision node (no condition prefix)
+        if line.starts_with("allow") {
+            format!("{}{}", style::green("allow"), &line["allow".len()..])
+        } else if line.starts_with("deny") {
+            format!("{}{}", style::red("deny"), &line["deny".len()..])
+        } else {
+            format!("{}{}", style::yellow("ask"), &line["ask".len()..])
+        }
+    } else {
+        line.to_string()
+    }
 }

--- a/clash/src/default_policy.star
+++ b/clash/src/default_policy.star
@@ -7,7 +7,7 @@ load("@clash//node.star", "node")
 _fs_access = sandbox(
     name = "cwd",
     fs = [
-        cwd(read = allow, write = allow, follow_worktrees = True),
+        cwd(follow_worktrees = True).allow(read = True, write = True),
     ],
 )
 

--- a/clash/src/policy/match_tree.rs
+++ b/clash/src/policy/match_tree.rs
@@ -276,27 +276,99 @@ impl CompiledPolicy {
         self.tree.len()
     }
 
-    /// Format rules as human-readable lines for display.
+    /// Format rules as human-readable lines for display (flat, denormalized).
     pub fn format_rules(&self) -> Vec<String> {
         let mut lines = Vec::new();
         for node in &self.tree {
-            format_node(node, &mut Vec::new(), &mut lines);
+            format_node_flat(node, &mut Vec::new(), &mut lines);
+        }
+        lines
+    }
+
+    /// Format rules as a tree with box-drawing characters.
+    /// Merges duplicate condition nodes to show shared structure.
+    pub fn format_tree(&self) -> Vec<String> {
+        let mut lines = Vec::new();
+        let len = self.tree.len();
+        for (i, node) in self.tree.iter().enumerate() {
+            let is_last = i == len - 1;
+            format_tree_node(node, "", is_last, true, &mut lines);
         }
         lines
     }
 }
 
-/// Recursively format a node as a human-readable rule line.
-fn format_node(node: &Node, path: &mut Vec<String>, lines: &mut Vec<String>) {
+/// Recursively render a node as tree lines with box-drawing characters.
+fn format_tree_node(
+    node: &Node,
+    prefix: &str,
+    is_last: bool,
+    is_root: bool,
+    lines: &mut Vec<String>,
+) {
+    let connector = if is_root {
+        ""
+    } else if is_last {
+        "└── "
+    } else {
+        "├── "
+    };
+    let child_prefix = if is_root {
+        ""
+    } else if is_last {
+        "    "
+    } else {
+        "│   "
+    };
+
     match node {
         Node::Decision(d) => {
-            let effect = match d {
-                Decision::Allow(Some(sb)) => format!("allow [sandbox: {}]", sb.0),
-                Decision::Allow(None) => "allow".to_string(),
-                Decision::Deny => "deny".to_string(),
-                Decision::Ask(Some(sb)) => format!("ask [sandbox: {}]", sb.0),
-                Decision::Ask(None) => "ask".to_string(),
-            };
+            let effect = format_decision(d);
+            lines.push(format!("{prefix}{connector}{effect}"));
+        }
+        Node::Condition {
+            observe,
+            pattern,
+            children,
+        } => {
+            let label = format_condition(observe, pattern);
+
+            // Single decision child → show inline: "label → effect"
+            if children.len() == 1 {
+                if let Node::Decision(d) = &children[0] {
+                    let effect = format_decision(d);
+                    lines.push(format!("{prefix}{connector}{label} → {effect}"));
+                    return;
+                }
+            }
+
+            // Branch — show label, then children as sub-tree
+            lines.push(format!("{prefix}{connector}{label}"));
+            let new_prefix = format!("{prefix}{child_prefix}");
+            let child_count = children.len();
+            for (i, child) in children.iter().enumerate() {
+                let child_is_last = i == child_count - 1;
+                format_tree_node(child, &new_prefix, child_is_last, false, lines);
+            }
+        }
+    }
+}
+
+fn format_decision(d: &Decision) -> String {
+    match d {
+        Decision::Allow(Some(sb)) => format!("allow [sandbox: {}]", sb.0),
+        Decision::Allow(None) => "allow".to_string(),
+        Decision::Deny => "deny".to_string(),
+        Decision::Ask(Some(sb)) => format!("ask [sandbox: {}]", sb.0),
+        Decision::Ask(None) => "ask".to_string(),
+    }
+}
+
+/// Recursively format a node as a flat, denormalized rule line.
+fn format_node_flat(node: &Node, path: &mut Vec<String>, lines: &mut Vec<String>) {
+    match node {
+        Node::Decision(d) => {
+            let effect = format_decision(d);
             if path.is_empty() {
                 lines.push(format!("{effect} *"));
             } else {
@@ -314,7 +386,7 @@ fn format_node(node: &Node, path: &mut Vec<String>, lines: &mut Vec<String>) {
                 lines.push(format!("(no decision) {}", path.join(" → ")));
             } else {
                 for child in children {
-                    format_node(child, path, lines);
+                    format_node_flat(child, path, lines);
                 }
             }
             path.pop();

--- a/clash_starlark/src/builders/base.rs
+++ b/clash_starlark/src/builders/base.rs
@@ -46,15 +46,11 @@ impl<'v> StarlarkValue<'v> for BasePolicyValue {
 fn base_policy_methods(builder: &mut starlark::environment::MethodsBuilder) {
     /// Merge two policies together.
     ///
-    /// Combines tree nodes and sandboxes from both policies. The default
-    /// effect is the most restrictive: if either policy defaults to "deny",
-    /// the merged policy defaults to "deny".
+    /// In `a.merge(b)`, `b` is merged on top: `b`'s default effect is used,
+    /// tree nodes are concatenated (`a`'s first, then `b`'s), and sandboxes
+    /// are merged (first defined wins on name conflicts).
     fn merge(this: &BasePolicyValue, other: &BasePolicyValue) -> anyhow::Result<BasePolicyValue> {
-        let default_effect = if this.default_effect == "deny" || other.default_effect == "deny" {
-            "deny".to_string()
-        } else {
-            this.default_effect.clone()
-        };
+        let default_effect = other.default_effect.clone();
 
         let base_doc = match (&this.base_doc, &other.base_doc) {
             (Some(left), Some(right)) => {

--- a/clash_starlark/src/globals.rs
+++ b/clash_starlark/src/globals.rs
@@ -73,6 +73,17 @@ fn register_globals(builder: &mut GlobalsBuilder) {
         })
     }
 
+    /// Convert a path value to a literal (exact) pattern (needs Rust for env/join dispatch).
+    fn _mt_literal<'v>(
+        #[starlark(require = pos)] value: Value<'v>,
+        heap: &'v starlark::values::Heap,
+    ) -> anyhow::Result<MatchTreeNode> {
+        let val_json = path_value_to_json(value, heap)?;
+        Ok(MatchTreeNode {
+            json: serde_json::json!({"literal": val_json}),
+        })
+    }
+
     /// Internal match tree policy constructor.
     fn _mt_policy<'v>(
         #[starlark(require = named)] default: Option<&str>,

--- a/clash_starlark/src/lib.rs
+++ b/clash_starlark/src/lib.rs
@@ -112,7 +112,7 @@ def main():
         name = "test",
         default = deny,
         fs = [
-            cwd(read = allow, write = allow),
+            cwd().allow(read = True, write = True),
         ],
         net = allow,
     )
@@ -178,7 +178,7 @@ def main():
 load("@clash//std.star", "exe", "policy", "sandbox", "cwd")
 
 def main():
-    box = sandbox(name = "test", default = deny, fs = [cwd(read = allow)])
+    box = sandbox(name = "test", default = deny, fs = [cwd().allow(read = True)])
     return policy(
         default = deny,
         rules = [
@@ -235,7 +235,7 @@ def main():
         name = "test",
         default = deny,
         fs = [
-            home().child(".ssh", read = allow),
+            home().child(".ssh").allow(read = True),
         ],
     )
     return policy(default = deny, rules = [exe("git").sandbox(box).allow()])
@@ -276,7 +276,7 @@ def main():
     box = sandbox(
         name = "test",
         default = deny,
-        fs = [cwd(follow_worktrees = True, read = allow, write = allow)],
+        fs = [cwd(follow_worktrees = True).allow(read = True, write = True)],
     )
     return policy(default = deny, rules = [exe("git").sandbox(box).allow()])
 "#,
@@ -297,7 +297,7 @@ def main():
     box = sandbox(
         name = "test",
         default = deny,
-        fs = [tempdir(allow_all = True)],
+        fs = [tempdir().allow()],
     )
     return policy(default = deny, rules = [exe("test").sandbox(box).allow()])
 "#,
@@ -316,7 +316,7 @@ def main():
     box = sandbox(
         name = "test",
         default = deny,
-        fs = [path("/usr/local/bin", read = allow, execute = allow)],
+        fs = [path("/usr/local/bin").allow(read = True, execute = True)],
     )
     return policy(default = deny, rules = [exe("test").sandbox(box).allow()])
 "#,
@@ -335,7 +335,7 @@ def main():
     box = sandbox(
         name = "test",
         default = deny,
-        fs = [path(env = "CARGO_HOME", read = allow, write = allow)],
+        fs = [path(env = "CARGO_HOME").allow(read = True, write = True)],
     )
     return policy(default = deny, rules = [exe("cargo").sandbox(box).allow()])
 "#,
@@ -345,13 +345,13 @@ def main():
     }
 
     #[test]
-    fn test_invalid_effect_errors() {
-        // Test with a path builder that validates effects
+    fn test_bare_path_in_sandbox_errors() {
+        // Using cwd() without a decision (.allow()/.deny()/.ask()) in sandbox fs= should fail
         let source = r#"
 load("@clash//std.star", "exe", "policy", "sandbox", "cwd")
 
 def main():
-    box = sandbox(name = "test", default = deny, fs = [cwd(read = "invalid")])
+    box = sandbox(name = "test", default = deny, fs = [cwd()])
     return policy(default = deny, rules = [exe("test").sandbox(box).allow()])
 "#;
         let result = evaluate(source, "test.star", &PathBuf::from("."));
@@ -412,7 +412,7 @@ def main():
             r#"
 load("@clash//std.star", "sandbox", "cwd")
 
-my_sandbox = sandbox(name = "test", default = deny, fs = [cwd(read = allow)])
+my_sandbox = sandbox(name = "test", default = deny, fs = [cwd().allow(read = True)])
 "#,
         )
         .unwrap();
@@ -442,14 +442,9 @@ def main():
         name = "gitbox",
         default = deny,
         fs = [
-            cwd(
-                follow_worktrees = True,
-                read = allow,
-                write = allow,
-                execute = allow,
-            ),
-            home().child(".git", allow_all = True),
-            home().child(".ssh", read = allow),
+            cwd(follow_worktrees = True).allow(read = True, write = True, execute = True),
+            home().child(".git").allow(),
+            home().child(".ssh").allow(read = True),
         ],
         net = allow,
     )
@@ -698,5 +693,141 @@ def main():
 "#,
         );
         assert_eq!(doc["schema_version"], 5);
+    }
+
+    #[test]
+    fn test_file_exact_match() {
+        let doc = eval_to_doc(
+            r#"
+load("@clash//std.star", "tool", "policy", "cwd")
+
+def main():
+    return policy(default = deny, rules = [
+        cwd().file(".env").deny(write = True),
+        cwd().allow(read = True, write = True),
+        tool().allow(),
+    ])
+"#,
+        );
+        assert_eq!(doc["schema_version"], 5);
+        let tree = doc["tree"].as_array().unwrap();
+        // First rule: FsOp=write → FsPath=literal(cwd/.env) → deny
+        let fs_op = &tree[0]["condition"];
+        assert_eq!(fs_op["observe"], "fs_op");
+        let fs_path = &fs_op["children"].as_array().unwrap()[0]["condition"];
+        assert_eq!(fs_path["observe"], "fs_path");
+        // Should be a literal pattern (not prefix)
+        assert!(
+            fs_path["pattern"]["literal"].is_object(),
+            "expected literal pattern for .file(), got {:?}",
+            fs_path["pattern"]
+        );
+    }
+
+    #[test]
+    fn test_file_sandbox_match_type() {
+        let doc = eval_to_doc(
+            r#"
+load("@clash//std.star", "exe", "policy", "sandbox", "cwd")
+
+def main():
+    box = sandbox(
+        name = "test",
+        default = deny,
+        fs = [
+            cwd().file("config.json").allow(read = True),
+            cwd().allow(read = True),
+        ],
+    )
+    return policy(default = deny, rules = [exe("test").sandbox(box).allow()])
+"#,
+        );
+        assert_eq!(doc["schema_version"], 5);
+        let sandbox = &doc["sandboxes"]["test"];
+        let rules = sandbox["rules"].as_array().unwrap();
+        // First rule should have path_match: literal
+        assert_eq!(rules[0]["path_match"], "literal");
+        // Second rule should have path_match: subpath
+        assert_eq!(rules[1]["path_match"], "subpath");
+    }
+
+    #[test]
+    fn test_tool_on_with_path_entries() {
+        let doc = eval_to_doc(
+            r#"
+load("@clash//std.star", "tool", "policy", "cwd")
+
+def main():
+    return policy(default = deny, rules = [
+        tool("Glob").on([
+            cwd().child("src").allow(read = True),
+        ]),
+    ])
+"#,
+        );
+        assert_eq!(doc["schema_version"], 5);
+        let tree = doc["tree"].as_array().unwrap();
+        assert_eq!(tree.len(), 1);
+        // tool("Glob") → ToolName=Glob → children should contain fs nodes
+        let tool_node = &tree[0]["condition"];
+        assert_eq!(tool_node["observe"], "tool_name");
+        let children = tool_node["children"].as_array().unwrap();
+        // Should have fs nodes nested under the tool condition
+        assert!(!children.is_empty());
+        assert_eq!(children[0]["condition"]["observe"], "fs_op");
+    }
+
+    #[test]
+    fn test_tool_on_mixed_children() {
+        let doc = eval_to_doc(
+            r#"
+load("@clash//std.star", "tool", "policy", "cwd")
+
+def main():
+    return policy(default = deny, rules = [
+        tool("Read").on([
+            cwd().file(".env").deny(read = True),
+            cwd().allow(read = True),
+        ]),
+    ])
+"#,
+        );
+        assert_eq!(doc["schema_version"], 5);
+        let tree = doc["tree"].as_array().unwrap();
+        assert_eq!(tree.len(), 1);
+        let tool_node = &tree[0]["condition"];
+        let children = tool_node["children"].as_array().unwrap();
+        // Should have 2 children: deny .env write, allow cwd read
+        assert_eq!(
+            children.len(),
+            2,
+            "expected 2 fs nodes, got {}",
+            children.len()
+        );
+    }
+
+    #[test]
+    fn test_path_match_with_regex() {
+        let doc = eval_to_doc(
+            r#"
+load("@clash//std.star", "tool", "policy", "cwd", "regex")
+
+def main():
+    return policy(default = deny, rules = [
+        cwd().match(regex(".*\\.log")).deny(write = True),
+        tool().allow(),
+    ])
+"#,
+        );
+        assert_eq!(doc["schema_version"], 5);
+        let tree = doc["tree"].as_array().unwrap();
+        let fs_op = &tree[0]["condition"];
+        let fs_path = &fs_op["children"].as_array().unwrap()[0]["condition"];
+        // Should be a regex pattern
+        assert!(
+            fs_path["pattern"]["regex"].is_string(),
+            "expected regex pattern for .match(), got {:?}",
+            fs_path["pattern"]
+        );
     }
 }

--- a/clash_starlark/stdlib/builtin.star
+++ b/clash_starlark/stdlib/builtin.star
@@ -4,7 +4,7 @@ clashbox = sandbox(
     name = "clash_box",
     default = deny,
     fs = [
-        home().child(".clash", read = allow),
+        home().child(".clash").allow(read = True),
     ],
     net = allow,
 )
@@ -22,11 +22,12 @@ clash = policy(
     ],
 )
 
-_claude_fs = sandbox(name = "claude_fs", fs = [ home().child(".claude", read = allow, write = allow),
-    path(env = "TRANSCRIPT_DIR", read = allow),
+_claude_fs = sandbox(name = "claude_fs", fs = [
+    home().child(".claude").allow(read = True, write = True),
+    path(env = "TRANSCRIPT_DIR").allow(read = True),
 ])
 
-claude =  policy(default = deny, rules = [
+claude = policy(default = deny, rules = [
     tool([
         "Agent",
         "AskUserQuestion",

--- a/clash_starlark/stdlib/node.star
+++ b/clash_starlark/stdlib/node.star
@@ -4,10 +4,10 @@ node_sandbox = sandbox(
     name = "node_dev",
     default = deny,
     fs = [
-        cwd(read = allow, write = allow, execute = allow),
-        home().child(".npm", allow_all = True),
-        home().child(".config/npm", read = allow),
-        tempdir(allow_all = True),
+        cwd().allow(read = True, write = True, execute = True),
+        home().child(".npm").allow(),
+        home().child(".config/npm").allow(read = True),
+        tempdir().allow(),
     ],
     net = [
         domains({

--- a/clash_starlark/stdlib/python.star
+++ b/clash_starlark/stdlib/python.star
@@ -4,10 +4,10 @@ python_sandbox = sandbox(
     name = "python_dev",
     default = deny,
     fs = [
-        cwd(read = allow, write = allow, execute = allow),
-        home().child(".local", read = allow, write = allow),
-        home().child(".cache/pip", allow_all = True),
-        tempdir(allow_all = True),
+        cwd().allow(read = True, write = True, execute = True),
+        home().child(".local").allow(read = True, write = True),
+        home().child(".cache/pip").allow(),
+        tempdir().allow(),
     ],
     net = [
         domains({

--- a/clash_starlark/stdlib/rust.star
+++ b/clash_starlark/stdlib/rust.star
@@ -4,11 +4,11 @@ rust_sandbox = sandbox(
     name = "rust_dev",
     default = deny,
     fs = [
-        cwd(read = allow, write = allow, execute = allow),
-        cwd().child("target", allow_all = True),
-        home().child(".cargo", allow_all = True),
-        home().child(".rustup", read = allow, execute = allow),
-        tempdir(allow_all = True),
+        cwd().allow(read = True, write = True, execute = True),
+        cwd().child("target").allow(),
+        home().child(".cargo").allow(),
+        home().child(".rustup").allow(read = True, execute = True),
+        tempdir().allow(),
     ],
     net = [
         domains({

--- a/clash_starlark/stdlib/std.star
+++ b/clash_starlark/stdlib/std.star
@@ -2,7 +2,7 @@
 #
 # Emits v5 match tree nodes using minimal Rust primitives.
 # Rust globals available: _mt_node, _mt_condition, _mt_pattern, _mt_prefix,
-# _mt_policy, allow, deny, ask
+# _mt_literal, _mt_policy, allow, deny, ask
 
 # ---------------------------------------------------------------------------
 # Pattern helpers
@@ -143,32 +143,17 @@ def tool(name = None):
 # Filesystem path builders
 # ---------------------------------------------------------------------------
 
-_VALID_EFFECTS = ["allow", "deny", "ask"]
-
-def _validate_effect(name, value):
-    """Validate that an effect is allow, deny, or ask."""
-    if value != None and value not in _VALID_EFFECTS:
-        fail("invalid effect '{}' for {}, must be allow, deny, or ask".format(value, name))
-
-def _fs_nodes(path_value, read = None, write = None, execute = None, allow_all = False):
+def _fs_nodes(path_pattern, read = None, write = None):
     """Build match tree nodes for filesystem access.
 
-    Returns a list of condition nodes that match on FsOp and FsPath.
+    path_pattern: a MatchTreeNode from _mt_prefix, _mt_literal, or _mt_pattern.
+    read/write: effect values (allow/deny/ask) or None to skip.
     """
-    _validate_effect("read", read)
-    _validate_effect("write", write)
-    _validate_effect("execute", execute)
-
-    if allow_all:
-        read = allow
-        write = allow
-        execute = allow
-
     nodes = []
 
     if read != None:
         node = _mt_fs_op(_pattern("read")).on([
-            _mt_fs_path(_mt_prefix(path_value)).on([
+            _mt_fs_path(path_pattern).on([
                 _effect_decision(read),
             ]),
         ])
@@ -176,7 +161,7 @@ def _fs_nodes(path_value, read = None, write = None, execute = None, allow_all =
 
     if write != None:
         node = _mt_fs_op(_pattern("write")).on([
-            _mt_fs_path(_mt_prefix(path_value)).on([
+            _mt_fs_path(path_pattern).on([
                 _effect_decision(write),
             ]),
         ])
@@ -195,100 +180,127 @@ def _effect_decision(effect):
     else:
         fail("unknown effect: " + str(effect))
 
-def _caps_list(read, write, execute, allow_all):
-    """Compute a sandbox caps list from permission kwargs."""
-    if allow_all:
+def _caps_from_bools(read, write, execute, all_ops):
+    """Compute sandbox caps list from boolean flags."""
+    if all_ops:
         return ["read", "write", "create", "delete", "execute"]
     parts = []
-    if read == allow:
+    if read:
         parts.append("read")
-    if write == allow:
+    if write:
         parts.extend(["write", "create"])
-    if execute == allow:
+    if execute:
         parts.append("execute")
     return parts
 
-def _path_entry(path_value, worktree = False, read = None, write = None,
-                execute = None, allow_all = False, _children = None,
-                _extra_sandbox_rules = None):
-    """Internal: build a path entry struct with .child() and ._nodes."""
-    if _children == None:
-        _children = []
+def _make_path_pattern(path_value, match_type):
+    """Create the appropriate FsPath pattern for the given match type."""
+    if match_type == "literal":
+        return _mt_literal(path_value)
+    elif match_type == "regex":
+        return _mt_pattern(path_value)
+    else:
+        return _mt_prefix(path_value)
 
-    _read = read
-    _write = write
-    _execute = execute
-    _allow_all = allow_all
+def _path_match(path_value, worktree = False, match_type = "subpath"):
+    """A path selector — use .child()/.file()/.match() to refine, then .allow()/.deny()/.ask() to decide."""
 
-    _nodes = _fs_nodes(path_value, read, write, execute, allow_all)
-    for c in _children:
-        _nodes.extend(c)
-
-    # Build sandbox rules (path + caps pairs for sandbox-exec compilation).
-    _sandbox_rules = list(_extra_sandbox_rules or [])
-    _caps = _caps_list(read, write, execute, allow_all)
-    if len(_caps) > 0:
-        _sandbox_rules.append({"path_value": path_value, "caps": _caps})
-
-    def child(name, read = None, write = None, execute = None, allow_all = False):
-        # For child paths, join with the parent
-        # We create a struct with the joined path info for _mt_prefix
+    def child(name):
+        """Select a subdirectory (subpath match)."""
         child_path = struct(_join = [path_value, name])
-        child_nodes = _fs_nodes(child_path, read, write, execute, allow_all)
-        child_caps = _caps_list(read, write, execute, allow_all)
-        child_sb_rules = list(_sandbox_rules)
-        if len(child_caps) > 0:
-            child_sb_rules.append({"path_value": child_path, "caps": child_caps})
-        return _path_entry(
-            path_value, worktree, _read, _write, _execute, _allow_all,
-            _children + [child_nodes],
-            child_sb_rules,
+        return _path_match(child_path, worktree, "subpath")
+
+    def file(name):
+        """Select a specific file (exact match)."""
+        file_path = struct(_join = [path_value, name])
+        return _path_match(file_path, worktree, "literal")
+
+    def match(pat):
+        """Select paths by regex pattern."""
+        return _path_match(pat, worktree, "regex")
+
+    def _resolve(effect, read, write, execute, all):
+        all_ops = (read == None and write == None and execute == None)
+        _read = effect if (read or all_ops) else None
+        _write = effect if (write or all_ops) else None
+
+        path_pat = _make_path_pattern(path_value, match_type)
+        nodes = _fs_nodes(path_pat, _read, _write)
+
+        sandbox_rules = []
+        if effect == allow:
+            caps = _caps_from_bools(
+                read or all_ops,
+                write or all_ops,
+                execute or all_ops,
+                all_ops,
+            )
+            if len(caps) > 0:
+                sandbox_rules.append({
+                    "path_value": path_value,
+                    "caps": caps,
+                    "match_type": match_type,
+                })
+
+        return struct(
+            _is_path = True,
+            _nodes = nodes,
+            _path_value = path_value,
+            _sandbox_rules = sandbox_rules,
         )
 
-    return struct(child = child, _nodes = _nodes, _is_path = True, _path_value = path_value,
-                  _sandbox_rules = _sandbox_rules)
+    def _allow(read = None, write = None, execute = None, all=None):
+        return _resolve(allow, read, write, execute, all)
 
-def cwd(follow_worktrees = False, read = None, write = None,
-        execute = None, allow_all = False):
-    """Build a CWD path entry.
+    def _deny(read = None, write = None, execute = None, all=None):
+        return _resolve(deny, read, write, execute, all)
+
+    def _ask(read = None, write = None, execute = None, all=None):
+        return _resolve(ask, read, write, execute, all)
+
+    return struct(child = child, file = file, match = match,
+                  allow = _allow, deny = _deny, ask = _ask)
+
+def cwd(follow_worktrees = False):
+    """Build a CWD path match.
 
     Usage:
-        cwd(read=allow, write=allow)
-        cwd(follow_worktrees=True, allow_all=True)
+        cwd().allow(read=True, write=True)
+        cwd(follow_worktrees=True).allow()
+        cwd().child("src").allow(read=True)
     """
-    return _path_entry(struct(_env = "PWD"), follow_worktrees, read, write, execute, allow_all)
+    return _path_match(struct(_env = "PWD"), follow_worktrees)
 
-def home(read = None, write = None, execute = None, allow_all = False):
-    """Build a HOME path entry.
+def home():
+    """Build a HOME path match.
 
     Usage:
-        home().child(".ssh", read=allow)
-        home().child(".cargo", allow_all=True)
+        home().child(".ssh").allow(read=True)
+        home().child(".cargo").allow()
     """
-    return _path_entry(struct(_env = "HOME"), False, read, write, execute, allow_all)
+    return _path_match(struct(_env = "HOME"), False)
 
-def tempdir(read = None, write = None, execute = None, allow_all = False):
-    """Build a TMPDIR path entry.
+def tempdir():
+    """Build a TMPDIR path match.
 
     Usage:
-        tempdir(allow_all=True)
+        tempdir().allow()
     """
-    return _path_entry(struct(_env = "TMPDIR"), False, read, write, execute, allow_all)
+    return _path_match(struct(_env = "TMPDIR"), False)
 
-def path(path_str = None, env = None, read = None, write = None,
-         execute = None, allow_all = False):
-    """Build a path entry for an arbitrary path or env var.
+def path(path_str = None, env = None):
+    """Build a path match for an arbitrary path or env var.
 
     Usage:
-        path("/usr/local/bin", read=allow, execute=allow)
-        path(env="CARGO_HOME", read=allow, write=allow)
+        path("/usr/local/bin").allow(read=True, execute=True)
+        path(env="CARGO_HOME").allow(read=True, write=True)
     """
     if path_str != None and env != None:
         fail("path() takes either a path string or env=, not both")
     if path_str == None and env == None:
         fail("path() requires either a path string or env= argument")
     path_value = struct(_env = env) if env != None else path_str
-    return _path_entry(path_value, False, read, write, execute, allow_all)
+    return _path_match(path_value, False)
 
 # ---------------------------------------------------------------------------
 # Network builders
@@ -343,7 +355,7 @@ def _make_sandbox(name, default, fs_rules, net_policy, net_domain_names = None):
     if net_domain_names == None:
         net_domain_names = []
     def _merge(other):
-        merged_default = deny if (default == deny or other._default == deny) else default
+        merged_default = default if other._default == None else other._default 
         merged_domains = net_domain_names + (other._net_domain_names if hasattr(other, "_net_domain_names") else [])
         return _make_sandbox(name, merged_default, fs_rules + other._fs_rules, net_policy or other._net_policy, merged_domains)
 
@@ -364,7 +376,7 @@ def sandbox(name = None, default = "deny", fs = None, net = None):
         sandbox(
             "example",
             default=deny,
-            fs=[cwd(read=allow), home().child(".ssh", read=allow)],
+            fs=[cwd().allow(read=True), home().child(".ssh").allow(read=True)],
             net=allow,
         )
     """
@@ -413,8 +425,20 @@ def sandbox(name = None, default = "deny", fs = None, net = None):
 # Sandbox support for rule builders (exe, tool)
 # ---------------------------------------------------------------------------
 
+def _expand_children(children):
+    """Expand a list of children, flattening path entries into their nodes."""
+    expanded = []
+    for child in children:
+        if hasattr(child, "_is_path"):
+            expanded.extend(child._nodes)
+        elif hasattr(child, "_node"):
+            expanded.append(child._node)
+        else:
+            expanded.append(child)
+    return expanded
+
 def _with_sandbox_support(node):
-    """Wrap a match tree node with .sandbox() and .also() support."""
+    """Wrap a match tree node with .sandbox(), .on(), and decision support."""
 
     def _allow():
         result = node.allow()
@@ -431,12 +455,17 @@ def _with_sandbox_support(node):
     def _set_sandbox(sb):
         return _with_sandbox_and_node(node, sb)
 
+    def _on(children):
+        expanded = _expand_children(children)
+        result = node.on(expanded)
+        return _with_sandbox_support(result)
+
     return struct(
         allow = _allow,
         deny = _deny,
         ask = _ask,
         sandbox = _set_sandbox,
-        on = node.on,
+        on = _on,
         _node = node,
         _sandbox = None,
     )
@@ -454,13 +483,17 @@ def _with_sandbox_and_node(node, sb):
         return struct(_node = result, _sandbox = sb)
     def _set_sandbox(new_sb):
         return _with_sandbox_and_node(node, new_sb)
+    def _on(children):
+        expanded = _expand_children(children)
+        result = node.on(expanded)
+        return _with_sandbox_and_node(result, sb)
 
     return struct(
         allow = _allow,
         deny = _deny,
         ask = _ask,
         sandbox = _set_sandbox,
-        on = node.on,
+        on = _on,
         _node = node,
         _sandbox = sb,
     )
@@ -474,10 +507,12 @@ def policy(default = "deny", rules = None):
 
     Usage:
         policy(default=deny, rules=[
-            cwd(read=allow, write=allow),
+            cwd().allow(read=True, write=True),
             exe("git", args=["push"]).deny(),
             exe("git").allow(),
-            domains({"github.com": allow}),
+            tool("Glob").on([
+                cwd().child("src").allow(read=True),
+            ]),
         ])
     """
     if rules == None:
@@ -526,7 +561,7 @@ def _sandbox_to_json(sb):
             "effect": "allow",
             "caps": caps,
             "path": path_str,
-            "path_match": "subpath",
+            "path_match": r.get("match_type", "subpath"),
         })
 
     net = "deny"

--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -76,9 +76,9 @@ The `exe()` builder compiles to match tree nodes that observe the tool name (mus
 
 | S-expression | Starlark |
 |---|---|
-| `(allow (fs read (subpath "/project")))` | `cwd(read = allow)` |
-| `(allow (fs (or read write) (subpath ".")))` | `cwd(read = allow, write = allow)` |
-| `(allow (fs read (subpath "$HOME/.ssh")))` | `home().child(".ssh", read = allow)` |
+| `(allow (fs read (subpath "/project")))` | `cwd().allow(read = True)` |
+| `(allow (fs (or read write) (subpath ".")))` | `cwd().allow(read = True, write = True)` |
+| `(allow (fs read (subpath "$HOME/.ssh")))` | `home().child(".ssh").allow(read = True)` |
 
 The `cwd()` and `home()` builders compile to match tree nodes that observe tool names (`Read`, `Write`, `Edit`, `Glob`, `Grep`) and match the file path argument against a subpath pattern.
 
@@ -111,7 +111,7 @@ def main():
         exe("git", args = ["push"]).deny(),
         exe("git").allow(),
         exe("cargo").allow(),
-        cwd(read = allow),
+        cwd().allow(read = True),
         domains({"github.com": allow}),
     ])
 ```
@@ -126,7 +126,7 @@ Claude Code's built-in format (used before Clash, or in v0.1.x with Clash) used 
 |---|---|
 | `"Bash(git:*)"` in allow | `exe("git").allow()` |
 | `"Bash(rm:*)"` in deny | `exe("rm").deny()` |
-| `"Read(*)"` in allow | `cwd(read = allow)` |
+| `"Read(*)"` in allow | `cwd().allow(read = True)` |
 | `"Read(.env)"` in deny | Use `default = deny` and scope `cwd()` to your project |
 
 ### Full example
@@ -148,7 +148,7 @@ def main():
     return policy(default = deny, rules = [
         exe("rm").deny(),
         exe("git").allow(),
-        cwd(read = allow),
+        cwd().allow(read = True),
     ])
 ```
 
@@ -180,7 +180,7 @@ profiles:
 load("@clash//std.star", "exe", "policy", "cwd")
 
 readonly_rules = [
-    cwd(read = allow),
+    cwd().allow(read = True),
 ]
 
 def main():

--- a/docs/policy-guide.md
+++ b/docs/policy-guide.md
@@ -16,7 +16,7 @@ def main():
     return policy(default = deny, rules = [
         exe("git", args = ["push"]).deny(),
         exe("git").allow(),
-        cwd(read = allow, write = allow),
+        cwd().allow(read = True, write = True),
         domains({"github.com": allow}),
     ])
 ```
@@ -83,9 +83,9 @@ The first argument matches the binary name; `args` matches positional arguments.
 ### Fs -- File Operations
 
 ```python
-cwd(read = allow)
-cwd(read = allow, write = allow)
-home().child(".ssh", read = allow)
+cwd().allow(read = True)
+cwd().allow(read = True, write = True)
+home().child(".ssh").allow(read = True)
 path("/etc").deny()
 ```
 
@@ -149,7 +149,7 @@ load("@clash//std.star", "exe", "policy", "cwd")
 
 def cwd_access():
     return [
-        cwd(read = allow, write = allow),
+        cwd().allow(read = True, write = True),
     ]
 
 def safe_git():
@@ -171,7 +171,7 @@ You can also use `load()` to import from other `.star` files.
 
 ### Merging Policies
 
-The `merge()` method combines two policies into one. Tree nodes and sandboxes from both policies are concatenated, and the most restrictive default effect wins (if either defaults to "deny", the merged result defaults to "deny").
+The `merge()` method combines two policies. In `a.merge(b)`, `b` is merged on top of `a`: `b`'s default effect is used, tree nodes from both are concatenated (`a`'s rules first, then `b`'s), and sandboxes are merged (first defined wins on name conflicts).
 
 ```python
 load("@clash//builtin.star", "base")
@@ -179,7 +179,7 @@ load("@clash//std.star", "exe", "policy", "cwd", "domains")
 
 def main():
     my_policy = policy(default = deny, rules = [
-        cwd(read = allow, write = allow),
+        cwd().allow(read = True, write = True),
         exe("git").allow(),
         domains({"github.com": allow}),
     ])
@@ -218,8 +218,8 @@ def main():
     cargo_env = sandbox(
         default = deny,
         fs = [
-            cwd(read = allow),
-            path("./target", write = allow),
+            cwd().allow(read = True),
+            path("./target").allow(write = True),
         ],
         net = allow,
     )
@@ -227,7 +227,7 @@ def main():
     git_env = sandbox(
         default = deny,
         fs = [
-            cwd(read = allow),
+            cwd().allow(read = True),
         ],
     )
 
@@ -235,7 +235,7 @@ def main():
         exe("git", args = ["push"]).deny(),
         exe("cargo").sandbox(cargo_env).allow(),
         exe("git").sandbox(git_env).allow(),
-        cwd(read = allow),
+        cwd().allow(read = True),
         domains({"github.com": allow}),
     ])
 ```
@@ -311,18 +311,18 @@ exe("git").also(exe("gh"))
 
 ```python
 # Current working directory (with worktree support)
-cwd(read = allow, write = allow)
-cwd(follow_worktrees = True, read = allow, write = allow)
+cwd().allow(read = True, write = True)
+cwd(follow_worktrees = True).allow(read = True, write = True)
 
 # Home directory and subdirectories
-home().child(".ssh", read = allow)
+home().child(".ssh").allow(read = True)
 
 # Temp directories
-tempdir(allow_all = True)
+tempdir().allow()
 
 # Arbitrary paths
-path("/usr/local", read = allow)
-path(env = "CARGO_HOME", read = allow)
+path("/usr/local").allow(read = True)
+path(env = "CARGO_HOME").allow(read = True)
 ```
 
 ### Tools
@@ -421,7 +421,7 @@ load("@clash//std.star", "policy", "cwd")
 
 def main():
     return policy(default = deny, rules = [
-        cwd(read = allow),
+        cwd().allow(read = True),
     ])
 ```
 
@@ -434,7 +434,7 @@ load("@clash//std.star", "exe", "policy", "cwd", "domains")
 
 def main():
     return policy(default = deny, rules = [
-        cwd(read = allow, write = allow),
+        cwd().allow(read = True, write = True),
         exe("cargo").allow(),
         exe("npm").allow(),
         exe("git", args = ["status"]).allow(),
@@ -461,8 +461,8 @@ def main():
         exe("git", args = ["push", "--force"]).deny(),
         exe("git", args = ["reset", "--hard"]).deny(),
         exe("sudo").deny(),
-        path(".env", write = deny),
-        home(write = deny),
+        path(".env").deny(write = True),
+        home().deny(write = True),
     ])
 ```
 
@@ -475,7 +475,7 @@ load("@clash//std.star", "exe", "policy", "cwd")
 
 def main():
     return policy(default = deny, rules = [
-        cwd(read = allow),
+        cwd().allow(read = True),
         exe("cat").allow(),
         exe("ls").allow(),
         exe("grep").allow(),
@@ -493,8 +493,8 @@ def main():
     cargo_env = sandbox(
         default = deny,
         fs = [
-            cwd(read = allow),
-            path("./target", write = allow),
+            cwd().allow(read = True),
+            path("./target").allow(write = True),
         ],
         net = allow,
     )
@@ -502,8 +502,8 @@ def main():
     npm_env = sandbox(
         default = deny,
         fs = [
-            cwd(read = allow),
-            path("./node_modules", write = allow),
+            cwd().allow(read = True),
+            path("./node_modules").allow(write = True),
         ],
         net = domains({"registry.npmjs.org": allow}),
     )
@@ -511,7 +511,7 @@ def main():
     return policy(default = deny, rules = [
         exe("cargo").sandbox(cargo_env).allow(),
         exe("npm").sandbox(npm_env).allow(),
-        cwd(read = allow),
+        cwd().allow(read = True),
     ])
 ```
 

--- a/docs/session-context.md
+++ b/docs/session-context.md
@@ -146,7 +146,7 @@ Suggest one of these fixes:
    ```python
    cargo_env = sandbox(
        default = deny,
-       fs = [cwd(read = allow)],
+       fs = [cwd().allow(read = True)],
        net = allow,
    )
    ```
@@ -177,8 +177,8 @@ Suggest adding the blocked paths to their policy:
    my_env = sandbox(
        default = deny,
        fs = [
-           cwd(read = allow, write = allow),
-           path("/Users/user/.fly", read = allow, write = allow),
+           cwd().allow(read = True, write = True),
+           path("/Users/user/.fly").allow(read = True, write = True),
        ],
    )
    ```

--- a/site/index.md
+++ b/site/index.md
@@ -113,7 +113,7 @@ load("@clash//std.star", "exe", "policy", "cwd", "domains")
 
 def main():
     my_rules = policy(default = ask, rules = [
-        cwd(follow_worktrees = True, read = allow, write = allow),
+        cwd(follow_worktrees = True).allow(read = True, write = True),
         exe("cargo").allow(),
         exe("git", args = ["push"]).deny(),
         exe("git", args = ["reset", "--hard"]).deny(),

--- a/site/pages/migration.md
+++ b/site/pages/migration.md
@@ -43,9 +43,9 @@ The Starlark builders (`exe()`, `cwd()`, `domains()`) compile down to match tree
 
 | S-expression | Starlark |
 |---|---|
-| `(allow (fs read (subpath ".")))` | `cwd(read = allow)` |
-| `(allow (fs (or read write) (subpath ".")))` | `cwd(read = allow, write = allow)` |
-| `(allow (fs read (subpath "$HOME/.ssh")))` | `home().child(".ssh", read = allow)` |
+| `(allow (fs read (subpath ".")))` | `cwd().allow(read = True)` |
+| `(allow (fs (or read write) (subpath ".")))` | `cwd().allow(read = True, write = True)` |
+| `(allow (fs read (subpath "$HOME/.ssh")))` | `home().child(".ssh").allow(read = True)` |
 
 ### Network rules
 
@@ -80,7 +80,7 @@ def main():
         exe("git", args = ["push"]).deny(),
         exe("git").allow(),
         exe("cargo").allow(),
-        cwd(read = allow),
+        cwd().allow(read = True),
         domains({"github.com": allow}),
     ])
 ```
@@ -99,7 +99,7 @@ Claude Code's built-in format (pre-Clash, or v0.1.x) used tool-name patterns.
 |---|---|
 | `"Bash(git:*)"` in allow | `exe("git").allow()` |
 | `"Bash(rm:*)"` in deny | `exe("rm").deny()` |
-| `"Read(*)"` in allow | `cwd(read = allow)` |
+| `"Read(*)"` in allow | `cwd().allow(read = True)` |
 | `"Read(.env)"` in deny | Use `default = deny` and scope `cwd()` to your project |
 
 <div class="migration-compare">
@@ -124,7 +124,7 @@ def main():
     return policy(default = deny, rules = [
         exe("rm").deny(),
         exe("git").allow(),
-        cwd(read = allow),
+        cwd().allow(read = True),
     ])
 ```
 
@@ -163,7 +163,7 @@ profiles:
 load("@clash//std.star", "exe", "policy", "cwd")
 
 readonly_rules = [
-    cwd(read = allow),
+    cwd().allow(read = True),
 ]
 
 def main():

--- a/site/pages/policy.md
+++ b/site/pages/policy.md
@@ -78,10 +78,10 @@ The `exe()` builder matches binary names. The `args` parameter matches positiona
 ### Fs — file operations
 
 ```python
-cwd(read = allow)                          # read under working directory
-cwd(read = allow, write = allow)           # read + write under cwd
-cwd(follow_worktrees = True, read = allow) # git worktree-aware
-home().child(".ssh", read = allow)          # read under ~/.ssh
+cwd().allow(read = True)                          # read under working directory
+cwd().allow(read = True, write = True)             # read + write under cwd
+cwd(follow_worktrees = True).allow(read = True)    # git worktree-aware
+home().child(".ssh").allow(read = True)             # read under ~/.ssh
 ```
 
 <details>
@@ -215,7 +215,7 @@ load("safe_git.star", "safe_git_rules")
 
 def main():
     return policy(default = deny, rules = [
-        cwd(follow_worktrees = True, read = allow, write = allow),
+        cwd(follow_worktrees = True).allow(read = True, write = True),
         *safe_git_rules,
         domains({"github.com": allow, "crates.io": allow}),
     ])
@@ -231,7 +231,7 @@ Starlark `load()` imports values from other `.star` files. All composition (func
 
 ### Merging policies
 
-The `merge()` method combines two policies. Tree nodes and sandboxes are concatenated; the most restrictive default effect wins.
+The `merge()` method combines two policies. In `a.merge(b)`, `b` is merged on top: `b`'s default effect is used, tree nodes from both are concatenated (`a`'s rules first, then `b`'s), and sandboxes are merged (first defined wins on name conflicts).
 
 ```python
 load("@clash//builtin.star", "base")
@@ -239,7 +239,7 @@ load("@clash//std.star", "exe", "policy", "cwd", "domains")
 
 def main():
     my_policy = policy(default = deny, rules = [
-        cwd(read = allow, write = allow),
+        cwd().allow(read = True, write = True),
         exe("git").allow(),
         domains({"github.com": allow}),
     ])
@@ -271,7 +271,7 @@ load("@clash//std.star", "exe", "policy", "sandbox", "cwd")
 def main():
     cargo_env = sandbox(
         default = deny,
-        fs = [cwd(read = allow, write = allow)],
+        fs = [cwd().allow(read = True, write = True)],
         net = allow,
     )
     return policy(default = deny, rules = [
@@ -326,7 +326,7 @@ load("@clash//std.star", "policy", "cwd")
 
 def main():
     return policy(default = deny, rules = [
-        cwd(read = allow),
+        cwd().allow(read = True),
     ])
 ```
 
@@ -337,7 +337,7 @@ load("@clash//std.star", "exe", "policy", "cwd", "domains")
 
 def main():
     return policy(default = ask, rules = [
-        cwd(follow_worktrees = True, read = allow, write = allow),
+        cwd(follow_worktrees = True).allow(read = True, write = True),
         exe(["cargo", "npm"]).allow(),
         exe("git", args = ["status"]).allow(),
         exe("git", args = ["diff"]).allow(),
@@ -375,17 +375,17 @@ load("@clash//std.star", "exe", "policy", "sandbox", "cwd", "domains")
 def main():
     cargo_env = sandbox(
         default = deny,
-        fs = [cwd(read = allow, write = allow)],
+        fs = [cwd().allow(read = True, write = True)],
         net = allow,
     )
     npm_env = sandbox(
         default = deny,
-        fs = [cwd(read = allow, write = allow)],
+        fs = [cwd().allow(read = True, write = True)],
         net = [domains({"registry.npmjs.org": allow})],
     )
     return policy(default = deny, rules = [
         exe("cargo").sandbox(cargo_env).allow(),
         exe("npm").sandbox(npm_env).allow(),
-        cwd(read = allow),
+        cwd().allow(read = True),
     ])
 ```


### PR DESCRIPTION
## Summary

- **Consistent path builder API**: Replace combined match+decision pattern with separate match and decision steps, making sandbox path entries work like regular policy rules
- **Explicit path matching**: Add .child() for subpath, .file() for exact match, .match(regex()) for regex patterns. Support nesting path entries under tool rules via .on()
- **Tree display**: Show policy decision tree with box-drawing characters instead of flat denormalized list
- **Compile-time dedup**: Node deduplication happens in Node::compact during compilation, not at display time
- **Merge semantics**: a.merge(b) now uses b default effect (merged-on-top policy wins), replacing the old most restrictive wins behavior
- **Docs/site updated**: All stdlib presets, migration guide, policy guide, and site pages updated to new API

## Test plan

- [ ] cargo test -p clash_starlark - all existing + 5 new tests for .file(), .match(), .on() with path entries
- [ ] cargo test -p clash - policy compilation and match tree tests
- [ ] clash policy validate - verify installed policy compiles with new API
- [ ] clash status - verify tree display renders correctly