### PR TITLE
Rewrite website: position clash as a general-purpose sandbox tool

### DIFF
--- a/site/_data/site.json
+++ b/site/_data/site.json
@@ -1,5 +1,5 @@
 {
   "title": "Clash",
-  "description": "Command Line Agent Safety Harness",
+  "description": "Pattern-matching sandboxes for commands you don't fully trust",
   "repo": "https://github.com/empathic/clash"
 }

--- a/site/_includes/base.njk
+++ b/site/_includes/base.njk
@@ -66,7 +66,7 @@
         <a href="https://crates.io/crates/clash">crates.io</a>
         <a href="https://docs.rs/clash">docs.rs</a>
       </div>
-      <p class="footer-copy">&copy; 2025 Empathic.</p>
+      <p class="footer-copy">&copy; 2025 <a href="https://empathic.dev">Empathic</a>.</p>
     </div>
   </footer>
 

--- a/site/eleventy.config.js
+++ b/site/eleventy.config.js
@@ -5,6 +5,7 @@ const Prism = require("prismjs");
 require("prismjs/components/prism-json");
 require("prismjs/components/prism-bash");
 require("prismjs/components/prism-lisp");
+require("prismjs/components/prism-python");
 
 function slugify(s) {
   return s

--- a/site/index.md
+++ b/site/index.md
@@ -1,19 +1,17 @@
 ---
 layout: base.njk
 title: Clash
-description: Command Line Agent Safety Harness
+description: Pattern-matching sandboxes for commands you don't fully trust
 ---
 
 <div class="hero">
   <h1 class="hero-title">clash</h1>
-  <p class="hero-tagline">Stop babysitting your agents, go touch grass.</p>
-  <p class="hero-subtitle">Command Line Agent Safety Harness</p>
+  <p class="hero-tagline">Sandbox anything, trust what you run.</p>
+  <p class="hero-subtitle"><strong>C</strong>ommand <strong>L</strong>ine <strong>A</strong>gent <strong>S</strong>afety <strong>H</strong>arness — a pattern-matching policy engine with kernel-enforced sandboxes for AI agents, build scripts, or anything you don't fully trust.</p>
   <div class="hero-install">
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/empathic/clash/main/install.sh | bash
-clash init
-claude
 ```
 
   </div>
@@ -27,46 +25,35 @@ claude
 
 <div class="section">
 
-## The problem
+## One tool, two modes
 
-Coding agents operate with broad tool access — executing commands, editing
-files, and making network requests on your behalf. Their permission models tend
-to be all-or-nothing: either you allow a tool entirely or get prompted every
-time.
-
-You end up clicking "yes" hundreds of times a session, or giving blanket
-approval and hoping for the best.
-
-Clash gives you granular control. Write policy rules that decide what to
-**allow**, **deny**, or **ask** about — then let the agent work freely on safe
-operations while blocking dangerous ones. On Linux, rules can generate
-kernel-enforced filesystem sandboxes so even allowed commands can only touch the
-files you specify.
-
-</div>
-
-<div class="divider">
-  <span class="divider-dot divider-dot--green"></span>
-  <span class="divider-dot divider-dot--amber"></span>
-  <span class="divider-dot divider-dot--red"></span>
-</div>
-
-<div class="section">
-
-## Three concepts
+Clash works standalone or as an agent plugin. Same policy engine, same kernel sandboxes, same rules.
 
 <div class="cards">
   <div class="card card--green">
-    <h3>Rule</h3>
-    <p>An effect paired with a capability matcher. <code>exe("git").allow()</code> lets the agent run any git command. <code>exe("git", args=["push"]).deny()</code> blocks pushes. Rules use first-match semantics — put specific rules before broad ones.</p>
+    <h3>Sandbox any command</h3>
+    <p>Run any command inside a sandbox with restricted filesystem and network access. No agent needed — just <code>clash sandbox exec</code>.</p>
+
+```bash
+# create a sandbox: read-only project, no network
+clash sandbox create build --network deny
+clash sandbox add-rule build ./src --caps read
+
+# run a build script inside it
+clash sandbox exec --sandbox build --cwd . \
+  make build
+```
+
   </div>
   <div class="card card--amber">
-    <h3>Domain</h3>
-    <p>Rules target one of three capability domains: <strong>exec</strong> (shell commands), <strong>fs</strong> (file operations), and <strong>net</strong> (network access). Clash speaks in capabilities, not tool names — a single rule can cover multiple agent tools.</p>
-  </div>
-  <div class="card card--red">
-    <h3>Layer</h3>
-    <p>Policies stack in three levels: <strong>User</strong> (personal defaults), <strong>Project</strong> (repo-specific rules), and <strong>Session</strong> (temporary overrides). Higher layers shadow lower layers. Session &gt; Project &gt; User.</p>
+    <h3>Guard your AI agent</h3>
+    <p>Write policy rules that auto-approve safe operations, block dangerous ones, and prompt you only when it matters. Hooks into your agent's plugin system.</p>
+
+```bash
+clash init    # install the agent plugin
+claude        # every tool call now goes through your policy
+```
+
   </div>
 </div>
 
@@ -80,19 +67,19 @@ files you specify.
 
 <div class="section">
 
-## Without Clash vs. with Clash
+## Kernel-enforced, not honor-system
 
-<div class="comparison">
+Clash doesn't ask processes to behave. It tells the kernel what they're allowed to touch.
 
-| Without Clash | With Clash |
-|---|---|
-| Click "yes" hundreds of times per session | Auto-approve safe operations, block dangerous ones |
-| All-or-nothing tool permissions | Granular rules by command, file path, and domain |
-| No visibility into what the agent is doing | Status line shows live allow/deny/ask counts |
-| Trust the agent with everything or nothing | Kernel-enforced sandboxes constrain even allowed commands |
-| Same permissions for every project | Per-project and per-session policy layers |
+On **Linux**, Landlock restricts filesystem access and seccomp + proxy filters network calls. On **macOS**, Seatbelt profiles do the same. Either way: restrictions are inherited by every child process, can't be escaped, and work on any binary — not just programs that opt in.
 
-</div>
+```bash
+# verify your platform supports sandboxing
+clash sandbox check
+
+# test it interactively
+clash sandbox test
+```
 
 </div>
 
@@ -104,56 +91,65 @@ files you specify.
 
 <div class="section">
 
-## A minimal policy
+## Yes, we see the irony
+
+Our install instructions say `curl | bash`. So does every Rust toolchain, Node version manager, and Homebrew setup guide. You've probably run a dozen of these this year. Each one had full access to your home directory, your SSH keys, your shell history, everything.
+
+What if you could sandbox that?
+
+```bash
+# create a sandbox for install scripts:
+# write only to ~/.local/bin, read the rest, no network after download
+clash sandbox create installer --network deny
+clash sandbox add-rule installer ~/.local/bin --caps write
+clash sandbox add-rule installer / --caps read
+
+# now run any install script inside it
+curl -fsSL https://example.com/install.sh \
+  | clash sandbox exec --sandbox installer --cwd /tmp bash
+```
+
+The script can write to `~/.local/bin` and nowhere else. It can't read your SSH keys, can't modify your shell profile, can't phone home. If it tries, the kernel says no.
+
+This is what Clash is for. Not just AI agents — anything you don't trust.
+
+</div>
+
+<div class="divider">
+  <span class="divider-dot divider-dot--green"></span>
+  <span class="divider-dot divider-dot--amber"></span>
+  <span class="divider-dot divider-dot--red"></span>
+</div>
+
+<div class="section">
+
+## Policies that read like English
 
 ```python
-# ~/.clash/policy.star (user level)
+# ~/.clash/policy.star
 load("@clash//builtin.star", "base")
 load("@clash//std.star", "exe", "policy", "cwd", "domains")
 
 def main():
     my_rules = policy(default = ask, rules = [
+        # project files: read and write
         cwd(follow_worktrees = True).allow(read = True, write = True),
+
+        # cargo and git are fine — except the destructive parts
         exe("cargo").allow(),
         exe("git", args = ["push"]).deny(),
         exe("git", args = ["reset", "--hard"]).deny(),
         exe("git").allow(),
+
+        # network: GitHub only
         domains({"github.com": allow}),
     ])
     return my_rules.merge(base)
 ```
 
-<details>
-<summary>Compiled JSON IR</summary>
+Three effects: <span class="badge badge--allow">allow</span> auto-approves, <span class="badge badge--deny">deny</span> blocks, <span class="badge badge--ask">ask</span> prompts you. First match wins. Edits take effect immediately.
 
-```json
-{
-  "schema_version": 5,
-  "default_effect": "ask",
-  "sandboxes": {},
-  "tree": [
-    { "condition": { "observe": "tool_name", "pattern": { "literal": { "literal": "Bash" } },
-        "children": [
-          { "condition": { "observe": { "positional_arg": 0 }, "pattern": { "literal": { "literal": "cargo" } },
-              "children": [{ "decision": { "allow": null } }] } },
-          { "condition": { "observe": { "positional_arg": 0 }, "pattern": { "literal": { "literal": "git" } },
-              "children": [
-                { "condition": { "observe": { "positional_arg": 1 }, "pattern": { "literal": { "literal": "push" } },
-                    "children": [{ "decision": "deny" }] } },
-                { "condition": { "observe": { "positional_arg": 1 }, "pattern": { "literal": { "literal": "reset" } },
-                    "children": [
-                      { "condition": { "observe": { "positional_arg": 2 }, "pattern": { "literal": { "literal": "--hard" } },
-                          "children": [{ "decision": "deny" }] } }
-                    ] } },
-                { "decision": { "allow": null } }
-              ] } }
-        ] } }
-  ]
-}
-```
-</details>
-
-Three effects: <span class="badge badge--allow">allow</span> auto-approves, <span class="badge badge--deny">deny</span> blocks, <span class="badge badge--ask">ask</span> prompts you. First matching rule wins — put specific rules before broad ones. Edits take effect immediately — no restart needed.
+Policies are Starlark (a Python dialect), compiled to a decision tree at load time. Evaluation is in-process and instant — no network, no external process.
 
 </div>
 
@@ -165,23 +161,80 @@ Three effects: <span class="badge badge--allow">allow</span> auto-approves, <spa
 
 <div class="section">
 
-## Quick start
+## How it thinks
+
+<div class="cards">
+  <div class="card card--green">
+    <h3>Pattern match</h3>
+    <p>Every invocation is tested against a tree of pattern-matching rules. Rules match across three domains — <strong>exec</strong> (commands), <strong>fs</strong> (files), and <strong>net</strong> (network). First match wins.</p>
+  </div>
+  <div class="card card--amber">
+    <h3>Sandbox</h3>
+    <p>A matched rule can carry a sandbox — kernel-level restrictions on what the process can touch. Filesystem paths, network access, all inherited by child processes, all inescapable.</p>
+  </div>
+  <div class="card card--red">
+    <h3>Decide</h3>
+    <p>The match resolves to one of three effects: <span class="badge badge--allow">allow</span> (proceed), <span class="badge badge--deny">deny</span> (block), or <span class="badge badge--ask">ask</span> (prompt the user). No match falls through to the policy default.</p>
+  </div>
+</div>
+
+</div>
+
+<div class="divider">
+  <span class="divider-dot divider-dot--green"></span>
+  <span class="divider-dot divider-dot--amber"></span>
+  <span class="divider-dot divider-dot--red"></span>
+</div>
+
+<div class="section">
+
+## Use cases
+
+<div class="cards">
+  <div class="card card--green">
+    <h3>AI agents</h3>
+    <p>Stop clicking "yes" hundreds of times per session. Write policy rules that let your agent work freely on safe operations while blocking dangerous ones. Currently supports <strong>Claude Code</strong>, with more agents planned.</p>
+  </div>
+  <div class="card card--amber">
+    <h3>Build scripts & CI</h3>
+    <p>Sandbox <code>make</code>, <code>npm run</code>, or any build command. Restrict it to the source tree and deny network access — so a compromised dependency can't phone home or read your SSH keys.</p>
+  </div>
+  <div class="card card--red">
+    <h3>Untrusted code</h3>
+    <p>Running something you didn't write? Give it read-only access to what it needs and nothing else. Kernel enforcement means it can't escape — even if it tries.</p>
+  </div>
+</div>
+
+</div>
+
+<div class="divider">
+  <span class="divider-dot divider-dot--green"></span>
+  <span class="divider-dot divider-dot--amber"></span>
+  <span class="divider-dot divider-dot--red"></span>
+</div>
+
+<div class="section">
+
+## Get started
 
 <ol class="steps">
   <li>
-    <strong>Install clash</strong>
+    <strong>Install</strong>
     <pre><code class="language-bash">curl -fsSL https://raw.githubusercontent.com/empathic/clash/main/install.sh | bash</code></pre>
-    Downloads the latest release binary for your platform (Apple Silicon Mac, Linux x86_64, Linux aarch64). On Intel Mac: <code>cargo install clash</code>.
+    Downloads the latest binary for your platform (Apple Silicon, Linux x86_64, Linux aarch64). On Intel Mac: <code>cargo install clash</code>.
   </li>
   <li>
-    <strong>Initialize</strong>
-    <pre><code class="language-bash">clash init</code></pre>
-    Writes a default policy, installs the Claude Code plugin, configures the status line, and walks you through initial setup.
+    <strong>Sandbox a command</strong>
+    <pre><code class="language-bash">clash sandbox create mybox --network deny
+clash sandbox add-rule mybox ./src --caps read
+clash sandbox exec --sandbox mybox --cwd . cat ./src/main.rs</code></pre>
+    You just ran a command with kernel-enforced filesystem and network restrictions.
   </li>
   <li>
-    <strong>Launch your agent</strong>
-    <pre><code class="language-bash">claude</code></pre>
-    Every Claude Code session now loads clash automatically. Use <code>/clash:status</code> inside a session to see your policy in action.
+    <strong>Or hook into your agent</strong>
+    <pre><code class="language-bash">clash init
+claude</code></pre>
+    Every tool call now evaluates against your policy. Use <code>/clash:status</code> to see it working.
   </li>
 </ol>
 
@@ -197,7 +250,7 @@ Three effects: <span class="badge badge--allow">allow</span> auto-approves, <spa
 
 ## Agent support
 
-Clash is designed to be **agent-agnostic** — a universal safety harness for any coding agent that executes tools on your behalf. The policy language and capability model are agent-independent; only the integration layer is specific to each agent.
+Clash's policy engine and sandboxes are agent-independent. The integration layer hooks into each agent's plugin system.
 
 | Agent | Status |
 |---|---|
@@ -206,34 +259,6 @@ Clash is designed to be **agent-agnostic** — a universal safety harness for an
 | [Gemini CLI](https://github.com/google-gemini/gemini-cli) | Planned |
 | [OpenCode](https://github.com/opencode-ai/opencode) | Planned |
 
-Currently, the Claude Code integration is the most mature. If you'd like to help bring Clash to another agent, [contributions are welcome](https://github.com/empathic/clash).
-
-</div>
-
-<div class="divider">
-  <span class="divider-dot divider-dot--green"></span>
-  <span class="divider-dot divider-dot--amber"></span>
-  <span class="divider-dot divider-dot--red"></span>
-</div>
-
-<div class="section">
-
-## How it works
-
-<div class="flow">
-  <span class="flow-node">Agent</span>
-  <span class="flow-arrow">&rarr;</span>
-  <span class="flow-node">hook</span>
-  <span class="flow-arrow">&rarr;</span>
-  <span class="flow-node">clash</span>
-  <span class="flow-arrow">&rarr;</span>
-  <span class="flow-node badge--allow">allow</span>
-  <span class="flow-node badge--deny">deny</span>
-  <span class="flow-node badge--ask">ask</span>
-</div>
-
-Clash integrates via the agent's plugin system. For Claude Code, a plugin registers hooks that intercept every tool call. Each invocation is evaluated against your policy and returns an allow, deny, or ask decision — before the agent executes anything.
-
-The policy is read on every tool call, so edits take effect immediately. On Linux, allowed exec rules can generate Landlock sandboxes; on macOS, Seatbelt profiles constrain filesystem and network access at the kernel level.
+Want to bring Clash to another agent? [Contributions welcome](https://github.com/empathic/clash).
 
 </div>

--- a/site/pages/faq.md
+++ b/site/pages/faq.md
@@ -6,90 +6,98 @@ permalink: /faq/
 ---
 
 <h1 class="page-title">FAQ</h1>
-<p class="page-desc">Common questions about Clash.</p>
+<p class="page-desc">Quick answers to common questions.</p>
+
+## Is Clash only for AI agents?
+
+No. Clash is a general-purpose sandboxing and policy engine. You can use `clash sandbox exec` to sandbox any command — build scripts, install scripts, untrusted binaries, anything. The AI agent integration is one application of the same underlying engine.
+
+---
+
+## How is this different from Docker or Firejail?
+
+Clash is lighter and more targeted. It doesn't virtualize anything — it applies Landlock (Linux) or Seatbelt (macOS) restrictions directly to a process. No container images, no namespaces, no root required. You write a few rules about which paths and network access a command should have, and the kernel enforces them. It's closer to a fine-grained `sandbox-exec` than a container runtime.
+
+---
+
+## How is this different from Claude Code's built-in permissions?
+
+Claude Code gives you per-tool toggles: allow a tool entirely, or get prompted every time. Clash gives you **pattern-matching rules within tools**: allow `git status` while denying `git push`, allow reads under your project while blocking writes to `.env`, allow network access to `github.com` while blocking everything else. Plus kernel-enforced sandboxes, policy composition, and per-project layering.
+
+---
 
 ## Which agents does Clash support?
 
-Currently, **Claude Code** is fully supported. Codex CLI, Gemini CLI, and OpenCode are planned. The policy language and capability model are agent-independent — only the integration layer (hooks) is specific to each agent. See the [agent support table]({{ version.pathPrefix }}/#agent-support) for tracking issues.
+**Claude Code** is fully supported today. Codex CLI, Gemini CLI, and OpenCode are planned. But Clash also works standalone — `clash sandbox exec` sandboxes any command, no agent required. The policy engine is agent-independent; only the hook layer is specific to each agent. See the [agent support table]({{ version.pathPrefix }}/#agent-support).
 
 ---
 
-## How is Clash different from Claude Code's built-in permissions?
+## Will it slow things down?
 
-Claude Code's built-in permission model is all-or-nothing per tool. Clash adds **granular, capability-based rules**: you can allow `git status` while denying `git push`, allow file reads under your project while denying writes to `.env`, or allow network access to `github.com` while blocking everything else. Clash also supports kernel-enforced sandboxes, policy composition, and per-project layering.
-
----
-
-## Does Clash slow down my agent?
-
-No. Clash evaluates policy rules in-process on every tool call with negligible overhead — the policy is compiled into a decision tree at load time. There's no network round-trip, no external process, and no noticeable latency.
+No. Policies compile into a decision tree at load time. Evaluation is in-process with no network round-trip. Sandbox setup adds a few milliseconds at process launch — then the kernel handles enforcement with zero runtime overhead.
 
 ---
 
-## What happens if my policy has a syntax error?
+## What happens if my policy has a bug?
 
-Clash blocks **all actions** when the policy fails to compile, rather than silently degrading. This is a safety-first design: a broken policy should never result in unintended approvals. Run `clash policy validate` to diagnose the error, or `clash init` to start fresh.
+Clash blocks **everything** when the policy fails to compile. A broken policy should never silently approve things. Run `clash policy validate` to find the error, or `clash init` to start over.
 
 ---
 
-## Can I share policies across a team?
+## Can I share policies with my team?
 
-Yes. Use a **project-level** policy at `<repo>/.clash/policy.star` and commit it to version control. Team members get shared rules automatically. Individual developers can override with user-level or session-level policies.
+Yes. Commit a **project-level** policy at `<repo>/.clash/policy.star`. Team members pick it up automatically. Individuals can still override with user-level or session-level policies.
 
 ---
 
 ## How does the kernel sandbox work?
 
-When an exec rule includes a sandbox (via `.sandbox(sb)` in Starlark, or the `"sandbox"` field in JSON IR), Clash generates OS-level restrictions:
+When a rule includes a sandbox, Clash generates OS-level restrictions:
 
-- **Linux:** Landlock LSM constrains filesystem access; seccomp + proxy handles network filtering.
-- **macOS:** Seatbelt profiles restrict filesystem and network access at the kernel level.
+- **Linux:** Landlock constrains filesystem access; seccomp + proxy filters network calls.
+- **macOS:** Seatbelt profiles restrict filesystem and network access.
 
-Sandbox restrictions are inherited by all child processes and cannot be bypassed by the sandboxed command. Run `clash sandbox check` to verify your platform supports sandboxing.
-
----
-
-## Do exec rules apply to subprocesses?
-
-No. Exec rules match only the **top-level command** the agent invokes. If an allowed command like `make deploy` internally calls `git push`, the deny rule for `git push` does not fire. However, **sandbox restrictions** on filesystem and network access *are* enforced on all child processes at the kernel level.
+Restrictions are inherited by all child processes and cannot be bypassed. Run `clash sandbox check` to verify your platform supports it.
 
 ---
 
-## How do I temporarily disable Clash?
+## Do rules apply to subprocesses?
 
-Set the `CLASH_DISABLE` environment variable:
+Exec rules match only the **top-level command**. If `make deploy` internally runs `git push`, the deny rule for `git push` won't fire. However, **sandbox restrictions** on filesystem and network access are enforced on all child processes at the kernel level — that's the whole point.
+
+---
+
+## How do I turn it off temporarily?
 
 ```bash
 CLASH_DISABLE=1 claude
 ```
 
-Clash stays installed but becomes a complete pass-through — no policy enforcement, no sandbox, no prompts. Unset the variable or set it to `0` to re-enable.
+Clash stays installed but becomes a pass-through — no enforcement, no prompts. Unset the variable to re-enable.
 
 ---
 
-## Which platforms are supported?
+## Which platforms work?
 
 - **macOS** — Apple Silicon and Intel
 - **Linux** — x86_64 and aarch64
 - **Windows** — not supported
 
-Kernel sandboxing requires Landlock (Linux 5.13+) or Seatbelt (macOS). Clash works without sandboxing on older kernels, but sandbox rules will be ignored.
+Kernel sandboxing needs Landlock (Linux 5.13+) or Seatbelt (macOS). Clash works without sandboxing on older kernels, but sandbox rules will be ignored.
 
 ---
 
-## How do I uninstall Clash?
+## How do I uninstall?
 
 ```bash
-# Remove the Claude Code plugin (stops hooks immediately)
+# Remove the agent plugin (if using one)
 claude plugin uninstall clash
 
 # Remove the binary
 cargo uninstall clash          # if installed via cargo
-rm -f ~/.local/bin/clash       # if installed via the install script
+rm -f ~/.local/bin/clash       # if installed via install script
 
-# Optional: clean up configuration
+# Optional: clean up config
 rm -rf ~/.clash                # user-level policy and logs
 rm -rf .clash                  # project-level policy
 ```
-
-After removing the plugin, Claude Code reverts to its built-in permission model immediately. Policy files are left in place so you can resume where you left off if you reinstall.

--- a/site/pages/grammar.njk
+++ b/site/pages/grammar.njk
@@ -6,7 +6,7 @@ permalink: /policy/grammar/
 ---
 
 <h1 class="page-title">Policy Schema</h1>
-<p class="page-desc">JSON IR schema (v5) for compiled clash policies. Policies are authored as <a href="{{ version.pathPrefix }}/policy/">Starlark (.star) files</a> and compiled to this format.</p>
+<p class="page-desc">JSON IR schema for compiled clash policies. Policies are authored as <a href="{{ version.pathPrefix }}/policy/">Starlark (.star) files</a> or managed via <code>policy.json</code>, and compiled to this format.</p>
 
 ## Document structure
 
@@ -21,7 +21,7 @@ permalink: /policy/grammar/
 
 | Field | Type | Description |
 |---|---|---|
-| `schema_version` | integer | Always `5` |
+| `schema_version` | integer | Internal version identifier |
 | `default_effect` | string | Effect when no rule matches: `"allow"`, `"deny"`, or `"ask"` |
 | `sandboxes` | object | Named sandbox definitions (may be empty) |
 | `tree` | array | Root-level nodes of the match tree |

--- a/site/pages/policy.md
+++ b/site/pages/policy.md
@@ -6,7 +6,7 @@ permalink: /policy/
 ---
 
 <h1 class="page-title">Policy Language</h1>
-<p class="page-desc">Everything you need to write clash policies. Policies can be written in Starlark (<code>.star</code> files) or managed via <code>policy.json</code> using CLI commands.</p>
+<p class="page-desc">Everything you need to write clash policies. Use Starlark (<code>.star</code>) for expressive, hand-crafted policies. Use <code>policy.json</code> for CLI-driven and tool-managed rules.</p>
 
 ## Effects
 
@@ -23,7 +23,7 @@ exe("git", args = ["commit"]).ask()
 ```
 
 <details>
-<summary>JSON IR (v5 match tree)</summary>
+<summary>Compiled JSON IR</summary>
 
 ```json
 { "condition": { "observe": "tool_name", "pattern": { "literal": { "literal": "Bash" } }, "children": [
@@ -36,13 +36,13 @@ exe("git", args = ["commit"]).ask()
 ```
 </details>
 
-**First match wins.** Within a capability domain, rules are evaluated in order — the first matching rule determines the effect. Put specific rules (like denies) before broad ones (like allows).
+**First match wins.** Rules are evaluated in order — the first matching rule determines the effect. Put specific rules (like denies) before broad ones (like allows).
 
 ---
 
-## Capability domains
+## Domains
 
-Clash controls three capability domains. Rules target capabilities, not tool names — a single rule can cover multiple agent tools.
+Clash matches rules across three domains. A single rule can cover multiple tools.
 
 ### Exec — shell commands
 
@@ -54,7 +54,7 @@ exe(["cargo", "rustc"]).allow()  # multiple binaries
 ```
 
 <details>
-<summary>JSON IR (v5 match tree)</summary>
+<summary>Compiled JSON IR</summary>
 
 ```json
 { "condition": { "observe": "tool_name", "pattern": { "literal": { "literal": "Bash" } }, "children": [
@@ -85,7 +85,7 @@ home().child(".ssh").allow(read = True)             # read under ~/.ssh
 ```
 
 <details>
-<summary>JSON IR (v5 match tree)</summary>
+<summary>Compiled JSON IR</summary>
 
 Filesystem rules are compiled by Starlark into condition nodes that observe tool names and named arguments. The `cwd()` builder generates conditions matching Read/Write/Edit/Glob/Grep tools with path checks via `named_arg` or `nested_field` observables.
 </details>
@@ -100,7 +100,7 @@ domains({"github.com": allow, "crates.io": allow})
 ```
 
 <details>
-<summary>JSON IR (v5 match tree)</summary>
+<summary>Compiled JSON IR</summary>
 
 Network rules are compiled by Starlark into condition nodes that observe the tool name (WebFetch/WebSearch) and extract the domain via `nested_field` or `named_arg` observables.
 </details>
@@ -118,9 +118,9 @@ The tool domain matches agent tools by name. Use this for tools that don't map t
 
 ---
 
-## Patterns (v5 match tree)
+## Patterns
 
-In the v5 match tree IR, patterns are used inside condition nodes to match against observable values.
+In the compiled match tree, patterns are used inside condition nodes to match against observable values.
 
 ### Wildcard
 
@@ -188,7 +188,7 @@ exe("git").allow()
 
 If the rules were reversed, `git push` would match the allow first and the deny would never fire.
 
-When a request matches rules in multiple capability domains, deny-overrides applies across domains: deny > ask > allow.
+When a request matches rules in multiple domains, deny-overrides applies across domains: deny > ask > allow.
 
 ---
 
@@ -221,21 +221,18 @@ def main():
     ])
 ```
 
-<details>
-<summary>Compiled JSON IR (v5 match tree)</summary>
-
-In v5, composition happens at the Starlark level — the compiled output is a flat match tree with no includes. The tree from the Starlark above would contain condition nodes for git commands (deny push/reset, ask commit, allow others) followed by the remaining rules, all flattened into a single tree array.
-</details>
-
 Starlark `load()` imports values from other `.star` files. All composition (function calls, list splicing, imports) resolves at compile time.
 
-### Machine-readable policy (policy.json)
+### Two formats: `.star` for humans, `.json` for tools
 
-For CLI-driven rule management, clash supports `policy.json` — a JSON file that extends the v5 IR with an `includes` field:
+Clash supports two policy formats that serve different purposes:
+
+**Starlark (`.star`)** is for humans. Write expressive policies with functions, variables, imports, and composition. When you want to craft a nuanced policy — conditionals, shared rule sets across projects, sandbox builders — this is the format to use.
+
+**JSON (`policy.json`)** is for tools. CLI commands like `clash policy allow`, `clash policy deny`, and `clash policy remove` read and write `policy.json` directly. It's a machine-readable format designed to be mutated programmatically — by the CLI, by scripts, or by agents themselves.
 
 ```json
 {
-  "schema_version": 5,
   "default_effect": "deny",
   "includes": [
     { "path": "@clash//builtin.star" },
@@ -245,7 +242,7 @@ For CLI-driven rule management, clash supports `policy.json` — a JSON file tha
 }
 ```
 
-CLI commands (`clash policy allow/deny/remove`) operate on `policy.json`. Included `.star` files are compiled and merged at load time, with inline `tree` rules taking precedence. When both `.json` and `.star` exist at the same level, `.json` takes precedence.
+The `includes` field lets `policy.json` pull in `.star` files, so you can combine CLI-managed rules with hand-written Starlark. Included files are compiled and merged at load time, with inline `tree` rules taking precedence. When both `.json` and `.star` exist at the same level, `.json` wins.
 
 ### Merging policies
 
@@ -300,11 +297,10 @@ def main():
 Note that `.sandbox(sb)` goes **before** `.allow()` / `.deny()` / `.ask()`.
 
 <details>
-<summary>JSON IR (v5 match tree)</summary>
+<summary>Compiled JSON IR</summary>
 
 ```json
 {
-  "schema_version": 5,
   "default_effect": "deny",
   "sandboxes": {
     "cargo-env": { "fs": [...], "net": "allow" }


### PR DESCRIPTION
## Summary

- Reframes clash from "AI agent safety harness" to a **pattern-matching sandbox engine** that works standalone (`clash sandbox exec`) or as an agent plugin
- New homepage structure: hero → two modes → kernel enforcement → curl|bash irony demo → policy example → match/sandbox/decide pipeline → use cases → get started
- Clarified `.star` (human-authored) vs `policy.json` (tool-managed) format distinction
- Removed internal jargon ("capability domains", "v5 schema") from public-facing pages
- Added Python syntax highlighting for Starlark blocks, linked empathic.dev in footer
- Broadened FAQ to cover non-agent usage (Docker/Firejail comparison, standalone sandboxing)

## Test plan

- [x] `bunx eleventy` builds cleanly
- [x] Visual review of homepage, policy page, FAQ, and grammar page
- [x] Verify Starlark code blocks now have syntax highlighting
- [x] Check footer link to empathic.dev