### PR TITLE
refactor(display): deduplicate user-facing formatting patterns

### DIFF
--- a/clash/src/cmd/explain.rs
+++ b/clash/src/cmd/explain.rs
@@ -2,6 +2,7 @@ use anyhow::{Context, Result};
 use serde::Deserialize;
 use tracing::{Level, instrument};
 
+use crate::display;
 use crate::settings::ClashSettings;
 use crate::style;
 
@@ -86,89 +87,20 @@ pub fn run(json_output: bool, tool: Option<String>, input_arg: Option<String>) -
     let noun = crate::permissions::extract_noun(&input.tool_name, &input.tool_input);
 
     if json_output {
-        let output = serde_json::json!({
-            "effect": format!("{}", decision.effect),
-            "reason": decision.reason,
-            "matched_rules": decision.trace.matched_rules.iter().map(|m| {
-                serde_json::json!({
-                    "rule_index": m.rule_index,
-                    "description": m.description,
-                    "effect": format!("{}", m.effect),
-                })
-            }).collect::<Vec<_>>(),
-            "skipped_rules": decision.trace.skipped_rules.iter().map(|s| {
-                serde_json::json!({
-                    "rule_index": s.rule_index,
-                    "description": s.description,
-                    "reason": s.reason,
-                })
-            }).collect::<Vec<_>>(),
-            "resolution": decision.trace.final_resolution,
-            "sandbox": decision.sandbox.as_ref().map(|s| serde_json::to_value(s).ok()),
-        });
+        let output = display::decision_to_json(&decision);
         println!("{}", serde_json::to_string_pretty(&output)?);
     } else {
-        println!("{}", style::bold("Input:"));
-        println!("  {}   {}", style::cyan("tool:"), input.tool_name);
-        println!("  {}   {}", style::cyan("noun:"), noun);
-        println!();
-
-        println!(
-            "{} {}",
-            style::bold("Decision:"),
-            style::effect(&decision.effect.to_string())
-        );
-        if let Some(ref reason) = decision.reason {
-            println!("{} {}", style::bold("Reason:  "), reason);
-        }
-        println!();
-
-        if !decision.trace.matched_rules.is_empty() {
-            println!("{}", style::header("Matched rules:"));
-            for m in &decision.trace.matched_rules {
-                let eff = style::effect(&m.effect.to_string());
-                println!("  [{}] {} -> {}", m.rule_index, m.description, eff);
-            }
-            println!();
-        }
-
-        if !decision.trace.skipped_rules.is_empty() {
-            println!("{}", style::dim("Skipped rules:"));
-            for s in &decision.trace.skipped_rules {
-                println!(
-                    "  {} {} {}",
-                    style::dim(&format!("[{}]", s.rule_index)),
-                    style::dim(&s.description),
-                    style::dim(&format!("({})", s.reason))
-                );
-            }
-            println!();
-        }
-
-        println!(
-            "{} {}",
-            style::bold("Resolution:"),
-            style::effect(&decision.trace.final_resolution.clone())
-        );
+        let mut lines = display::format_tool_header("Input:", &input.tool_name, &noun);
+        lines.push(String::new());
+        lines.extend(display::format_decision(&decision));
 
         if let Some(ref sandbox) = decision.sandbox {
-            println!();
-            println!("{}", style::header("Sandbox policy:"));
-            println!(
-                "  {}: {}",
-                style::cyan("default"),
-                sandbox.default.display()
-            );
-            println!("  {}: {:?}", style::cyan("network"), sandbox.network);
-            for rule in &sandbox.rules {
-                println!(
-                    "  {:?} {} in {}",
-                    rule.effect,
-                    rule.caps.display(),
-                    rule.path
-                );
-            }
+            lines.push(String::new());
+            lines.push(style::header("Sandbox policy:").to_string());
+            lines.extend(display::format_sandbox_summary(sandbox));
         }
+
+        println!("{}", lines.join("\n"));
     }
 
     Ok(())

--- a/clash/src/cmd/status.rs
+++ b/clash/src/cmd/status.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
 use tracing::{Level, instrument};
 
+use crate::display;
 use crate::policy::Effect;
 use crate::settings::{ClashSettings, PolicyLevel};
 use crate::style;
