### PR TITLE
fix(starlark): compile deny rules into sandbox fs rules

### DIFF
--- a/clash_starlark/stdlib/std.star
+++ b/clash_starlark/stdlib/std.star
@@ -232,7 +232,7 @@ def _path_match(path_value, worktree = False, match_type = "literal"):
         nodes = _fs_nodes(path_pat, _read, _write)
 
         sandbox_rules = []
-        if effect == allow:
+        if effect == allow or effect == deny:
             caps = _caps_from_bools(
                 read or all_ops,
                 write or all_ops,
@@ -241,6 +241,7 @@ def _path_match(path_value, worktree = False, match_type = "literal"):
             )
             if len(caps) > 0:
                 sandbox_rules.append({
+                    "effect": "allow" if effect == allow else "deny",
                     "path_value": path_value,
                     "caps": caps,
                     "match_type": match_type,
@@ -593,7 +594,7 @@ def _sandbox_to_json(sb):
         path_str = _resolve_path_value(pv)
         caps = r.get("caps", ["read", "write", "create"])
         rules.append({
-            "effect": "allow",
+            "effect": r.get("effect", "allow"),
             "caps": caps,
             "path": path_str,
             "path_match": r.get("match_type", "subpath"),


### PR DESCRIPTION
## Summary

- `.deny()` on path selectors (e.g. `path("/Users").recurse().deny()`) was silently dropped during Starlark-to-JSON compilation — deny rules never appeared in the sandbox IR
- Two bugs in `std.star`:
  - `_resolve()` only collected sandbox rules when `effect == allow`, skipping deny entirely
  - `_sandbox_to_json()` hardcoded `"effect": "allow"` for all rules, so even if deny rules were present they'd be emitted as allows

## Test plan

- [x] `just check` — all 33 steps pass
- [x] Manually verify: add `path("/Users").recurse().deny()` to a sandbox's `fs=` list, run `clash status`, confirm the deny rule appears