### PR TITLE
feat(policy): compile-time sandbox validation and platform warnings

### DIFF
--- a/clash/src/cmd/policy.rs
+++ b/clash/src/cmd/policy.rs
@@ -207,14 +207,19 @@ fn handle_validate(file: Option<std::path::PathBuf>, json: bool) -> Result<()> {
 
         match crate::policy::compile::compile_to_tree(&source) {
             Ok(policy) => {
+                let warnings = policy.platform_warnings();
                 if json {
-                    results.push(serde_json::json!({
+                    let mut entry = serde_json::json!({
                         "level": level.to_string(),
                         "path": path.display().to_string(),
                         "valid": true,
                         "default": format!("{}", policy.default_effect),
                         "rule_count": policy.rule_count(),
-                    }));
+                    });
+                    if !warnings.is_empty() {
+                        entry["warnings"] = serde_json::json!(warnings);
+                    }
+                    results.push(entry);
                 } else {
                     println!(
                         "{} {} {}",
@@ -227,6 +232,13 @@ fn handle_validate(file: Option<std::path::PathBuf>, json: bool) -> Result<()> {
                         style::effect(&policy.default_effect.to_string()),
                         policy.rule_count()
                     );
+                    for w in &warnings {
+                        eprintln!(
+                            "  {} {}",
+                            style::err_yellow("warning:"),
+                            w,
+                        );
+                    }
                 }
             }
             Err(e) => {
@@ -283,15 +295,20 @@ fn validate_single_file(path: &std::path::Path, json: bool) -> Result<()> {
 
     match crate::policy::compile::compile_to_tree(&source) {
         Ok(policy) => {
+            let warnings = policy.platform_warnings();
             if json {
+                let mut output = serde_json::json!({
+                    "valid": true,
+                    "path": path.display().to_string(),
+                    "default": format!("{}", policy.default_effect),
+                    "rule_count": policy.rule_count(),
+                });
+                if !warnings.is_empty() {
+                    output["warnings"] = serde_json::json!(warnings);
+                }
                 println!(
                     "{}",
-                    serde_json::to_string_pretty(&serde_json::json!({
-                        "valid": true,
-                        "path": path.display().to_string(),
-                        "default": format!("{}", policy.default_effect),
-                        "rule_count": policy.rule_count(),
-                    }))?
+                    serde_json::to_string_pretty(&output)?
                 );
             } else {
                 println!("{} {}", style::green_bold("✓"), path.display());
@@ -300,6 +317,13 @@ fn validate_single_file(path: &std::path::Path, json: bool) -> Result<()> {
                     style::effect(&policy.default_effect.to_string()),
                     policy.rule_count()
                 );
+                for w in &warnings {
+                    eprintln!(
+                        "  {} {}",
+                        style::err_yellow("warning:"),
+                        w,
+                    );
+                }
             }
             Ok(())
         }

--- a/clash/src/policy/compile.rs
+++ b/clash/src/policy/compile.rs
@@ -148,4 +148,52 @@ mod tests {
         let policy = compile_policy(source).unwrap();
         assert_eq!(policy.tree.len(), 1);
     }
+
+    #[test]
+    fn compile_valid_sandbox_reference() {
+        let source = r#"{
+            "schema_version": 5,
+            "default_effect": "deny",
+            "sandboxes": {
+                "dev": {
+                    "default": ["read", "execute"],
+                    "network": "deny"
+                }
+            },
+            "tree": [{
+                "condition": {
+                    "observe": "tool_name",
+                    "pattern": {"literal": {"literal": "Bash"}},
+                    "children": [{"decision": {"allow": "dev"}}]
+                }
+            }]
+        }"#;
+        let policy = compile_to_tree(source);
+        assert!(policy.is_ok(), "valid sandbox reference should compile");
+        let policy = policy.unwrap();
+        assert!(policy.sandboxes.contains_key("dev"));
+    }
+
+    #[test]
+    fn compile_undefined_sandbox_reference_fails() {
+        let source = r#"{
+            "schema_version": 5,
+            "default_effect": "deny",
+            "sandboxes": {},
+            "tree": [{
+                "condition": {
+                    "observe": "tool_name",
+                    "pattern": {"literal": {"literal": "Bash"}},
+                    "children": [{"decision": {"allow": "nonexistent"}}]
+                }
+            }]
+        }"#;
+        let result = compile_to_tree(source);
+        assert!(result.is_err(), "undefined sandbox reference should fail");
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("nonexistent"),
+            "error should mention the undefined sandbox name, got: {err}"
+        );
+    }
 }

--- a/clash/src/policy/match_tree.rs
+++ b/clash/src/policy/match_tree.rs
@@ -928,6 +928,36 @@ impl CompiledPolicy {
             }
         }
     }
