### PR TITLE
refactor(policy): unify path resolution into PathResolver

### DIFF
--- a/clash/src/debug/sandbox.rs
+++ b/clash/src/debug/sandbox.rs
@@ -240,10 +240,13 @@ pub fn inspect(tool: &str, input: Option<&str>) -> Result<SandboxReport> {
 
 /// Compute effective capabilities for a set of notable paths.
 fn compute_notable_path_caps(policy: &SandboxPolicy, cwd: &str) -> Vec<(String, Cap)> {
-    let home = dirs::home_dir()
-        .map(|h| h.to_string_lossy().into_owned())
-        .unwrap_or_else(|| "/home".into());
-    let tmpdir = std::env::var("TMPDIR").unwrap_or_else(|_| "/tmp".into());
+    let resolver = crate::policy::path::PathResolver::from_env();
+    let home = if resolver.home().is_empty() {
+        "/home".to_string()
+    } else {
+        resolver.home().to_string()
+    };
+    let tmpdir = resolver.tmpdir().to_string();
 
     let mut paths = vec![
         (cwd.to_string(), "CWD"),

--- a/clash/src/policy/match_tree.rs
+++ b/clash/src/policy/match_tree.rs
@@ -551,12 +551,7 @@ impl QueryContext {
 
 /// Resolve a potentially relative path against CWD.
 fn resolve_relative_path(path: &str) -> String {
-    if path.starts_with('/') {
-        path.to_string()
-    } else {
-        let cwd = std::env::var("PWD").unwrap_or_default();
-        format!("{cwd}/{path}")
-    }
+    super::path::PathResolver::from_env().resolve_relative(path)
 }
 
 /// Extract the domain from a URL string.

--- a/clash/src/policy/mod.rs
+++ b/clash/src/policy/mod.rs
@@ -7,6 +7,7 @@ pub mod compile;
 pub mod error;
 pub mod ir;
 pub mod match_tree;
+pub mod path;
 pub mod sandbox_types;
 
 pub use compile::compile_multi_level_to_tree;

--- a/clash/src/policy/path.rs
+++ b/clash/src/policy/path.rs
@@ -1,0 +1,118 @@
+//! Unified path resolution for sandbox enforcement.
+//!
+//! Centralises environment-variable expansion (`$PWD`, `$HOME`, `$TMPDIR`)
+//! and relative-path resolution into a single [`PathResolver`] type so that
+//! every callsite in the codebase behaves consistently.
+
+/// Resolves environment-variable placeholders in paths.
+///
+/// Constructed with explicit `cwd`, `home`, and `tmpdir` values so that
+/// resolution is deterministic and never reads the ambient environment.
+#[derive(Debug, Clone)]
+pub struct PathResolver {
+    cwd: String,
+    home: String,
+    tmpdir: String,
+}
+
+impl PathResolver {
+    /// Build a resolver from explicit values.
+    pub fn new(cwd: impl Into<String>, home: impl Into<String>, tmpdir: impl Into<String>) -> Self {
+        Self {
+            cwd: cwd.into(),
+            home: home.into(),
+            tmpdir: tmpdir.into(),
+        }
+    }
+
+    /// Build a resolver by reading the current process environment once.
+    pub fn from_env() -> Self {
+        let cwd = std::env::var("PWD").unwrap_or_default();
+        let home = dirs::home_dir()
+            .map(|p| p.to_string_lossy().into_owned())
+            .unwrap_or_default();
+        let tmpdir = std::env::var("TMPDIR").unwrap_or_else(|_| "/tmp".into());
+        Self { cwd, home, tmpdir }
+    }
+
+    /// Expand `$PWD`, `$HOME`, and `$TMPDIR` in `path`.
+    pub fn resolve_env_vars(&self, path: &str) -> String {
+        path.replace("$PWD", &self.cwd)
+            .replace("$HOME", &self.home)
+            .replace("$TMPDIR", &self.tmpdir)
+    }
+
+    /// Expand environment variables, then make relative paths absolute
+    /// by prepending the resolver's CWD.
+    pub fn resolve_relative(&self, path: &str) -> String {
+        let expanded = self.resolve_env_vars(path);
+        if expanded.starts_with('/') {
+            expanded
+        } else {
+            format!("{}/{}", self.cwd, expanded)
+        }
+    }
+
+    /// The working directory this resolver was built with.
+    pub fn cwd(&self) -> &str {
+        &self.cwd
+    }
+
+    /// The home directory this resolver was built with.
+    pub fn home(&self) -> &str {
+        &self.home
+    }
+
+    /// The temp directory this resolver was built with.
+    pub fn tmpdir(&self) -> &str {
+        &self.tmpdir
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn resolver() -> PathResolver {
+        PathResolver::new("/work", "/home/alice", "/tmp")
+    }
+
+    #[test]
+    fn resolve_env_vars_replaces_all_placeholders() {
+        let r = resolver();
+        assert_eq!(r.resolve_env_vars("$PWD/src"), "/work/src");
+        assert_eq!(r.resolve_env_vars("$HOME/.config"), "/home/alice/.config");
+        assert_eq!(r.resolve_env_vars("$TMPDIR/build"), "/tmp/build");
+    }
+
+    #[test]
+    fn resolve_env_vars_no_placeholder() {
+        let r = resolver();
+        assert_eq!(r.resolve_env_vars("/usr/bin"), "/usr/bin");
+    }
+
+    #[test]
+    fn resolve_relative_makes_relative_absolute() {
+        let r = resolver();
+        assert_eq!(r.resolve_relative("src/main.rs"), "/work/src/main.rs");
+    }
+
+    #[test]
+    fn resolve_relative_keeps_absolute() {
+        let r = resolver();
+        assert_eq!(r.resolve_relative("/etc/passwd"), "/etc/passwd");
+    }
+
+    #[test]
+    fn resolve_relative_expands_then_resolves() {
+        let r = resolver();
+        // $PWD/foo is already absolute after expansion
+        assert_eq!(r.resolve_relative("$PWD/foo"), "/work/foo");
+    }
+
+    #[test]
+    fn from_env_does_not_panic() {
+        // Smoke test — just make sure it doesn't blow up.
+        let _ = PathResolver::from_env();
+    }
+}

--- a/clash/src/policy/sandbox_types.rs
+++ b/clash/src/policy/sandbox_types.rs
@@ -322,18 +322,16 @@ impl<'de> Deserialize<'de> for NetworkPolicy {
 
 impl SandboxPolicy {
     /// Resolve a path, expanding environment variables ($PWD, $HOME, $TMPDIR).
+    ///
+    /// This is a convenience wrapper around [`super::path::PathResolver`].
+    /// The `cwd` parameter is used for `$PWD`; `$HOME` and `$TMPDIR` are
+    /// read from the current process environment.
     pub fn resolve_path(path: &str, cwd: &str) -> String {
-        path.replace("$PWD", cwd)
-            .replace(
-                "$HOME",
-                &dirs::home_dir()
-                    .map(|p| p.to_string_lossy().into_owned())
-                    .unwrap_or_default(),
-            )
-            .replace(
-                "$TMPDIR",
-                &std::env::var("TMPDIR").unwrap_or_else(|_| "/tmp".into()),
-            )
+        let home = dirs::home_dir()
+            .map(|p| p.to_string_lossy().into_owned())
+            .unwrap_or_default();
+        let tmpdir = std::env::var("TMPDIR").unwrap_or_else(|_| "/tmp".into());
+        super::path::PathResolver::new(cwd, home, tmpdir).resolve_env_vars(path)
     }
 
     /// Compute the effective capabilities for a given path by evaluating all rules.

--- a/clash/src/shell_cmd.rs
+++ b/clash/src/shell_cmd.rs
@@ -140,15 +140,12 @@ fn make_sandbox_hook(
         // $HOME and $TMPDIR are process-global; $PWD is resolved by sandbox
         // exec via its process cwd (which brush sets correctly).
         let mut resolved = sandbox.clone();
-        let home = dirs::home_dir()
-            .map(|p| p.to_string_lossy().into_owned())
-            .unwrap_or_default();
-        let tmpdir = std::env::var("TMPDIR").unwrap_or_else(|_| "/tmp".into());
+        let resolver = crate::policy::path::PathResolver::from_env();
         for rule in &mut resolved.rules {
             rule.path = rule
                 .path
-                .replace("$HOME", &home)
-                .replace("$TMPDIR", &tmpdir);
+                .replace("$HOME", resolver.home())
+                .replace("$TMPDIR", resolver.tmpdir());
         }
 
         if debug {


### PR DESCRIPTION
## Summary

- Introduces a `PathResolver` struct in `clash/src/policy/path.rs` that centralises `$PWD`/`$HOME`/`$TMPDIR` expansion and relative-path resolution
- `PathResolver::new()` takes explicit values (no ambient env reads); `PathResolver::from_env()` snapshots the environment once
- Updates 4 callsites that previously duplicated env-var resolution independently:
  - `SandboxPolicy::resolve_path()` now delegates to `PathResolver` internally (API unchanged)
  - `resolve_relative_path()` in `match_tree.rs` uses `PathResolver::from_env().resolve_relative()`
  - Shell hook in `shell_cmd.rs` uses `PathResolver` for `$HOME`/`$TMPDIR`
  - Debug sandbox in `debug/sandbox.rs` uses `PathResolver` for notable-path computation
- Includes unit tests for the new type

## Test plan

- [x] All 288 existing `cargo test -p clash` tests pass
- [x] New `policy::path` unit tests cover env-var expansion, relative-path resolution, and `from_env()` smoke test