@@ -177,25 +178,9 @@ fn colorize_tree_line(line: &str) -> String {
     if let Some(idx) = line.rfind(" → ") {
         let (prefix, rest) = line.split_at(idx);
         let effect = &rest[" → ".len()..];
-        let colored_effect = if effect.starts_with("allow") {
-            format!("{}{}", style::green("allow"), &effect["allow".len()..])
-        } else if effect.starts_with("deny") {
-            format!("{}{}", style::red("deny"), &effect["deny".len()..])
-        } else if effect.starts_with("ask") {
-            format!("{}{}", style::yellow("ask"), &effect["ask".len()..])
-        } else {
-            effect.to_string()
-        };
-        format!("{} → {}", prefix, colored_effect)
+        format!("{} → {}", prefix, display::colorize_effect_prefix(effect))
     } else if line.starts_with("allow") || line.starts_with("deny") || line.starts_with("ask") {
-        // Bare decision node (no condition prefix)
-        if line.starts_with("allow") {
-            format!("{}{}", style::green("allow"), &line["allow".len()..])
-        } else if line.starts_with("deny") {
-            format!("{}{}", style::red("deny"), &line["deny".len()..])
-        } else {
-            format!("{}{}", style::yellow("ask"), &line["ask".len()..])
-        }
+        display::colorize_effect_prefix(line)
     } else {
         line.to_string()
     }

--- a/clash/src/debug/replay.rs
+++ b/clash/src/debug/replay.rs
@@ -2,8 +2,8 @@
 
 use anyhow::{Context, Result};
 
+use crate::display;
 use crate::policy::ir::PolicyDecision;
-use crate::policy::sandbox_types::SandboxPolicy;
 use crate::settings::ClashSettings;
 use crate::style;
 
@@ -18,50 +18,9 @@ pub struct ReplayResult {
 impl ReplayResult {
     /// Render as human-readable text.
     pub fn format_human(&self) -> String {
-        let mut lines = Vec::new();
-
-        lines.push(style::bold("Input:").to_string());
-        lines.push(format!("  {}   {}", style::cyan("tool:"), self.tool_name));
-        lines.push(format!("  {}   {}", style::cyan("noun:"), self.noun));
+        let mut lines = display::format_tool_header("Input:", &self.tool_name, &self.noun);
         lines.push(String::new());
-
-        lines.push(format!(
-            "{} {}",
-            style::bold("Decision:"),
-            style::effect(&self.decision.effect.to_string())
-        ));
-        if let Some(ref reason) = self.decision.reason {
-            lines.push(format!("{} {}", style::bold("Reason:  "), reason));
-        }
-        lines.push(String::new());
-
-        if !self.decision.trace.matched_rules.is_empty() {
-            lines.push(style::header("Matched rules:").to_string());
-            for m in &self.decision.trace.matched_rules {
-                let eff = style::effect(&m.effect.to_string());
-                lines.push(format!("  [{}] {} -> {}", m.rule_index, m.description, eff));
-            }
-            lines.push(String::new());
-        }
-
-        if !self.decision.trace.skipped_rules.is_empty() {
-            lines.push(style::dim("Skipped rules:").to_string());
-            for s in &self.decision.trace.skipped_rules {
-                lines.push(format!(
-                    "  {} {} {}",
-                    style::dim(&format!("[{}]", s.rule_index)),
-                    style::dim(&s.description),
-                    style::dim(&format!("({})", s.reason))
-                ));
-            }
-            lines.push(String::new());
-        }
-
-        lines.push(format!(
-            "{} {}",
-            style::bold("Resolution:"),
-            style::effect(&self.decision.trace.final_resolution)
-        ));
+        lines.extend(display::format_decision(&self.decision));
 
         if let Some(ref sandbox) = self.decision.sandbox {
             lines.push(String::new());
@@ -75,7 +34,7 @@ impl ReplayResult {
                     .map(|x| x.0.clone())
                     .unwrap_or_default(),
             ));
-            format_sandbox_summary(&mut lines, sandbox);
+            lines.extend(display::format_sandbox_summary(sandbox));
         }
 
         if self.decision.effect == crate::policy::Effect::Deny {
@@ -92,28 +51,11 @@ impl ReplayResult {
 
     /// Render as JSON.
     pub fn format_json(&self) -> Result<String> {
-        let mut output = serde_json::json!({
-            "tool_name": self.tool_name,
-            "noun": self.noun,
-            "effect": format!("{}", self.decision.effect),
-            "reason": self.decision.reason,
-            "matched_rules": self.decision.trace.matched_rules.iter().map(|m| {
-                serde_json::json!({
-                    "rule_index": m.rule_index,
-                    "description": m.description,
-                    "effect": format!("{}", m.effect),
-                })
-            }).collect::<Vec<_>>(),
-            "skipped_rules": self.decision.trace.skipped_rules.iter().map(|s| {
-                serde_json::json!({
-                    "rule_index": s.rule_index,
-                    "description": s.description,
-                    "reason": s.reason,
-                })
-            }).collect::<Vec<_>>(),
-            "resolution": self.decision.trace.final_resolution,
-            "sandbox": self.decision.sandbox.as_ref().map(|s| serde_json::to_value(s).ok()),
-        });
+        let mut output = display::decision_to_json(&self.decision);
+
+        // replay JSON includes tool_name and noun at the top level
+        output["tool_name"] = serde_json::json!(self.tool_name);
+        output["noun"] = serde_json::json!(self.noun);
 
         if self.decision.effect == crate::policy::Effect::Deny {
             output["suggestion"] = serde_json::json!(self.suggest_allow_command());
@@ -214,27 +156,6 @@ fn build_tool_input(tool_name: &str, noun: &str) -> serde_json::Value {
         _ => "command",
     };
     serde_json::json!({ field: noun })
-}
-
-fn format_sandbox_summary(lines: &mut Vec<String>, sandbox: &SandboxPolicy) {
-    lines.push(format!(
-        "  {}: {}",
-        style::cyan("default"),
-        sandbox.default.display()
-    ));
-    lines.push(format!(
-        "  {}: {:?}",
-        style::cyan("network"),
-        sandbox.network
-    ));
-    for rule in &sandbox.rules {
-        lines.push(format!(
-            "  {:?} {} in {}",
-            rule.effect,
-            rule.caps.display(),
-            rule.path
-        ));
-    }
 }
 
 #[cfg(test)]

--- a/clash/src/debug/sandbox.rs
+++ b/clash/src/debug/sandbox.rs
@@ -8,6 +8,7 @@ use std::path::Path;
 
 use anyhow::{Context, Result};
 
+use crate::display;
 use crate::policy::sandbox_types::{Cap, NetworkPolicy, SandboxPolicy};
 use crate::settings::ClashSettings;
 use crate::style;
@@ -31,11 +32,8 @@ pub struct SandboxReport {
 impl SandboxReport {
     /// Render as human-readable text.
     pub fn format_human(&self) -> String {
-        let mut lines = Vec::new();
-
-        lines.push(style::bold("Sandbox inspection:").to_string());
-        lines.push(format!("  {}   {}", style::cyan("tool:"), self.tool_name));
-        lines.push(format!("  {}   {}", style::cyan("noun:"), self.noun));
+        let mut lines =
+            display::format_tool_header("Sandbox inspection:", &self.tool_name, &self.noun);
         lines.push(format!(
             "  {} {}",
             style::cyan("effect:"),

--- a/clash/src/display.rs
+++ b/clash/src/display.rs
@@ -1,0 +1,128 @@
+//! Shared formatting helpers for human-readable and JSON policy output.
+//!
+//! Centralises the display patterns used by `cmd::explain`, `debug::replay`,
+//! and `debug::sandbox` so that each call-site only needs to join/print the
+//! returned `Vec<String>` lines.
+
+use crate::policy::ir::PolicyDecision;
+use crate::policy::sandbox_types::SandboxPolicy;
+use crate::style;
+
+/// Format the "Input:" header block (tool + noun).
+pub fn format_tool_header(title: &str, tool_name: &str, noun: &str) -> Vec<String> {
+    vec![
+        style::bold(title).to_string(),
+        format!("  {}   {}", style::cyan("tool:"), tool_name),
+        format!("  {}   {}", style::cyan("noun:"), noun),
+    ]
+}
+
+/// Format a policy decision: effect, reason, matched/skipped rules, resolution.
+pub fn format_decision(decision: &PolicyDecision) -> Vec<String> {
+    let mut lines = Vec::new();
+
+    lines.push(format!(
+        "{} {}",
+        style::bold("Decision:"),
+        style::effect(&decision.effect.to_string())
+    ));
+    if let Some(ref reason) = decision.reason {
+        lines.push(format!("{} {}", style::bold("Reason:  "), reason));
+    }
+    lines.push(String::new());
+
+    if !decision.trace.matched_rules.is_empty() {
+        lines.push(style::header("Matched rules:").to_string());
+        for m in &decision.trace.matched_rules {
+            let eff = style::effect(&m.effect.to_string());
+            lines.push(format!("  [{}] {} -> {}", m.rule_index, m.description, eff));
+        }
+        lines.push(String::new());
+    }
+
+    if !decision.trace.skipped_rules.is_empty() {
+        lines.push(style::dim("Skipped rules:").to_string());
+        for s in &decision.trace.skipped_rules {
+            lines.push(format!(
+                "  {} {} {}",
+                style::dim(&format!("[{}]", s.rule_index)),
+                style::dim(&s.description),
+                style::dim(&format!("({})", s.reason))
+            ));
+        }
+        lines.push(String::new());
+    }
+
+    lines.push(format!(
+        "{} {}",
+        style::bold("Resolution:"),
+        style::effect(&decision.trace.final_resolution)
+    ));
+
+    lines
+}
+
+/// Format a sandbox policy summary (default caps, network, rules).
+pub fn format_sandbox_summary(sandbox: &SandboxPolicy) -> Vec<String> {
+    let mut lines = Vec::new();
+    lines.push(format!(
+        "  {}: {}",
+        style::cyan("default"),
+        sandbox.default.display()
+    ));
+    lines.push(format!(
+        "  {}: {:?}",
+        style::cyan("network"),
+        sandbox.network
+    ));
+    for rule in &sandbox.rules {
+        lines.push(format!(
+            "  {:?} {} in {}",
+            rule.effect,
+            rule.caps.display(),
+            rule.path
+        ));
+    }
+    lines
+}
+
+/// Build the standard JSON representation of a policy decision.
+pub fn decision_to_json(decision: &PolicyDecision) -> serde_json::Value {
+    serde_json::json!({
+        "effect": format!("{}", decision.effect),
+        "reason": decision.reason,
+        "matched_rules": decision.trace.matched_rules.iter().map(|m| {
+            serde_json::json!({
+                "rule_index": m.rule_index,
+                "description": m.description,
+                "effect": format!("{}", m.effect),
+            })
+        }).collect::<Vec<_>>(),
+        "skipped_rules": decision.trace.skipped_rules.iter().map(|s| {
+            serde_json::json!({
+                "rule_index": s.rule_index,
+                "description": s.description,
+                "reason": s.reason,
+            })
+        }).collect::<Vec<_>>(),
+        "resolution": decision.trace.final_resolution,
+        "sandbox": decision.sandbox.as_ref().map(|s| serde_json::to_value(s).ok()),
+    })
+}
+
+/// Colorize an effect string that may have a trailing suffix.
+///
+/// For example, `"allow (sandbox: test)"` will colour the `"allow"` prefix
+/// green and leave `" (sandbox: test)"` unstyled.  This replaces the inline
+/// reimplementation that was previously in `cmd::status::colorize_tree_line`.
+pub fn colorize_effect_prefix(text: &str) -> String {
+    if text.starts_with("allow") {
+        format!("{}{}", style::green("allow"), &text["allow".len()..])
+    } else if text.starts_with("deny") {
+        format!("{}{}", style::red("deny"), &text["deny".len()..])
+    } else if text.starts_with("ask") {
+        format!("{}{}", style::yellow("ask"), &text["ask".len()..])
+    } else {
+        text.to_string()
+    }
+}

--- a/clash/src/lib.rs
+++ b/clash/src/lib.rs
@@ -32,6 +32,7 @@ pub mod audit;
 pub mod cli;
 pub mod cmd;
 pub mod debug;
+pub mod display;
 pub mod errors;
 pub mod git;
 pub mod handlers;


### PR DESCRIPTION
## Summary

- Extract repeated display/formatting patterns from `cmd::explain`, `debug::replay`, `debug::sandbox`, and `cmd::status` into a new `clash::display` module
- New shared helpers: `format_tool_header`, `format_decision`, `format_sandbox_summary`, `decision_to_json`, and `colorize_effect_prefix`
- Remove the now-redundant `format_sandbox_summary` from `replay.rs` and simplify `colorize_tree_line` in `status.rs`

## Motivation

Several files had near-identical blocks for rendering tool headers ("Input: tool/noun"), policy decisions (effect, reason, matched/skipped rules, resolution), sandbox summaries, and JSON output. This made it easy for the formats to drift apart and required updating multiple places for any display change.

## Test plan

- [x] `cargo test -p clash` passes (282 tests, no regressions)
- [x] Pure refactor: no changes to visual output or JSON structure
- [x] `cargo clippy -p clash` clean (no new warnings)