+
+    /// Return platform-specific warnings for sandbox policies.
+    ///
+    /// These are non-fatal: the policy is valid but some rules behave
+    /// differently on certain platforms.
+    pub fn platform_warnings(&self) -> Vec<String> {
+        use crate::policy::sandbox_types::{NetworkPolicy, PathMatch};
+
+        let mut warnings = Vec::new();
+        for (name, sandbox) in &self.sandboxes {
+            for rule in &sandbox.rules {
+                if rule.path_match == PathMatch::Regex {
+                    warnings.push(format!(
+                        "sandbox '{}': regex path rule '{}' is not enforced on Linux \
+                         (Landlock cannot match regex paths)",
+                        name, rule.path,
+                    ));
+                }
+            }
+            if let NetworkPolicy::AllowDomains(domains) = &sandbox.network {
+                warnings.push(format!(
+                    "sandbox '{}': domain filtering ({}) is advisory on Linux \
+                     (relies on HTTP_PROXY which programs can bypass)",
+                    name,
+                    domains.join(", "),
+                ));
+            }
+        }
+        warnings
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -1713,5 +1743,85 @@ mod tests {
         assert!(ctx.fs_op.is_none());
         assert!(ctx.fs_path.is_none());
         assert!(ctx.net_domain.is_none());
+    }
+
+    // -----------------------------------------------------------------------
+    // platform_warnings tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn platform_warnings_regex_path() {
+        use crate::policy::sandbox_types::*;
+
+        let policy = CompiledPolicy {
+            sandboxes: HashMap::from([(
+                "dev".to_string(),
+                SandboxPolicy {
+                    default: Cap::READ | Cap::EXECUTE,
+                    rules: vec![SandboxRule {
+                        effect: RuleEffect::Allow,
+                        caps: Cap::WRITE,
+                        path: r"/tmp/build-\d+".to_string(),
+                        path_match: PathMatch::Regex,
+                    }],
+                    network: NetworkPolicy::Deny,
+                },
+            )]),
+            tree: vec![],
+            default_effect: Effect::Deny,
+            default_sandbox: None,
+        };
+        let warnings = policy.platform_warnings();
+        assert_eq!(warnings.len(), 1);
+        assert!(warnings[0].contains("regex"));
+        assert!(warnings[0].contains("Linux"));
+    }
+
+    #[test]
+    fn platform_warnings_allow_domains() {
+        use crate::policy::sandbox_types::*;
+
+        let policy = CompiledPolicy {
+            sandboxes: HashMap::from([(
+                "net".to_string(),
+                SandboxPolicy {
+                    default: Cap::READ | Cap::EXECUTE,
+                    rules: vec![],
+                    network: NetworkPolicy::AllowDomains(vec!["github.com".to_string()]),
+                },
+            )]),
+            tree: vec![],
+            default_effect: Effect::Deny,
+            default_sandbox: None,
+        };
+        let warnings = policy.platform_warnings();
+        assert_eq!(warnings.len(), 1);
+        assert!(warnings[0].contains("advisory"));
+        assert!(warnings[0].contains("Linux"));
+    }
+
+    #[test]
+    fn platform_warnings_none_for_clean_policy() {
+        use crate::policy::sandbox_types::*;
+
+        let policy = CompiledPolicy {
+            sandboxes: HashMap::from([(
+                "dev".to_string(),
+                SandboxPolicy {
+                    default: Cap::READ | Cap::EXECUTE,
+                    rules: vec![SandboxRule {
+                        effect: RuleEffect::Allow,
+                        caps: Cap::WRITE,
+                        path: "/tmp".to_string(),
+                        path_match: PathMatch::Subpath,
+                    }],
+                    network: NetworkPolicy::Deny,
+                },
+            )]),
+            tree: vec![],
+            default_effect: Effect::Deny,
+            default_sandbox: None,
+        };
+        assert!(policy.platform_warnings().is_empty());
     }
 }


### PR DESCRIPTION
## Summary

- **Sandbox reference validation at compile time**: The existing `CompiledPolicy::validate()` method already checks that sandbox references in decision nodes point to defined sandbox names. Added tests in `compile.rs` that exercise this validation through the public `compile_to_tree()` API, confirming that valid references compile and undefined references produce clear errors.

- **Platform-specific warnings in `clash policy validate`**: Added a `platform_warnings()` method on `CompiledPolicy` that detects two cross-platform gotchas:
  - Regex path rules in sandboxes (not enforced on Linux — Landlock cannot match regex paths)
  - `AllowDomains` network policies (advisory on Linux — relies on `HTTP_PROXY` which programs can bypass)

  Warnings are printed to stderr (not errors) in human-readable mode, and included in the JSON output under a `"warnings"` key. Both the multi-level and single-file validation paths emit these warnings.

- **Tests**: 5 new tests covering sandbox reference validation (valid + undefined) and platform warnings (regex path, AllowDomains, clean policy).

## Test plan

- [x] `cargo test -p clash` — all 287 tests pass
- [ ] Manual: create a policy with a regex path sandbox rule, run `clash policy validate`, verify warning appears
- [ ] Manual: create a policy referencing an undefined sandbox, verify compilation fails with clear error message

> **Note**: This PR depends on #286 for the broader policy loader refactor context, but the changes here are self-contained on `main`.