### PR TITLE
feat(tui): interactive policy editor with ratatui

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -586,6 +586,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -724,6 +733,7 @@ dependencies = [
  "clash_starlark",
  "claude_settings",
  "console",
+ "crossterm",
  "dialoguer",
  "dirs",
  "figment",
@@ -738,6 +748,7 @@ dependencies = [
  "mockito",
  "nu-ansi-term",
  "proptest",
+ "ratatui",
  "reedline 0.45.0",
  "regex",
  "seccompiler",
@@ -747,6 +758,7 @@ dependencies = [
  "serde_regex",
  "serde_yaml",
  "sha2",
+ "similar",
  "tar",
  "tempfile",
  "thiserror 2.0.18",
@@ -771,7 +783,7 @@ dependencies = [
  "clap",
  "clash-brush-core",
  "clash-brush-parser",
- "fancy-regex",
+ "fancy-regex 0.17.0",
  "futures",
  "itertools 0.14.0",
  "nix 0.31.2",
@@ -801,7 +813,7 @@ dependencies = [
  "clash-brush-parser",
  "color-print",
  "command-fds",
- "fancy-regex",
+ "fancy-regex 0.17.0",
  "futures",
  "getrandom 0.4.2",
  "hostname",
@@ -982,6 +994,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "compact_str"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdb1325a1cece981e8a296ab8f0f9b63ae357bd0784a9faaf548cc7b480707a"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "static_assertions",
+]
+
+[[package]]
 name = "concurrent-queue"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1159,6 +1185,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "csscolorparser"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb2a7d3066da2de787b7f032c736763eb7ae5d355f81a68bab2675a96008b0bf"
+dependencies = [
+ "lab",
+ "phf",
+]
+
+[[package]]
 name = "ctor"
 version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1247,6 +1283,12 @@ dependencies = [
  "serde",
  "serde_json",
 ]
+
+[[package]]
+name = "deltae"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5729f5117e208430e437df2f4843f5e5952997175992d1414f94c57d61e270b4"
 
 [[package]]
 name = "deranged"
@@ -1552,6 +1594,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
 
 [[package]]
+name = "euclid"
+version = "0.22.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df61bf483e837f88d5c2291dcf55c67be7e676b3a51acc48db3a7b163b91ed63"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "event-listener"
 version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1570,6 +1621,16 @@ checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
 dependencies = [
  "event-listener",
  "pin-project-lite",
+]
+
+[[package]]
+name = "fancy-regex"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b95f7c0680e4142284cf8b22c14a476e87d61b004a3a0861872b32ef7ead40a2"
+dependencies = [
+ "bit-set 0.5.3",
+ "regex",
 ]
 
 [[package]]
@@ -1616,6 +1677,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "filedescriptor"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e40758ed24c9b2eeb76c35fb0aebc66c626084edd827e07e1552279814c6682d"
+dependencies = [
+ "libc",
+ "thiserror 1.0.69",
+ "winapi",
+]
+
+[[package]]
 name = "filetime"
 version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1631,6 +1703,12 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "finl_unicode"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9844ddc3a6e533d62bba727eb6c28b5d360921d5175e9ff0f1e621a5c590a4d5"
 
 [[package]]
 name = "fixedbitset"
@@ -1704,6 +1782,12 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "form_urlencoded"
@@ -1946,7 +2030,7 @@ checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
+ "foldhash 0.1.5",
 ]
 
 [[package]]
@@ -1954,6 +2038,11 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "heck"
@@ -2289,6 +2378,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "indoc"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "inherent"
 version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2315,6 +2413,19 @@ dependencies = [
  "similar",
  "tempfile",
  "walkdir",
+]
+
+[[package]]
+name = "instability"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357b7205c6cd18dd2c86ed312d1e70add149aea98e7ef72b9fdf0270e555c11d"
+dependencies = [
+ "darling 0.23.0",
+ "indoc",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2412,6 +2523,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "kasuari"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fe90c1150662e858c7d5f945089b7517b0a80d8bf7ba4b1b5ffc984e7230a5b"
+dependencies = [
+ "hashbrown 0.16.1",
+ "portable-atomic",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "lab"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf36173d4167ed999940f804952e6b08197cae5ad5d572eb4db150ce8ad5d58f"
+
+[[package]]
 name = "lalrpop"
 version = "0.19.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2490,6 +2618,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "line-clipping"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f4de44e98ddbf09375cbf4d17714d18f39195f4f4894e8524501726fd9a8a4a"
+dependencies = [
+ "bitflags 2.11.0",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2546,6 +2683,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1dc47f592c06f33f8e3aea9591776ec7c9f9e4124778ff8a3c3b87159f7e593"
+dependencies = [
+ "hashbrown 0.16.1",
+]
+
+[[package]]
 name = "lsp-types"
 version = "0.94.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2571,6 +2717,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "mac_address"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0aeb26bf5e836cc1c341c8106051b573f1766dfa05aa87f0b98be5e51b02303"
+dependencies = [
+ "nix 0.29.0",
+ "winapi",
+]
+
+[[package]]
 name = "maplit"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2590,6 +2746,12 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "memmem"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a64a92489e2744ce060c349162be1c5f33c6969234104dbd99ddb5feb08b8c15"
 
 [[package]]
 name = "memoffset"
@@ -2721,6 +2883,19 @@ dependencies = [
 
 [[package]]
 name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags 2.11.0",
+ "cfg-if",
+ "cfg_aliases 0.2.1",
+ "libc",
+ "memoffset 0.9.1",
+]
+
+[[package]]
+name = "nix"
 version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
@@ -2799,6 +2974,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
 
 [[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2814,6 +3000,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -2896,6 +3091,15 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "ordered-float"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "ordered-stream"
@@ -3059,6 +3263,7 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
 dependencies = [
+ "phf_macros",
  "phf_shared",
 ]
 
@@ -3080,6 +3285,19 @@ checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared",
  "rand 0.8.5",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3161,6 +3379,12 @@ dependencies = [
  "rustix",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "potential_utf"
@@ -3399,6 +3623,91 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
 dependencies = [
  "rand_core 0.9.5",
+]
+
+[[package]]
+name = "ratatui"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1ce67fb8ba4446454d1c8dbaeda0557ff5e94d39d5e5ed7f10a65eb4c8266bc"
+dependencies = [
+ "instability",
+ "ratatui-core",
+ "ratatui-crossterm",
+ "ratatui-macros",
+ "ratatui-termwiz",
+ "ratatui-widgets",
+]
+
+[[package]]
+name = "ratatui-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ef8dea09a92caaf73bff7adb70b76162e5937524058a7e5bff37869cbbec293"
+dependencies = [
+ "bitflags 2.11.0",
+ "compact_str",
+ "hashbrown 0.16.1",
+ "indoc",
+ "itertools 0.14.0",
+ "kasuari",
+ "lru",
+ "strum 0.27.2",
+ "thiserror 2.0.18",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width 0.2.2",
+]
+
+[[package]]
+name = "ratatui-crossterm"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "577c9b9f652b4c121fb25c6a391dd06406d3b092ba68827e6d2f09550edc54b3"
+dependencies = [
+ "cfg-if",
+ "crossterm",
+ "instability",
+ "ratatui-core",
+]
+
+[[package]]
+name = "ratatui-macros"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7f1342a13e83e4bb9d0b793d0ea762be633f9582048c892ae9041ef39c936f4"
+dependencies = [
+ "ratatui-core",
+ "ratatui-widgets",
+]
+
+[[package]]
+name = "ratatui-termwiz"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f76fe0bd0ed4295f0321b1676732e2454024c15a35d01904ddb315afd3d545c"
+dependencies = [
+ "ratatui-core",
+ "termwiz",
+]
+
+[[package]]
+name = "ratatui-widgets"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7dbfa023cd4e604c2553483820c5fe8aa9d71a42eea5aa77c6e7f35756612db"
+dependencies = [
+ "bitflags 2.11.0",
+ "hashbrown 0.16.1",
+ "indoc",
+ "instability",
+ "itertools 0.14.0",
+ "line-clipping",
+ "ratatui-core",
+ "strum 0.27.2",
+ "time",
+ "unicode-segmentation",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -4142,6 +4451,15 @@ checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
 
 [[package]]
 name = "strum"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+dependencies = [
+ "strum_macros 0.27.2",
+]
+
+[[package]]
+name = "strum"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
@@ -4156,6 +4474,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
  "syn 2.0.117",
 ]
 
@@ -4301,6 +4631,57 @@ dependencies = [
 ]
 
 [[package]]
+name = "termios"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "411c5bf740737c7918b8b1fe232dca4dc9f8e754b8ad5e20966814001ed0ac6b"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "termwiz"
+version = "0.23.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4676b37242ccbd1aabf56edb093a4827dc49086c0ffd764a5705899e0f35f8f7"
+dependencies = [
+ "anyhow",
+ "base64",
+ "bitflags 2.11.0",
+ "fancy-regex 0.11.0",
+ "filedescriptor",
+ "finl_unicode",
+ "fixedbitset",
+ "hex",
+ "lazy_static",
+ "libc",
+ "log",
+ "memmem",
+ "nix 0.29.0",
+ "num-derive",
+ "num-traits",
+ "ordered-float",
+ "pest",
+ "pest_derive",
+ "phf",
+ "sha2",
+ "signal-hook",
+ "siphasher",
+ "terminfo",
+ "termios",
+ "thiserror 1.0.69",
+ "ucd-trie",
+ "unicode-segmentation",
+ "vtparse",
+ "wezterm-bidi",
+ "wezterm-blob-leases",
+ "wezterm-color-types",
+ "wezterm-dynamic",
+ "wezterm-input-types",
+ "winapi",
+]
+
+[[package]]
 name = "textwrap"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4375,7 +4756,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
+ "libc",
  "num-conv",
+ "num_threads",
  "powerfmt",
  "serde_core",
  "time-core",
@@ -4735,6 +5118,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
+name = "unicode-truncate"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16b380a1238663e5f8a691f9039c73e1cdae598a30e9855f541d29b08b53e9a5"
+dependencies = [
+ "itertools 0.14.0",
+ "unicode-segmentation",
+ "unicode-width 0.2.2",
+]
+
+[[package]]
 name = "unicode-width"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4859,6 +5253,7 @@ version = "1.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
 dependencies = [
+ "atomic",
  "getrandom 0.4.2",
  "js-sys",
  "serde_core",
@@ -4894,6 +5289,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "231fdcd7ef3037e8330d8e17e61011a2c244126acc0a982f4040ac3f9f0bc077"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "vtparse"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d9b2acfb050df409c972a37d3b8e08cdea3bddb0c09db9d53137e504cfabed0"
+dependencies = [
+ "utf8parse",
 ]
 
 [[package]]
@@ -5081,6 +5485,78 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "wezterm-bidi"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0a6e355560527dd2d1cf7890652f4f09bb3433b6aadade4c9b5ed76de5f3ec"
+dependencies = [
+ "log",
+ "wezterm-dynamic",
+]
+
+[[package]]
+name = "wezterm-blob-leases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "692daff6d93d94e29e4114544ef6d5c942a7ed998b37abdc19b17136ea428eb7"
+dependencies = [
+ "getrandom 0.3.4",
+ "mac_address",
+ "sha2",
+ "thiserror 1.0.69",
+ "uuid",
+]
+
+[[package]]
+name = "wezterm-color-types"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7de81ef35c9010270d63772bebef2f2d6d1f2d20a983d27505ac850b8c4b4296"
+dependencies = [
+ "csscolorparser",
+ "deltae",
+ "lazy_static",
+ "wezterm-dynamic",
+]
+
+[[package]]
+name = "wezterm-dynamic"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f2ab60e120fd6eaa68d9567f3226e876684639d22a4219b313ff69ec0ccd5ac"
+dependencies = [
+ "log",
+ "ordered-float",
+ "strsim 0.11.1",
+ "thiserror 1.0.69",
+ "wezterm-dynamic-derive",
+]
+
+[[package]]
+name = "wezterm-dynamic-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46c0cf2d539c645b448eaffec9ec494b8b19bd5077d9e58cb1ae7efece8d575b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "wezterm-input-types"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7012add459f951456ec9d6c7e6fc340b1ce15d6fc9629f8c42853412c029e57e"
+dependencies = [
+ "bitflags 1.3.2",
+ "euclid",
+ "lazy_static",
+ "serde",
+ "wezterm-dynamic",
 ]
 
 [[package]]

--- a/clash/Cargo.toml
+++ b/clash/Cargo.toml
@@ -46,6 +46,9 @@ tar = { workspace = true }
 chrono = { workspace = true }
 toolpath = { workspace = true }
 toolpath-claude = { workspace = true }
+ratatui = { workspace = true }
+crossterm = { workspace = true }
+similar = { workspace = true }
 
 # from the workspace
 clash_notify = { workspace = true }

--- a/clash/src/cli.rs
+++ b/clash/src/cli.rs
@@ -56,11 +56,14 @@ pub enum PolicyCmd {
         #[arg(long)]
         json: bool,
     },
-    /// Open the policy file in $EDITOR
+    /// Open the interactive policy editor (or $EDITOR with --raw)
     Edit {
         /// Policy scope to edit: "user" or "project" (default: auto-detect)
         #[arg(long)]
         scope: Option<String>,
+        /// Open in $EDITOR instead of the interactive TUI
+        #[arg(long)]
+        raw: bool,
     },
     /// Add an allow rule for a tool or binary
     ///

--- a/clash/src/cmd/policy.rs
+++ b/clash/src/cmd/policy.rs
@@ -25,10 +25,26 @@ pub fn run(cmd: PolicyCmd) -> Result<()> {
         PolicyCmd::List { json } => handle_list(json),
         PolicyCmd::Validate { file, json } => handle_validate(file, json),
         PolicyCmd::Show { json } => handle_show(json),
-        PolicyCmd::Edit { scope } => handle_edit(scope),
-        PolicyCmd::Allow { command, tool, bin, sandbox, scope } => handle_allow(command, tool, bin, sandbox, scope),
-        PolicyCmd::Deny { command, tool, bin, scope } => handle_deny(command, tool, bin, scope),
-        PolicyCmd::Remove { command, tool, bin, scope } => handle_remove(command, tool, bin, scope),
+        PolicyCmd::Edit { scope, raw } => handle_edit(scope, raw),
+        PolicyCmd::Allow {
+            command,
+            tool,
+            bin,
+            sandbox,
+            scope,
+        } => handle_allow(command, tool, bin, sandbox, scope),
+        PolicyCmd::Deny {
+            command,
+            tool,
+            bin,
+            scope,
+        } => handle_deny(command, tool, bin, scope),
+        PolicyCmd::Remove {
+            command,
+            tool,
+            bin,
+            scope,
+        } => handle_remove(command, tool, bin, scope),
     }
 }
 
@@ -359,24 +375,31 @@ pub fn open_in_editor(path: &Path) -> Result<()> {
 }
 
 /// Handle `clash policy edit`.
-fn handle_edit(scope: Option<String>) -> Result<()> {
-    let level = match scope.as_deref() {
-        Some("user") => PolicyLevel::User,
-        Some("project") => PolicyLevel::Project,
-        Some(other) => {
-            anyhow::bail!("unknown scope: \"{other}\" (expected \"user\" or \"project\")")
+fn handle_edit(scope: Option<String>, raw: bool) -> Result<()> {
+    if raw {
+        // --raw: open in $EDITOR
+        let level = match scope.as_deref() {
+            Some("user") => PolicyLevel::User,
+            Some("project") => PolicyLevel::Project,
+            Some(other) => {
+                anyhow::bail!("unknown scope: \"{other}\" (expected \"user\" or \"project\")")
+            }
+            None => ClashSettings::default_scope(),
+        };
+        let path = ClashSettings::policy_file_for_level(level)?;
+        if !path.exists() {
+            anyhow::bail!(
+                "no policy file at {} — run `clash init {}` first",
+                path.display(),
+                level,
+            );
         }
-        None => ClashSettings::default_scope(),
-    };
-    let path = ClashSettings::policy_file_for_level(level)?;
-    if !path.exists() {
-        anyhow::bail!(
-            "no policy file at {} — run `clash init {}` first",
-            path.display(),
-            level,
-        );
+        return open_in_editor(&path);
     }
-    open_in_editor(&path)
+
+    // Interactive TUI editor
+    let path = resolve_manifest_path(scope)?;
+    crate::tui::run(&path)
 }
 
 // ---------------------------------------------------------------------------
@@ -469,7 +492,9 @@ fn build_rule_node(
     // Positional command takes priority.
     if let Some((bin_name, args)) = parse_command(command) {
         let arg_refs: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
-        return Ok(manifest_edit::build_exec_rule(&bin_name, &arg_refs, decision));
+        return Ok(manifest_edit::build_exec_rule(
+            &bin_name, &arg_refs, decision,
+        ));
     }
     match (tool.as_deref(), bin.as_deref()) {
         (_, Some(bin_name)) => Ok(manifest_edit::build_exec_rule(bin_name, &[], decision)),
@@ -494,7 +519,10 @@ fn handle_allow(
     match result {
         manifest_edit::UpsertResult::Inserted => println!("{} Rule added", style::green_bold("✓")),
         manifest_edit::UpsertResult::Replaced => {
-            println!("{} Rule updated (replaced existing)", style::green_bold("✓"))
+            println!(
+                "{} Rule updated (replaced existing)",
+                style::green_bold("✓")
+            )
         }
     }
     println!("  {}", style::dim(&path.display().to_string()));
@@ -515,7 +543,10 @@ fn handle_deny(
     match result {
         manifest_edit::UpsertResult::Inserted => println!("{} Rule added", style::green_bold("✓")),
         manifest_edit::UpsertResult::Replaced => {
-            println!("{} Rule updated (replaced existing)", style::green_bold("✓"))
+            println!(
+                "{} Rule updated (replaced existing)",
+                style::green_bold("✓")
+            )
         }
     }
     println!("  {}", style::dim(&path.display().to_string()));

--- a/clash/src/lib.rs
+++ b/clash/src/lib.rs
@@ -53,4 +53,5 @@ pub mod shell_cmd;
 pub mod style;
 pub mod trace;
 pub mod tracing_init;
+pub mod tui;
 pub mod version;

--- a/clash/src/policy/manifest_edit.rs
+++ b/clash/src/policy/manifest_edit.rs
@@ -117,9 +117,7 @@ fn patterns_equal(a: &Pattern, b: &Pattern) -> bool {
 }
 
 fn children_are_all_decisions(children: &[Node]) -> bool {
-    children
-        .iter()
-        .all(|n| matches!(n, Node::Decision(_)))
+    children.iter().all(|n| matches!(n, Node::Decision(_)))
 }
 
 /// Extract the leaf decision from a node tree (DFS to the first Decision).
@@ -245,7 +243,10 @@ mod tests {
     #[test]
     fn upsert_different_bins_are_separate() {
         let mut manifest = empty_manifest();
-        upsert_rule(&mut manifest, build_exec_rule("grep", &[], Decision::Allow(None)));
+        upsert_rule(
+            &mut manifest,
+            build_exec_rule("grep", &[], Decision::Allow(None)),
+        );
         upsert_rule(&mut manifest, build_exec_rule("rm", &[], Decision::Deny));
         // Both should exist (compacted under a shared Bash parent).
         let total_rules = count_leaf_decisions(&manifest.policy.tree);
@@ -255,7 +256,10 @@ mod tests {
     #[test]
     fn remove_existing_rule() {
         let mut manifest = empty_manifest();
-        upsert_rule(&mut manifest, build_exec_rule("grep", &[], Decision::Allow(None)));
+        upsert_rule(
+            &mut manifest,
+            build_exec_rule("grep", &[], Decision::Allow(None)),
+        );
         let target = build_exec_rule("grep", &[], Decision::Allow(None));
         assert!(remove_rule(&mut manifest, &target));
         assert!(manifest.policy.tree.is_empty());
@@ -264,7 +268,10 @@ mod tests {
     #[test]
     fn remove_nonexistent_returns_false() {
         let mut manifest = empty_manifest();
-        upsert_rule(&mut manifest, build_exec_rule("grep", &[], Decision::Allow(None)));
+        upsert_rule(
+            &mut manifest,
+            build_exec_rule("grep", &[], Decision::Allow(None)),
+        );
         let target = build_exec_rule("rm", &[], Decision::Allow(None));
         assert!(!remove_rule(&mut manifest, &target));
     }
@@ -306,8 +313,14 @@ mod tests {
     #[test]
     fn exec_rule_different_args_are_separate() {
         let mut manifest = empty_manifest();
-        upsert_rule(&mut manifest, build_exec_rule("gh", &["pr", "create"], Decision::Allow(None)));
-        upsert_rule(&mut manifest, build_exec_rule("gh", &["pr", "merge"], Decision::Deny));
+        upsert_rule(
+            &mut manifest,
+            build_exec_rule("gh", &["pr", "create"], Decision::Allow(None)),
+        );
+        upsert_rule(
+            &mut manifest,
+            build_exec_rule("gh", &["pr", "merge"], Decision::Deny),
+        );
         let total = count_leaf_decisions(&manifest.policy.tree);
         assert_eq!(total, 2);
     }

--- a/clash/src/policy/mod.rs
+++ b/clash/src/policy/mod.rs
@@ -8,8 +8,8 @@ pub mod error;
 pub mod ir;
 pub mod manifest_edit;
 pub mod match_tree;
-pub mod sandbox_edit;
 pub mod path;
+pub mod sandbox_edit;
 pub mod sandbox_types;
 
 pub use compile::compile_multi_level_to_tree;

--- a/clash/src/policy/sandbox_edit.rs
+++ b/clash/src/policy/sandbox_edit.rs
@@ -96,11 +96,7 @@ pub fn add_rule(
 /// Remove a rule matching the given path from a named sandbox.
 ///
 /// Returns `true` if a rule was removed.
-pub fn remove_rule(
-    manifest: &mut PolicyManifest,
-    sandbox_name: &str,
-    path: &str,
-) -> Result<bool> {
+pub fn remove_rule(manifest: &mut PolicyManifest, sandbox_name: &str, path: &str) -> Result<bool> {
     let sandbox = manifest
         .policy
         .sandboxes
@@ -133,7 +129,14 @@ mod tests {
     #[test]
     fn create_inserts_new_sandbox() {
         let mut m = empty_manifest();
-        create_sandbox(&mut m, "dev", Cap::READ | Cap::EXECUTE, NetworkPolicy::Deny, None).unwrap();
+        create_sandbox(
+            &mut m,
+            "dev",
+            Cap::READ | Cap::EXECUTE,
+            NetworkPolicy::Deny,
+            None,
+        )
+        .unwrap();
         assert!(m.policy.sandboxes.contains_key("dev"));
         let sb = &m.policy.sandboxes["dev"];
         assert_eq!(sb.default, Cap::READ | Cap::EXECUTE);
@@ -171,9 +174,15 @@ mod tests {
         let mut m = empty_manifest();
         create_sandbox(&mut m, "dev", Cap::READ, NetworkPolicy::Deny, None).unwrap();
         let result = add_rule(
-            &mut m, "dev", RuleEffect::Allow, Cap::READ | Cap::WRITE,
-            "$PWD".into(), PathMatch::Subpath, None,
-        ).unwrap();
+            &mut m,
+            "dev",
+            RuleEffect::Allow,
+            Cap::READ | Cap::WRITE,
+            "$PWD".into(),
+            PathMatch::Subpath,
+            None,
+        )
+        .unwrap();
         assert_eq!(result, UpsertResult::Inserted);
         assert_eq!(m.policy.sandboxes["dev"].rules.len(), 1);
     }
@@ -182,11 +191,26 @@ mod tests {
     fn add_rule_replaces_same_path() {
         let mut m = empty_manifest();
         create_sandbox(&mut m, "dev", Cap::READ, NetworkPolicy::Deny, None).unwrap();
-        add_rule(&mut m, "dev", RuleEffect::Allow, Cap::READ, "$PWD".into(), PathMatch::Subpath, None).unwrap();
+        add_rule(
+            &mut m,
+            "dev",
+            RuleEffect::Allow,
+            Cap::READ,
+            "$PWD".into(),
+            PathMatch::Subpath,
+            None,
+        )
+        .unwrap();
         let result = add_rule(
-            &mut m, "dev", RuleEffect::Deny, Cap::WRITE,
-            "$PWD".into(), PathMatch::Subpath, None,
-        ).unwrap();
+            &mut m,
+            "dev",
+            RuleEffect::Deny,
+            Cap::WRITE,
+            "$PWD".into(),
+            PathMatch::Subpath,
+            None,
+        )
+        .unwrap();
         assert_eq!(result, UpsertResult::Replaced);
         assert_eq!(m.policy.sandboxes["dev"].rules.len(), 1);
         assert_eq!(m.policy.sandboxes["dev"].rules[0].effect, RuleEffect::Deny);
@@ -196,7 +220,15 @@ mod tests {
     #[test]
     fn add_rule_errors_on_missing_sandbox() {
         let mut m = empty_manifest();
-        let err = add_rule(&mut m, "nope", RuleEffect::Allow, Cap::READ, "$PWD".into(), PathMatch::Subpath, None);
+        let err = add_rule(
+            &mut m,
+            "nope",
+            RuleEffect::Allow,
+            Cap::READ,
+            "$PWD".into(),
+            PathMatch::Subpath,
+            None,
+        );
         assert!(err.is_err());
     }
 
@@ -204,7 +236,16 @@ mod tests {
     fn remove_rule_by_path() {
         let mut m = empty_manifest();
         create_sandbox(&mut m, "dev", Cap::READ, NetworkPolicy::Deny, None).unwrap();
-        add_rule(&mut m, "dev", RuleEffect::Allow, Cap::READ, "$PWD".into(), PathMatch::Subpath, None).unwrap();
+        add_rule(
+            &mut m,
+            "dev",
+            RuleEffect::Allow,
+            Cap::READ,
+            "$PWD".into(),
+            PathMatch::Subpath,
+            None,
+        )
+        .unwrap();
         assert!(remove_rule(&mut m, "dev", "$PWD").unwrap());
         assert!(m.policy.sandboxes["dev"].rules.is_empty());
     }

--- a/clash/src/policy_loader.rs
+++ b/clash/src/policy_loader.rs
@@ -127,12 +127,57 @@ pub fn read_manifest(path: &Path) -> Result<PolicyManifest> {
     serde_json::from_str(&raw).with_context(|| format!("failed to parse {}", path.display()))
 }
 
+/// Resolve includes and return the combined included policy.
+///
+/// Evaluates each include entry and merges their rules and sandboxes.
+/// Returns the merged included content (without the inline policy).
+/// Rules/sandboxes from includes should be treated as read-only in the TUI.
+pub fn resolve_includes(manifest: &PolicyManifest, base_dir: &Path) -> Result<CompiledPolicy> {
+    use std::collections::HashMap;
+
+    let mut merged = CompiledPolicy {
+        sandboxes: HashMap::new(),
+        tree: vec![],
+        default_effect: manifest.policy.default_effect.clone(),
+        default_sandbox: None,
+    };
+
+    for include in &manifest.includes {
+        match evaluate_include(&include.path, base_dir) {
+            Ok(json_source) => {
+                if let Ok(included) = serde_json::from_str::<CompiledPolicy>(&json_source) {
+                    // Stamp source provenance on root-level condition nodes
+                    for mut node in included.tree {
+                        if let crate::policy::match_tree::Node::Condition {
+                            ref mut source, ..
+                        } = node
+                        {
+                            if source.is_none() {
+                                *source = Some(include.path.clone());
+                            }
+                        }
+                        merged.tree.push(node);
+                    }
+                    for (k, v) in included.sandboxes {
+                        merged.sandboxes.entry(k).or_insert(v);
+                    }
+                }
+            }
+            Err(_) => {
+                // Silently skip failed includes — the TUI will show the include
+                // entry itself, and validation will catch errors on save.
+            }
+        }
+    }
+
+    Ok(merged)
+}
+
 /// Write a [`PolicyManifest`] to disk as pretty-printed JSON.
 pub fn write_manifest(path: &Path, manifest: &PolicyManifest) -> Result<()> {
-    let json = serde_json::to_string_pretty(manifest)
-        .context("failed to serialize policy manifest")?;
-    std::fs::write(path, json)
-        .with_context(|| format!("failed to write {}", path.display()))
+    let json =
+        serde_json::to_string_pretty(manifest).context("failed to serialize policy manifest")?;
+    std::fs::write(path, json).with_context(|| format!("failed to write {}", path.display()))
 }
 
 /// Validate a policy file's metadata (existence, type, size, permissions).

--- a/clash/src/sandbox_cmd.rs
+++ b/clash/src/sandbox_cmd.rs
@@ -364,7 +364,11 @@ fn handle_add_rule(
 
     match result {
         sandbox_edit::UpsertResult::Inserted => {
-            println!("{} Rule added to sandbox '{}'", style::green_bold("✓"), name)
+            println!(
+                "{} Rule added to sandbox '{}'",
+                style::green_bold("✓"),
+                name
+            )
         }
         sandbox_edit::UpsertResult::Replaced => println!(
             "{} Rule updated in sandbox '{}'",
@@ -398,7 +402,9 @@ fn parse_network_policy(s: &str) -> Result<NetworkPolicy> {
         "deny" => Ok(NetworkPolicy::Deny),
         "allow" => Ok(NetworkPolicy::Allow),
         "localhost" => Ok(NetworkPolicy::Localhost),
-        other => anyhow::bail!("unknown network policy '{other}' (expected: deny, allow, localhost)"),
+        other => {
+            anyhow::bail!("unknown network policy '{other}' (expected: deny, allow, localhost)")
+        }
     }
 }
 

--- a/clash/src/tui/app.rs
+++ b/clash/src/tui/app.rs
@@ -1,0 +1,656 @@
+//! App — the root TUI component that manages tabs, overlays, and the event loop.
+
+use std::path::PathBuf;
+use std::time::Instant;
+
+use anyhow::Result;
+use crossterm::event::{self, Event, KeyCode, KeyEvent, KeyModifiers};
+use ratatui::Frame;
+use ratatui::Terminal;
+use ratatui::backend::Backend;
+use ratatui::layout::{Alignment, Constraint, Layout, Rect};
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::Paragraph;
+use similar::TextDiff;
+
+use crate::policy::match_tree::{CompiledPolicy, Node, PolicyManifest};
+use crate::policy_loader;
+
+use super::includes_view::IncludesView;
+use super::inline_form::{FormEvent, FormState};
+use super::sandbox_view::SandboxView;
+use super::settings_view::SettingsView;
+use super::tea::{Action, Component};
+use super::tree_view::TreeView;
+use super::widgets::{self, DiffLine};
+
+/// Which tab is active.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Tab {
+    Tree,
+    Sandboxes,
+    Includes,
+    Settings,
+}
+
+/// Overlay mode the app can be in.
+enum Mode {
+    Normal,
+    Help,
+    Confirm(ConfirmAction),
+    SaveReview(DiffState),
+    Form(FormState),
+}
+
+/// What action to take after confirmation.
+enum ConfirmAction {
+    Quit,
+}
+
+/// State for the diff review overlay.
+struct DiffState {
+    lines: Vec<DiffLine>,
+    scroll: usize,
+}
+
+/// Messages for the App component.
+pub enum Msg {
+    SwitchTab(Tab),
+    NextTab,
+    PrevTab,
+    Save,
+    Quit,
+    ToggleHelp,
+    ConfirmYes,
+    ConfirmNo,
+    DiffScrollDown,
+    DiffScrollUp,
+    TreeMsg(<TreeView as Component>::Msg),
+    SandboxMsg(<SandboxView as Component>::Msg),
+    IncludesMsg(<IncludesView as Component>::Msg),
+    SettingsMsg(<SettingsView as Component>::Msg),
+}
+
+pub struct App {
+    manifest: PolicyManifest,
+    /// Content resolved from `includes` entries — shown as read-only.
+    included: CompiledPolicy,
+    original_json: String,
+    path: PathBuf,
+    active_tab: Tab,
+    tree_view: TreeView,
+    sandbox_view: SandboxView,
+    includes_view: IncludesView,
+    settings_view: SettingsView,
+    mode: Mode,
+    dirty: bool,
+    flash: Option<(String, Instant)>,
+}
+
+impl App {
+    pub fn new(path: PathBuf, manifest: PolicyManifest) -> Result<Self> {
+        let original_json = serde_json::to_string_pretty(&manifest)?;
+
+        // Resolve includes to show their rules/sandboxes as read-only
+        let base_dir = path.parent().unwrap_or(std::path::Path::new("."));
+        let included = policy_loader::resolve_includes(&manifest, base_dir)
+            .unwrap_or_else(|_| CompiledPolicy {
+                sandboxes: std::collections::HashMap::new(),
+                tree: vec![],
+                default_effect: manifest.policy.default_effect.clone(),
+                default_sandbox: None,
+            });
+
+        let tree_view = TreeView::new(&manifest, &included);
+        let sandbox_view = SandboxView::new(&manifest, &included);
+        let includes_view = IncludesView::new();
+        let settings_view = SettingsView::new();
+
+        Ok(App {
+            manifest,
+            included,
+            original_json,
+            path,
+            active_tab: Tab::Tree,
+            tree_view,
+            sandbox_view,
+            includes_view,
+            settings_view,
+            mode: Mode::Normal,
+            dirty: false,
+            flash: None,
+        })
+    }
+
+    /// Run the main event loop.
+    pub fn run<B: Backend<Error: Send + Sync + 'static>>(
+        &mut self,
+        terminal: &mut Terminal<B>,
+    ) -> Result<()> {
+        loop {
+            // Clone manifest for view to avoid borrow issues
+            let manifest_snapshot = self.manifest.clone();
+            terminal.draw(|frame| self.view(frame, frame.area(), &manifest_snapshot))?;
+
+            let event = event::read()?;
+            if let Event::Key(key) = event {
+                // Form mode handles keys directly — not via Msg
+                if matches!(self.mode, Mode::Form(_)) {
+                    let FormHandled::Continue = self.handle_form_key(key);
+                    continue;
+                }
+
+                if let Some(msg) = self.handle_key(key) {
+                    let action = self.update_msg(msg);
+                    match action {
+                        Action::Quit => break,
+                        Action::Modified => {
+                            self.dirty = true;
+                            self.rebuild_views();
+                        }
+                        Action::RunForm(req) => {
+                            let form = FormState::from_request(
+                                &req,
+                                &self.manifest,
+                                Some(&self.included),
+                            );
+                            self.mode = Mode::Form(form);
+                        }
+                        Action::Flash(s) => {
+                            self.flash = Some((s, Instant::now()));
+                        }
+                        Action::None => {}
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Handle a key event when in Form mode.
+    fn handle_form_key(&mut self, key: KeyEvent) -> FormHandled {
+        let Mode::Form(ref form) = self.mode else {
+            return FormHandled::Continue;
+        };
+
+        // 'a' in an edit form → close and open AddChild for the same path.
+        // Only when active field is a Select (not typing in a Text field).
+        if key.code == KeyCode::Char('a') && form.active_field_is_select() {
+            let add_path = match &form.kind {
+                super::inline_form::FormKind::EditDecision { path }
+                | super::inline_form::FormKind::EditCondition { path } => {
+                    // For EditDecision on an inline leaf, the path points to the
+                    // Condition node — use it directly as the parent.
+                    // For a bare Decision, go up to the parent Condition.
+                    let tree = &self.manifest.policy.tree;
+                    if TreeView::get_node_at_path_ref(tree, path)
+                        .is_some_and(|n| matches!(n, Node::Condition { .. }))
+                    {
+                        Some(path.clone())
+                    } else if path.len() >= 2 {
+                        Some(path[..path.len() - 1].to_vec())
+                    } else {
+                        None
+                    }
+                }
+                _ => None,
+            };
+
+            if let Some(parent_path) = add_path {
+                let req = super::tea::FormRequest::AddChild { parent_path };
+                let new_form =
+                    FormState::from_request(&req, &self.manifest, Some(&self.included));
+                self.mode = Mode::Form(new_form);
+                return FormHandled::Continue;
+            }
+        }
+
+        let Mode::Form(ref mut form) = self.mode else {
+            return FormHandled::Continue;
+        };
+
+        match form.handle_key(key) {
+            FormEvent::Continue => FormHandled::Continue,
+            FormEvent::Cancel => {
+                self.mode = Mode::Normal;
+                FormHandled::Continue
+            }
+            FormEvent::Submit => {
+                // Take the form out of mode so we can use it
+                let Mode::Form(form) = std::mem::replace(&mut self.mode, Mode::Normal) else {
+                    return FormHandled::Continue;
+                };
+                match form.apply(&mut self.manifest) {
+                    Ok(true) => {
+                        self.dirty = true;
+                        self.rebuild_views();
+                        self.flash = Some(("Added".into(), Instant::now()));
+                    }
+                    Ok(false) => {}
+                    Err(msg) => {
+                        self.flash = Some((msg, Instant::now()));
+                    }
+                }
+                FormHandled::Continue
+            }
+        }
+    }
+
+    fn handle_key(&self, key: KeyEvent) -> Option<Msg> {
+        // Mode-specific key handling
+        match &self.mode {
+            Mode::Help => return Some(Msg::ToggleHelp), // any key closes help
+            Mode::Confirm(_) => {
+                return match key.code {
+                    KeyCode::Char('y') | KeyCode::Char('Y') => Some(Msg::ConfirmYes),
+                    _ => Some(Msg::ConfirmNo),
+                };
+            }
+            Mode::SaveReview(_) => {
+                return match key.code {
+                    KeyCode::Char('y') | KeyCode::Char('Y') => Some(Msg::ConfirmYes),
+                    KeyCode::Char('n') | KeyCode::Char('N') | KeyCode::Esc => Some(Msg::ConfirmNo),
+                    KeyCode::Char('j') | KeyCode::Down => Some(Msg::DiffScrollDown),
+                    KeyCode::Char('k') | KeyCode::Up => Some(Msg::DiffScrollUp),
+                    _ => None,
+                };
+            }
+            Mode::Form(_) => return None, // handled separately
+            Mode::Normal => {}
+        }
+
+        // Global keys
+        match key.code {
+            KeyCode::Char('q') => return Some(Msg::Quit),
+            KeyCode::Char('s') => return Some(Msg::Save),
+            KeyCode::Char('?') => return Some(Msg::ToggleHelp),
+            KeyCode::Char('1') => return Some(Msg::SwitchTab(Tab::Tree)),
+            KeyCode::Char('2') => return Some(Msg::SwitchTab(Tab::Sandboxes)),
+            KeyCode::Char('3') => return Some(Msg::SwitchTab(Tab::Includes)),
+            KeyCode::Char('4') => return Some(Msg::SwitchTab(Tab::Settings)),
+            KeyCode::Tab if key.modifiers.contains(KeyModifiers::SHIFT) => {
+                return Some(Msg::PrevTab);
+            }
+            KeyCode::BackTab => return Some(Msg::PrevTab),
+            KeyCode::Tab => return Some(Msg::NextTab),
+            _ => {}
+        }
+
+        // Delegate to active tab
+        match self.active_tab {
+            Tab::Tree => self.tree_view.handle_key(key).map(Msg::TreeMsg),
+            Tab::Sandboxes => self.sandbox_view.handle_key(key).map(Msg::SandboxMsg),
+            Tab::Includes => self.includes_view.handle_key(key).map(Msg::IncludesMsg),
+            Tab::Settings => self.settings_view.handle_key(key).map(Msg::SettingsMsg),
+        }
+    }
+
+    /// Process a message and return an action.
+    fn update_msg(&mut self, msg: Msg) -> Action {
+        match msg {
+            Msg::SwitchTab(tab) => {
+                self.active_tab = tab;
+                Action::None
+            }
+            Msg::NextTab => {
+                self.active_tab = match self.active_tab {
+                    Tab::Tree => Tab::Sandboxes,
+                    Tab::Sandboxes => Tab::Includes,
+                    Tab::Includes => Tab::Settings,
+                    Tab::Settings => Tab::Tree,
+                };
+                Action::None
+            }
+            Msg::PrevTab => {
+                self.active_tab = match self.active_tab {
+                    Tab::Tree => Tab::Settings,
+                    Tab::Sandboxes => Tab::Tree,
+                    Tab::Includes => Tab::Sandboxes,
+                    Tab::Settings => Tab::Includes,
+                };
+                Action::None
+            }
+            Msg::Save => {
+                if !self.dirty {
+                    return Action::Flash("No changes to save".into());
+                }
+                let new_json = serde_json::to_string_pretty(&self.manifest).unwrap_or_default();
+                let diff_lines = compute_diff(&self.original_json, &new_json);
+                self.mode = Mode::SaveReview(DiffState {
+                    lines: diff_lines,
+                    scroll: 0,
+                });
+                Action::None
+            }
+            Msg::Quit => {
+                if self.dirty {
+                    self.mode = Mode::Confirm(ConfirmAction::Quit);
+                    Action::None
+                } else {
+                    Action::Quit
+                }
+            }
+            Msg::ToggleHelp => {
+                self.mode = match self.mode {
+                    Mode::Help => Mode::Normal,
+                    _ => Mode::Help,
+                };
+                Action::None
+            }
+            Msg::ConfirmYes => {
+                let mode = std::mem::replace(&mut self.mode, Mode::Normal);
+                match mode {
+                    Mode::Confirm(ConfirmAction::Quit) => Action::Quit,
+                    Mode::SaveReview(_) => {
+                        // Actually save
+                        match policy_loader::write_manifest(&self.path, &self.manifest) {
+                            Ok(()) => {
+                                self.original_json = serde_json::to_string_pretty(&self.manifest)
+                                    .unwrap_or_default();
+                                self.dirty = false;
+
+                                // Post-save validation
+                                let new_json = serde_json::to_string_pretty(&self.manifest)
+                                    .unwrap_or_default();
+                                match crate::policy::compile::compile_to_tree(&new_json) {
+                                    Ok(policy) => {
+                                        let warnings = policy.platform_warnings();
+                                        if warnings.is_empty() {
+                                            Action::Flash("Saved".into())
+                                        } else {
+                                            Action::Flash(format!(
+                                                "Saved (warnings: {})",
+                                                warnings.join("; ")
+                                            ))
+                                        }
+                                    }
+                                    Err(e) => {
+                                        Action::Flash(format!("Saved (validation error: {e})"))
+                                    }
+                                }
+                            }
+                            Err(e) => Action::Flash(format!("Save failed: {e}")),
+                        }
+                    }
+                    _ => Action::None,
+                }
+            }
+            Msg::ConfirmNo => {
+                self.mode = Mode::Normal;
+                Action::None
+            }
+            Msg::DiffScrollDown => {
+                if let Mode::SaveReview(ref mut state) = self.mode {
+                    if state.scroll + 1 < state.lines.len() {
+                        state.scroll += 1;
+                    }
+                }
+                Action::None
+            }
+            Msg::DiffScrollUp => {
+                if let Mode::SaveReview(ref mut state) = self.mode {
+                    state.scroll = state.scroll.saturating_sub(1);
+                }
+                Action::None
+            }
+            Msg::TreeMsg(m) => self.tree_view.update(m, &mut self.manifest),
+            Msg::SandboxMsg(m) => self.sandbox_view.update(m, &mut self.manifest),
+            Msg::IncludesMsg(m) => self.includes_view.update(m, &mut self.manifest),
+            Msg::SettingsMsg(m) => self.settings_view.update(m, &mut self.manifest),
+        }
+    }
+
+    fn rebuild_views(&mut self) {
+        self.tree_view.rebuild_with_included(&self.manifest, &self.included);
+        self.sandbox_view.rebuild_with_included(&self.manifest, &self.included);
+    }
+
+    fn view(&self, frame: &mut Frame, area: Rect, manifest: &PolicyManifest) {
+        let chunks = Layout::vertical([
+            Constraint::Length(2), // title + tab bar
+            Constraint::Min(3),   // content
+            Constraint::Length(1), // status bar
+        ])
+        .split(area);
+
+        // Title bar
+        let title = Line::from(vec![
+            Span::styled(
+                " clash policy editor ",
+                Style::default()
+                    .fg(Color::Cyan)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(
+                format!("-- {} ", self.path.display()),
+                Style::default().fg(Color::DarkGray),
+            ),
+        ]);
+        frame.render_widget(
+            Paragraph::new(title).alignment(Alignment::Left),
+            Rect::new(chunks[0].x, chunks[0].y, chunks[0].width, 1),
+        );
+
+        // Tab bar
+        widgets::render_tab_bar(
+            frame,
+            Rect::new(chunks[0].x, chunks[0].y + 1, chunks[0].width, 1),
+            &self.active_tab,
+            self.dirty,
+        );
+
+        // Content area — delegate to active tab
+        match self.active_tab {
+            Tab::Tree => self.tree_view.view(frame, chunks[1], manifest),
+            Tab::Sandboxes => self.sandbox_view.view(frame, chunks[1], manifest),
+            Tab::Includes => self.includes_view.view(frame, chunks[1], manifest),
+            Tab::Settings => self.settings_view.view(frame, chunks[1], manifest),
+        }
+
+        // Status bar
+        let flash_msg = self.flash.as_ref().and_then(|(msg, instant)| {
+            if instant.elapsed().as_secs() < 3 {
+                Some(msg.as_str())
+            } else {
+                None
+            }
+        });
+
+        let hints: &[(&str, &str)] = match self.active_tab {
+            Tab::Tree => &[
+                ("j/k", "move"),
+                ("h/l", "collapse/expand"),
+                ("e", "edit"),
+                ("a", "add"),
+                ("d", "delete"),
+                ("c", "copy to inline"),
+                ("s", "save"),
+            ],
+            Tab::Sandboxes => &[
+                ("j/k", "move"),
+                ("l/h", "focus rules/back"),
+                ("a", "add"),
+                ("e", "edit"),
+                ("d", "delete"),
+                ("c", "copy to inline"),
+                ("s", "save"),
+            ],
+            Tab::Includes => &[
+                ("j/k", "move"),
+                ("J/K", "reorder"),
+                ("a", "add"),
+                ("d", "delete"),
+                ("s", "save"),
+            ],
+            Tab::Settings => &[("j/k", "move"), ("Enter", "cycle"), ("s", "save")],
+        };
+
+        widgets::render_status_bar(frame, chunks[2], hints, flash_msg);
+
+        // Overlays
+        match &self.mode {
+            Mode::Help => widgets::render_help_overlay(frame, area),
+            Mode::Confirm(ConfirmAction::Quit) => {
+                widgets::render_confirm_overlay(frame, area, "Unsaved changes. Quit anyway?");
+            }
+            Mode::SaveReview(state) => {
+                widgets::render_diff_overlay(frame, area, &state.lines, state.scroll);
+            }
+            Mode::Form(form) => {
+                form.view(frame, area);
+            }
+            Mode::Normal => {}
+        }
+    }
+}
+
+/// Internal result from handling a form key.
+enum FormHandled {
+    Continue,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::policy::match_tree::*;
+    use crate::policy::Effect;
+    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+    use ratatui::backend::TestBackend;
+    use std::collections::HashMap;
+
+    fn empty_manifest() -> PolicyManifest {
+        PolicyManifest {
+            includes: vec![],
+            policy: CompiledPolicy {
+                sandboxes: HashMap::new(),
+                tree: vec![],
+                default_effect: Effect::Deny,
+                default_sandbox: None,
+            },
+        }
+    }
+
+    fn key(code: KeyCode) -> KeyEvent {
+        KeyEvent::new(code, KeyModifiers::empty())
+    }
+
+    /// Simulate pressing a key and rendering the result.
+    /// Panics if the render crashes.
+    fn press_and_render(app: &mut App, terminal: &mut Terminal<TestBackend>, key_event: KeyEvent) {
+        // Handle key
+        if matches!(app.mode, Mode::Form(_)) {
+            let FormHandled::Continue = app.handle_form_key(key_event);
+        } else if let Some(msg) = app.handle_key(key_event) {
+            let action = app.update_msg(msg);
+            match action {
+                Action::Quit => {}
+                Action::Modified => {
+                    app.dirty = true;
+                    app.rebuild_views();
+                }
+                Action::RunForm(req) => {
+                    let form = FormState::from_request(&req, &app.manifest, Some(&app.included));
+                    app.mode = Mode::Form(form);
+                }
+                Action::Flash(s) => {
+                    app.flash = Some((s, Instant::now()));
+                }
+                Action::None => {}
+            }
+        }
+
+        // Render — this is what we're testing doesn't panic
+        let manifest_snapshot = app.manifest.clone();
+        terminal
+            .draw(|frame| app.view(frame, frame.area(), &manifest_snapshot))
+            .unwrap();
+    }
+
+    #[test]
+    fn test_edit_on_root_renders_without_crash() {
+        let manifest = empty_manifest();
+        let mut app = App::new(PathBuf::from("/tmp/test.json"), manifest).unwrap();
+        let backend = TestBackend::new(80, 24);
+        let mut terminal = Terminal::new(backend).unwrap();
+
+        // Initial render
+        let snap = app.manifest.clone();
+        terminal
+            .draw(|frame| app.view(frame, frame.area(), &snap))
+            .unwrap();
+
+        // Press 'e' on root (selected=0)
+        press_and_render(&mut app, &mut terminal, key(KeyCode::Char('e')));
+
+        // Press another key — should still render fine
+        press_and_render(&mut app, &mut terminal, key(KeyCode::Char('j')));
+        press_and_render(&mut app, &mut terminal, key(KeyCode::Char('k')));
+    }
+
+    #[test]
+    fn test_delete_on_root_renders_without_crash() {
+        let manifest = empty_manifest();
+        let mut app = App::new(PathBuf::from("/tmp/test.json"), manifest).unwrap();
+        let backend = TestBackend::new(80, 24);
+        let mut terminal = Terminal::new(backend).unwrap();
+
+        let snap = app.manifest.clone();
+        terminal
+            .draw(|frame| app.view(frame, frame.area(), &snap))
+            .unwrap();
+
+        press_and_render(&mut app, &mut terminal, key(KeyCode::Char('d')));
+        press_and_render(&mut app, &mut terminal, key(KeyCode::Char('j')));
+    }
+
+    #[test]
+    fn test_add_on_root_opens_form_and_renders() {
+        let manifest = empty_manifest();
+        let mut app = App::new(PathBuf::from("/tmp/test.json"), manifest).unwrap();
+        let backend = TestBackend::new(80, 24);
+        let mut terminal = Terminal::new(backend).unwrap();
+
+        let snap = app.manifest.clone();
+        terminal
+            .draw(|frame| app.view(frame, frame.area(), &snap))
+            .unwrap();
+
+        // Press 'a' on root — should open Add Rule form
+        press_and_render(&mut app, &mut terminal, key(KeyCode::Char('a')));
+        assert!(matches!(app.mode, Mode::Form(_)));
+
+        // Render form overlay
+        press_and_render(&mut app, &mut terminal, key(KeyCode::Esc));
+        assert!(matches!(app.mode, Mode::Normal));
+    }
+}
+
+/// Compute a diff between two strings, returning colored diff lines.
+fn compute_diff(old: &str, new: &str) -> Vec<DiffLine> {
+    let diff = TextDiff::from_lines(old, new);
+    let mut lines = Vec::new();
+
+    for (idx, group) in diff.grouped_ops(3).iter().enumerate() {
+        if idx > 0 {
+            lines.push(DiffLine::Header("---".into()));
+        }
+        for op in group {
+            for change in diff.iter_changes(op) {
+                let line_content = change.to_string_lossy();
+                let s = line_content.trim_end_matches('\n').to_string();
+                match change.tag() {
+                    similar::ChangeTag::Equal => lines.push(DiffLine::Context(format!("  {s}"))),
+                    similar::ChangeTag::Insert => lines.push(DiffLine::Add(format!("+ {s}"))),
+                    similar::ChangeTag::Delete => lines.push(DiffLine::Remove(format!("- {s}"))),
+                }
+            }
+        }
+    }
+
+    if lines.is_empty() {
+        lines.push(DiffLine::Context("(no changes)".into()));
+    }
+
+    lines
+}

--- a/clash/src/tui/includes_view.rs
+++ b/clash/src/tui/includes_view.rs
@@ -1,0 +1,220 @@
+//! Includes view component for managing policy include entries.
+
+use crossterm::event::{KeyCode, KeyEvent};
+use ratatui::Frame;
+use ratatui::layout::Rect;
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, Paragraph};
+
+use super::tea::{Action, Component, FormRequest};
+use crate::policy::match_tree::PolicyManifest;
+
+pub struct IncludesView {
+    pub selected: usize,
+}
+
+#[derive(Debug)]
+pub enum Msg {
+    MoveUp,
+    MoveDown,
+    JumpTop,
+    JumpBottom,
+    Add,
+    Delete,
+    MoveItemUp,
+    MoveItemDown,
+}
+
+impl IncludesView {
+    pub fn new() -> Self {
+        IncludesView { selected: 0 }
+    }
+}
+
+impl Component for IncludesView {
+    type Msg = Msg;
+
+    fn handle_key(&self, key: KeyEvent) -> Option<Msg> {
+        match key.code {
+            KeyCode::Char('j') | KeyCode::Down => Some(Msg::MoveDown),
+            KeyCode::Char('k') | KeyCode::Up => Some(Msg::MoveUp),
+            KeyCode::Char('g') => Some(Msg::JumpTop),
+            KeyCode::Char('G') => Some(Msg::JumpBottom),
+            KeyCode::Char('a') => Some(Msg::Add),
+            KeyCode::Char('d') => Some(Msg::Delete),
+            KeyCode::Char('J') => Some(Msg::MoveItemDown),
+            KeyCode::Char('K') => Some(Msg::MoveItemUp),
+            _ => None,
+        }
+    }
+
+    fn update(&mut self, msg: Msg, manifest: &mut PolicyManifest) -> Action {
+        let len = manifest.includes.len();
+        match msg {
+            Msg::MoveDown => {
+                if len > 0 {
+                    self.selected = (self.selected + 1).min(len - 1);
+                }
+                Action::None
+            }
+            Msg::MoveUp => {
+                self.selected = self.selected.saturating_sub(1);
+                Action::None
+            }
+            Msg::JumpTop => {
+                self.selected = 0;
+                Action::None
+            }
+            Msg::JumpBottom => {
+                if len > 0 {
+                    self.selected = len - 1;
+                }
+                Action::None
+            }
+            Msg::Add => Action::RunForm(FormRequest::AddInclude),
+            Msg::Delete => {
+                if self.selected < len {
+                    manifest.includes.remove(self.selected);
+                    if self.selected >= manifest.includes.len() && !manifest.includes.is_empty() {
+                        self.selected = manifest.includes.len() - 1;
+                    }
+                    return Action::Modified;
+                }
+                Action::None
+            }
+            Msg::MoveItemUp => {
+                if self.selected > 0 && self.selected < len {
+                    manifest.includes.swap(self.selected, self.selected - 1);
+                    self.selected -= 1;
+                    return Action::Modified;
+                }
+                Action::None
+            }
+            Msg::MoveItemDown => {
+                if self.selected + 1 < len {
+                    manifest.includes.swap(self.selected, self.selected + 1);
+                    self.selected += 1;
+                    return Action::Modified;
+                }
+                Action::None
+            }
+        }
+    }
+
+    fn view(&self, frame: &mut Frame, area: Rect, manifest: &PolicyManifest) {
+        let block = Block::default()
+            .borders(Borders::LEFT | Borders::RIGHT)
+            .border_style(Style::default().fg(Color::DarkGray));
+
+        let inner = block.inner(area);
+        frame.render_widget(block, area);
+
+        if manifest.includes.is_empty() {
+            let empty = Paragraph::new(Line::from(vec![
+                Span::styled(
+                    "  No includes. Press ",
+                    Style::default().fg(Color::DarkGray),
+                ),
+                Span::styled(
+                    "a",
+                    Style::default()
+                        .fg(Color::Yellow)
+                        .add_modifier(Modifier::BOLD),
+                ),
+                Span::styled(" to add one.", Style::default().fg(Color::DarkGray)),
+            ]));
+            frame.render_widget(empty, inner);
+            return;
+        }
+
+        let lines: Vec<Line> = manifest
+            .includes
+            .iter()
+            .enumerate()
+            .map(|(i, include)| {
+                let style = if i == self.selected {
+                    Style::default()
+                        .bg(Color::DarkGray)
+                        .fg(Color::White)
+                        .add_modifier(Modifier::BOLD)
+                } else {
+                    Style::default().fg(Color::White)
+                };
+
+                let priority = format!("[{}]", i + 1);
+                Line::from(vec![
+                    Span::styled(
+                        format!("  {priority} "),
+                        Style::default().fg(Color::DarkGray),
+                    ),
+                    Span::styled(&include.path, style),
+                ])
+            })
+            .collect();
+
+        let para = Paragraph::new(lines);
+        frame.render_widget(para, inner);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::policy::match_tree::*;
+    use std::collections::HashMap;
+
+    fn manifest_with_includes() -> PolicyManifest {
+        PolicyManifest {
+            includes: vec![
+                IncludeEntry {
+                    path: "a.star".into(),
+                },
+                IncludeEntry {
+                    path: "b.star".into(),
+                },
+                IncludeEntry {
+                    path: "c.star".into(),
+                },
+            ],
+            policy: CompiledPolicy {
+                sandboxes: HashMap::new(),
+                tree: vec![],
+                default_effect: crate::policy::Effect::Deny,
+                default_sandbox: None,
+            },
+        }
+    }
+
+    #[test]
+    fn test_reorder_includes() {
+        let mut manifest = manifest_with_includes();
+        let mut view = IncludesView::new();
+
+        // Select second item and move it up
+        view.selected = 1;
+        view.update(Msg::MoveItemUp, &mut manifest);
+        assert_eq!(view.selected, 0);
+        assert_eq!(manifest.includes[0].path, "b.star");
+        assert_eq!(manifest.includes[1].path, "a.star");
+
+        // Move it back down
+        view.update(Msg::MoveItemDown, &mut manifest);
+        assert_eq!(view.selected, 1);
+        assert_eq!(manifest.includes[0].path, "a.star");
+        assert_eq!(manifest.includes[1].path, "b.star");
+    }
+
+    #[test]
+    fn test_delete_include() {
+        let mut manifest = manifest_with_includes();
+        let mut view = IncludesView::new();
+        view.selected = 1;
+
+        let action = view.update(Msg::Delete, &mut manifest);
+        assert!(matches!(action, Action::Modified));
+        assert_eq!(manifest.includes.len(), 2);
+        assert_eq!(manifest.includes[0].path, "a.star");
+        assert_eq!(manifest.includes[1].path, "c.star");
+    }
+}

--- a/clash/src/tui/inline_form.rs
+++ b/clash/src/tui/inline_form.rs
@@ -1,0 +1,2608 @@
+//! Inline ratatui form overlays — no raw-mode exit needed.
+//!
+//! Each form is a list of [`FormField`]s rendered as a centered popup.
+//! Navigation: Tab/Shift-Tab between fields, type into text fields,
+//! Left/Right to cycle selects, Space to toggle multi-selects.
+
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use ratatui::Frame;
+use ratatui::layout::{Constraint, Layout, Rect};
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, Clear, Paragraph};
+
+use crate::policy::manifest_edit;
+use crate::policy::match_tree::{
+    Decision, IncludeEntry, Node, Observable, Pattern, PolicyManifest, SandboxRef, Value,
+};
+use crate::policy::sandbox_edit;
+use crate::policy::sandbox_types::{Cap, NetworkPolicy, PathMatch, RuleEffect};
+use crate::tui::tool_registry;
+
+use super::tea::FormRequest;
+
+// ---------------------------------------------------------------------------
+// Field types
+// ---------------------------------------------------------------------------
+
+pub enum FormField {
+    Text {
+        label: String,
+        value: String,
+        cursor: usize,
+        placeholder: String,
+        hint: Option<&'static str>,
+    },
+    Select {
+        label: String,
+        options: Vec<String>,
+        selected: usize,
+        /// Per-option hints — `hints[selected]` is shown when this field is active.
+        hints: Vec<&'static str>,
+    },
+    MultiSelect {
+        label: String,
+        options: Vec<String>,
+        toggled: Vec<bool>,
+        cursor: usize,
+        hint: Option<&'static str>,
+    },
+}
+
+impl FormField {
+    /// Returns the contextual hint for this field's current state.
+    fn hint(&self) -> Option<&'static str> {
+        match self {
+            FormField::Text { hint, .. } => *hint,
+            FormField::Select {
+                hints, selected, ..
+            } => {
+                let h = hints.get(*selected).copied().unwrap_or("");
+                if h.is_empty() { None } else { Some(h) }
+            }
+            FormField::MultiSelect { hint, .. } => *hint,
+        }
+    }
+}
+
+
+// ---------------------------------------------------------------------------
+// Form state
+// ---------------------------------------------------------------------------
+
+pub struct FormState {
+    pub title: String,
+    pub kind: FormKind,
+    pub fields: Vec<FormField>,
+    /// Indices into `fields` that are currently visible.
+    visible: Vec<usize>,
+    /// Index into `visible`.
+    active: usize,
+    /// Tool name context (from ancestor nodes or typed value), used to
+    /// filter effects and validate observables.
+    tool_context: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub enum FormKind {
+    AddRule,
+    AddSandbox,
+    AddSandboxRule { sandbox_name: String },
+    AddInclude,
+    EditCondition { path: Vec<usize> },
+    EditDecision { path: Vec<usize> },
+    AddChild { parent_path: Vec<usize> },
+    EditSandbox { sandbox_name: String },
+    EditSandboxRule {
+        sandbox_name: String,
+        rule_index: usize,
+    },
+}
+
+/// Result of processing a key event in the form.
+pub enum FormEvent {
+    /// Still editing.
+    Continue,
+    /// User submitted — apply changes.
+    Submit,
+    /// User cancelled.
+    Cancel,
+}
+
+// ---------------------------------------------------------------------------
+// Constructors
+// ---------------------------------------------------------------------------
+
+impl FormState {
+    /// Create the appropriate form for the given request.
+    ///
+    /// `included` provides sandboxes from resolved `.star` includes so they
+    /// appear in sandbox dropdowns (but are not editable).
+    pub fn from_request(
+        request: &FormRequest,
+        manifest: &PolicyManifest,
+        included: Option<&crate::policy::match_tree::CompiledPolicy>,
+    ) -> Self {
+        match request {
+            FormRequest::AddRule => Self::new_add_rule(manifest, included),
+            FormRequest::AddSandbox => Self::new_add_sandbox(),
+            FormRequest::AddSandboxRule { sandbox_name } => {
+                Self::new_add_sandbox_rule(sandbox_name)
+            }
+            FormRequest::AddInclude => Self::new_add_include(),
+            FormRequest::EditCondition { path } => Self::new_edit_condition(path, manifest),
+            FormRequest::EditDecision { path } => {
+                Self::new_edit_decision(path, manifest, included)
+            }
+            FormRequest::AddChild { parent_path } => {
+                Self::new_add_child(parent_path, manifest, included)
+            }
+            FormRequest::EditSandbox { sandbox_name } => {
+                Self::new_edit_sandbox(sandbox_name, manifest)
+            }
+            FormRequest::EditSandboxRule {
+                sandbox_name,
+                rule_index,
+            } => Self::new_edit_sandbox_rule(sandbox_name, *rule_index, manifest),
+        }
+    }
+
+    fn new_add_rule(
+        manifest: &PolicyManifest,
+        included: Option<&crate::policy::match_tree::CompiledPolicy>,
+    ) -> Self {
+        let (sandbox_opts, sb_default) = Self::build_sandbox_options_with_included(manifest, included);
+
+        let fields = vec![
+            FormField::Select {
+                label: "Rule type".into(),
+                options: vec!["Tool rule".into(), "Shell command".into()],
+                selected: 0,
+                hints: vec![
+                    "Match a Claude tool like Read, Write, Bash, Edit",
+                    "Match a shell command like git, npm, curl",
+                ],
+            },
+            FormField::Text {
+                label: "Tool name".into(),
+                value: String::new(),
+                cursor: 0,
+                placeholder: "e.g. Read, Write, Bash, Edit".into(),
+                hint: Some("e.g. Read, Write, Bash, Edit, Glob, Grep, WebSearch"),
+            },
+            FormField::Text {
+                label: "Command".into(),
+                value: String::new(),
+                cursor: 0,
+                placeholder: "e.g. git, npm, gh, curl".into(),
+                hint: Some("The program to match, e.g. git, npm, gh, curl"),
+            },
+            FormField::Text {
+                label: "Arguments".into(),
+                value: String::new(),
+                cursor: 0,
+                placeholder: "optional, e.g. push --force".into(),
+                hint: Some("Optional: only match when these args are used"),
+            },
+            FormField::Select {
+                label: "When matched".into(),
+                options: vec![
+                    "allow (permit)".into(),
+                    "deny (block)".into(),
+                    "ask (prompt)".into(),
+                ],
+                selected: 0,
+                hints: vec!["", "", ""],
+            },
+            FormField::Select {
+                label: "Sandbox".into(),
+                options: sandbox_opts,
+                selected: sb_default,
+                hints: vec![],
+            },
+        ];
+
+        let mut form = FormState {
+            title: "Add Rule".into(),
+            kind: FormKind::AddRule,
+            fields,
+            visible: vec![],
+            active: 0,
+            tool_context: None,
+        };
+        form.recompute_visible();
+        form
+    }
+
+    fn new_add_sandbox() -> Self {
+        let fields = vec![
+            FormField::Text {
+                label: "Name".into(),
+                value: String::new(),
+                cursor: 0,
+                placeholder: "e.g. cwd, strict".into(),
+                hint: Some("A short name for this sandbox profile"),
+            },
+            FormField::MultiSelect {
+                label: "Default caps".into(),
+                options: vec![
+                    "read".into(),
+                    "write".into(),
+                    "create".into(),
+                    "delete".into(),
+                    "execute".into(),
+                ],
+                toggled: vec![true, false, false, false, true],
+                cursor: 0,
+                hint: Some("Default filesystem capabilities for this sandbox"),
+            },
+            FormField::Select {
+                label: "Network".into(),
+                options: vec!["deny".into(), "allow".into(), "localhost".into()],
+                selected: 0,
+                hints: vec![
+                    "Block all network access",
+                    "Permit all network access",
+                    "Only allow connections to 127.0.0.1",
+                ],
+            },
+        ];
+
+        FormState {
+            title: "Add Sandbox".into(),
+            kind: FormKind::AddSandbox,
+            fields,
+            visible: vec![0, 1, 2],
+            active: 0,
+            tool_context: None,
+        }
+    }
+
+    fn new_add_sandbox_rule(sandbox_name: &str) -> Self {
+        let fields = vec![
+            FormField::Select {
+                label: "Effect".into(),
+                options: vec!["allow".into(), "deny".into()],
+                selected: 0,
+                hints: vec!["", ""],
+            },
+            FormField::MultiSelect {
+                label: "Caps".into(),
+                options: vec![
+                    "read".into(),
+                    "write".into(),
+                    "create".into(),
+                    "delete".into(),
+                    "execute".into(),
+                ],
+                toggled: vec![true, true, false, false, false],
+                cursor: 0,
+                hint: None,
+            },
+            FormField::Text {
+                label: "Path".into(),
+                value: String::new(),
+                cursor: 0,
+                placeholder: "e.g. $PWD, $HOME/.config".into(),
+                hint: Some("The filesystem path this rule applies to"),
+            },
+            FormField::Select {
+                label: "Path match".into(),
+                options: vec!["subpath".into(), "literal".into(), "regex".into()],
+                selected: 0,
+                hints: vec![
+                    "Match this path and everything under it",
+                    "Match this exact path only",
+                    "Match paths by regular expression",
+                ],
+            },
+        ];
+
+        FormState {
+            title: format!("Add Rule to '{sandbox_name}'"),
+            kind: FormKind::AddSandboxRule {
+                sandbox_name: sandbox_name.to_string(),
+            },
+            fields,
+            visible: vec![0, 1, 2, 3],
+            active: 0,
+            tool_context: None,
+        }
+    }
+
+    fn new_edit_sandbox(sandbox_name: &str, manifest: &PolicyManifest) -> Self {
+        let sb = manifest.policy.sandboxes.get(sandbox_name);
+
+        let caps_toggled = if let Some(sb) = sb {
+            vec![
+                sb.default.contains(Cap::READ),
+                sb.default.contains(Cap::WRITE),
+                sb.default.contains(Cap::CREATE),
+                sb.default.contains(Cap::DELETE),
+                sb.default.contains(Cap::EXECUTE),
+            ]
+        } else {
+            vec![true, false, false, false, true]
+        };
+
+        let network_idx = match sb.map(|s| &s.network) {
+            Some(NetworkPolicy::Deny) | None => 0,
+            Some(NetworkPolicy::Allow) => 1,
+            Some(NetworkPolicy::Localhost) => 2,
+            Some(NetworkPolicy::AllowDomains(_)) => 1, // approximate
+        };
+
+        let fields = vec![
+            FormField::MultiSelect {
+                label: "Default caps".into(),
+                options: vec![
+                    "read".into(),
+                    "write".into(),
+                    "create".into(),
+                    "delete".into(),
+                    "execute".into(),
+                ],
+                toggled: caps_toggled,
+                cursor: 0,
+                hint: Some("Default filesystem capabilities for this sandbox"),
+            },
+            FormField::Select {
+                label: "Network".into(),
+                options: vec!["deny".into(), "allow".into(), "localhost".into()],
+                selected: network_idx,
+                hints: vec![
+                    "Block all network access",
+                    "Permit all network access",
+                    "Only allow connections to 127.0.0.1",
+                ],
+            },
+        ];
+
+        FormState {
+            title: format!("Edit Sandbox '{sandbox_name}'"),
+            kind: FormKind::EditSandbox {
+                sandbox_name: sandbox_name.to_string(),
+            },
+            fields,
+            visible: vec![0, 1],
+            active: 0,
+            tool_context: None,
+        }
+    }
+
+    fn new_edit_sandbox_rule(
+        sandbox_name: &str,
+        rule_index: usize,
+        manifest: &PolicyManifest,
+    ) -> Self {
+        let rule = manifest
+            .policy
+            .sandboxes
+            .get(sandbox_name)
+            .and_then(|sb| sb.rules.get(rule_index));
+
+        let effect_idx = match rule.map(|r| &r.effect) {
+            Some(RuleEffect::Allow) | None => 0,
+            Some(RuleEffect::Deny) => 1,
+        };
+
+        let caps_toggled = if let Some(r) = rule {
+            vec![
+                r.caps.contains(Cap::READ),
+                r.caps.contains(Cap::WRITE),
+                r.caps.contains(Cap::CREATE),
+                r.caps.contains(Cap::DELETE),
+                r.caps.contains(Cap::EXECUTE),
+            ]
+        } else {
+            vec![true, true, false, false, false]
+        };
+
+        let path_value = rule.map(|r| r.path.clone()).unwrap_or_default();
+        let path_cursor = path_value.len();
+
+        let path_match_idx = match rule.map(|r| &r.path_match) {
+            Some(PathMatch::Subpath) | None => 0,
+            Some(PathMatch::Literal) => 1,
+            Some(PathMatch::Regex) => 2,
+        };
+
+        let fields = vec![
+            FormField::Select {
+                label: "Effect".into(),
+                options: vec!["allow".into(), "deny".into()],
+                selected: effect_idx,
+                hints: vec!["", ""],
+            },
+            FormField::MultiSelect {
+                label: "Caps".into(),
+                options: vec![
+                    "read".into(),
+                    "write".into(),
+                    "create".into(),
+                    "delete".into(),
+                    "execute".into(),
+                ],
+                toggled: caps_toggled,
+                cursor: 0,
+                hint: None,
+            },
+            FormField::Text {
+                label: "Path".into(),
+                value: path_value,
+                cursor: path_cursor,
+                placeholder: "e.g. $PWD, $HOME/.config".into(),
+                hint: Some("The filesystem path this rule applies to"),
+            },
+            FormField::Select {
+                label: "Path match".into(),
+                options: vec!["subpath".into(), "literal".into(), "regex".into()],
+                selected: path_match_idx,
+                hints: vec![
+                    "Match this path and everything under it",
+                    "Match this exact path only",
+                    "Match paths by regular expression",
+                ],
+            },
+        ];
+
+        FormState {
+            title: format!("Edit Rule in '{sandbox_name}'"),
+            kind: FormKind::EditSandboxRule {
+                sandbox_name: sandbox_name.to_string(),
+                rule_index,
+            },
+            fields,
+            visible: vec![0, 1, 2, 3],
+            active: 0,
+            tool_context: None,
+        }
+    }
+
+    fn new_add_include() -> Self {
+        let fields = vec![FormField::Text {
+            label: "Include path".into(),
+            value: String::new(),
+            cursor: 0,
+            placeholder: "e.g. rules.star, @clash//builtin.star".into(),
+            hint: Some("e.g. rules.star, @clash//builtin.star"),
+        }];
+
+        FormState {
+            title: "Add Include".into(),
+            kind: FormKind::AddInclude,
+            fields,
+            visible: vec![0],
+            active: 0,
+            tool_context: None,
+        }
+    }
+
+    fn new_edit_condition(path: &[usize], manifest: &PolicyManifest) -> Self {
+        let (obs_idx, pat_value) = Self::read_condition_at_path(&manifest.policy.tree, path);
+        let title = Self::describe_condition_at_path(&manifest.policy.tree, path);
+
+        let pat_type_idx = Self::pattern_type_index_at_path(&manifest.policy.tree, path);
+        let fields = vec![
+            FormField::Select {
+                label: "Match on".into(),
+                options: observable_options(),
+                selected: obs_idx,
+                hints: observable_option_hints(),
+            },
+            FormField::Text {
+                label: "Which one".into(),
+                value: Self::observable_param_at_path(&manifest.policy.tree, path),
+                cursor: 0,
+                placeholder: observable_param_placeholder(obs_idx).into(),
+                hint: {
+                    let h = observable_param_hint(obs_idx);
+                    if h.is_empty() { None } else { Some(h) }
+                },
+            },
+            FormField::Select {
+                label: "Match type".into(),
+                options: vec![
+                    "exact value".into(),
+                    "anything".into(),
+                    "regex".into(),
+                    "path prefix".into(),
+                ],
+                selected: pat_type_idx,
+                hints: pattern_option_hints(),
+            },
+            FormField::Text {
+                label: "Match value".into(),
+                value: pat_value,
+                cursor: 0,
+                placeholder: pattern_value_placeholder(obs_idx).into(),
+                hint: {
+                    let h = pattern_value_hint(pat_type_idx);
+                    if h.is_empty() { None } else { Some(h) }
+                },
+            },
+        ];
+
+        let mut form = FormState {
+            title,
+            kind: FormKind::EditCondition {
+                path: path.to_vec(),
+            },
+            fields,
+            visible: vec![],
+            active: 0,
+            tool_context: Self::ancestor_tool_name(&manifest.policy.tree, path),
+        };
+        form.recompute_visible();
+        form
+    }
+
+    fn new_edit_decision(
+        path: &[usize],
+        manifest: &PolicyManifest,
+        included: Option<&crate::policy::match_tree::CompiledPolicy>,
+    ) -> Self {
+        let (effect_idx, sandbox_name) =
+            Self::read_decision_at_path(&manifest.policy.tree, path);
+        let title = Self::describe_node_at_path(&manifest.policy.tree, path);
+        let tool_ctx = Self::ancestor_tool_name(&manifest.policy.tree, path);
+
+        let (effect_labels, effect_hints) =
+            tool_registry::effect_options_for_tool(tool_ctx.as_deref());
+        // Clamp effect_idx if it's beyond filtered options
+        let selected_effect = effect_idx.min(effect_labels.len().saturating_sub(1));
+
+        let (sandbox_opts, sb_default) =
+            Self::build_sandbox_options_with_included(manifest, included);
+
+        // Use existing sandbox if set, otherwise fall back to default
+        let sb_selected = if let Some(ref name) = sandbox_name {
+            sandbox_opts.iter().position(|s| s == name).unwrap_or(sb_default)
+        } else {
+            sb_default
+        };
+
+        let fields = vec![
+            FormField::Select {
+                label: "When matched".into(),
+                options: effect_labels,
+                selected: selected_effect,
+                hints: effect_hints,
+            },
+            FormField::Select {
+                label: "Sandbox".into(),
+                options: sandbox_opts,
+                selected: sb_selected,
+                hints: vec![],
+            },
+        ];
+
+        let mut form = FormState {
+            title,
+            kind: FormKind::EditDecision {
+                path: path.to_vec(),
+            },
+            fields,
+            visible: vec![],
+            active: 0,
+            tool_context: tool_ctx,
+        };
+        form.recompute_visible();
+        form
+    }
+
+    fn read_decision_at_path(tree: &[Node], path: &[usize]) -> (usize, Option<String>) {
+        match Self::get_node_at_path(tree, path) {
+            Some(Node::Decision(d)) => match d {
+                Decision::Allow(sb) => (0, sb.as_ref().map(|s| s.0.clone())),
+                Decision::Deny => (1, None),
+                Decision::Ask(sb) => (2, sb.as_ref().map(|s| s.0.clone())),
+            },
+            // For inline leaves (Condition with single Decision child), read the child
+            Some(Node::Condition { children, .. }) => {
+                if let Some(Node::Decision(d)) = children.first() {
+                    match d {
+                        Decision::Allow(sb) => (0, sb.as_ref().map(|s| s.0.clone())),
+                        Decision::Deny => (1, None),
+                        Decision::Ask(sb) => (2, sb.as_ref().map(|s| s.0.clone())),
+                    }
+                } else {
+                    (0, None)
+                }
+            }
+            _ => (0, None),
+        }
+    }
+
+    fn new_add_child(
+        parent_path: &[usize],
+        manifest: &PolicyManifest,
+        included: Option<&crate::policy::match_tree::CompiledPolicy>,
+    ) -> Self {
+        let parent_desc = Self::describe_condition_at_path(&manifest.policy.tree, parent_path);
+
+        let (sandbox_opts, sb_default) =
+            Self::build_sandbox_options_with_included(manifest, included);
+
+        let fields = vec![
+            FormField::Select {
+                label: "Add".into(),
+                options: vec!["Match condition".into(), "Effect (allow/deny/ask)".into()],
+                selected: 0,
+                hints: vec![
+                    "Add a branch that narrows what this rule matches",
+                    "Add a final allow/deny/ask decision",
+                ],
+            },
+            FormField::Select {
+                label: "Match on".into(),
+                options: observable_options(),
+                selected: 0,
+                hints: observable_option_hints(),
+            },
+            FormField::Text {
+                label: "Which one".into(),
+                value: String::new(),
+                cursor: 0,
+                placeholder: "e.g. 0, arg_name, field.path".into(),
+                hint: None, // updated in recompute_visible
+            },
+            FormField::Select {
+                label: "Match type".into(),
+                options: vec![
+                    "exact value".into(),
+                    "anything".into(),
+                    "regex".into(),
+                    "path prefix".into(),
+                ],
+                selected: 0,
+                hints: pattern_option_hints(),
+            },
+            FormField::Text {
+                label: "Match value".into(),
+                value: String::new(),
+                cursor: 0,
+                placeholder: "e.g. Read, /^git.*/, $HOME".into(),
+                hint: None, // updated in recompute_visible
+            },
+            FormField::Select {
+                label: "When matched".into(),
+                options: vec![
+                    "allow (permit)".into(),
+                    "deny (block)".into(),
+                    "ask (prompt)".into(),
+                ],
+                selected: 0,
+                hints: vec!["", "", ""],
+            },
+            FormField::Select {
+                label: "Sandbox".into(),
+                options: sandbox_opts,
+                selected: sb_default,
+                hints: vec![],
+            },
+        ];
+
+        let mut form = FormState {
+            title: parent_desc,
+            kind: FormKind::AddChild {
+                parent_path: parent_path.to_vec(),
+            },
+            fields,
+            visible: vec![],
+            active: 0,
+            tool_context: Self::ancestor_tool_name(&manifest.policy.tree, parent_path),
+        };
+        form.recompute_visible();
+        form
+    }
+
+    /// Build a human-readable title describing the condition node at this path.
+    fn describe_condition_at_path(tree: &[Node], path: &[usize]) -> String {
+        match Self::get_node_at_path(tree, path) {
+            Some(Node::Condition {
+                observe, pattern, ..
+            }) => {
+                let what = observable_short_desc(observe);
+                let val = short_pattern_desc(pattern);
+                format!("Edit: {what} = {val}")
+            }
+            _ => "Edit Condition".into(),
+        }
+    }
+
+    /// Build a human-readable title describing any node at this path.
+    fn describe_node_at_path(tree: &[Node], path: &[usize]) -> String {
+        // Walk up from the node to build context breadcrumbs
+        match Self::get_node_at_path(tree, path) {
+            Some(Node::Decision(d)) => {
+                // Try to describe the parent condition for context
+                if path.len() >= 2 {
+                    let parent_path = &path[..path.len() - 1];
+                    if let Some(Node::Condition {
+                        observe, pattern, ..
+                    }) = Self::get_node_at_path(tree, parent_path)
+                    {
+                        let what = observable_short_desc(observe);
+                        let val = short_pattern_desc(pattern);
+                        return format!("Edit effect for {what} = {val}");
+                    }
+                }
+                let effect = match d {
+                    Decision::Allow(_) => "allow",
+                    Decision::Deny => "deny",
+                    Decision::Ask(_) => "ask",
+                };
+                format!("Edit effect (currently {effect})")
+            }
+            Some(Node::Condition {
+                observe,
+                pattern,
+                children,
+                ..
+            }) => {
+                // Inline leaf — show condition context + current effect
+                if children.len() == 1 {
+                    if let Node::Decision(d) = &children[0] {
+                        let what = observable_short_desc(observe);
+                        let val = short_pattern_desc(pattern);
+                        let effect = match d {
+                            Decision::Allow(_) => "allow",
+                            Decision::Deny => "deny",
+                            Decision::Ask(_) => "ask",
+                        };
+                        return format!("Edit: {what} = {val} (currently {effect})");
+                    }
+                }
+                let what = observable_short_desc(observe);
+                let val = short_pattern_desc(pattern);
+                format!("Edit: {what} = {val}")
+            }
+            None => "Edit".into(),
+        }
+    }
+
+    /// Read the observable index and pattern value from a node at a path.
+    fn read_condition_at_path(tree: &[Node], path: &[usize]) -> (usize, String) {
+        let node = Self::get_node_at_path(tree, path);
+        match node {
+            Some(Node::Condition {
+                observe, pattern, ..
+            }) => {
+                let obs_idx = observable_to_index(observe);
+                let pat_val = pattern_to_value_string(pattern);
+                (obs_idx, pat_val)
+            }
+            _ => (0, String::new()),
+        }
+    }
+
+    fn observable_param_at_path(tree: &[Node], path: &[usize]) -> String {
+        match Self::get_node_at_path(tree, path) {
+            Some(Node::Condition { observe, .. }) => match observe {
+                Observable::PositionalArg(n) => n.to_string(),
+                Observable::NamedArg(name) => name.clone(),
+                Observable::NestedField(parts) => parts.join("."),
+                _ => String::new(),
+            },
+            _ => String::new(),
+        }
+    }
+
+    fn pattern_type_index_at_path(tree: &[Node], path: &[usize]) -> usize {
+        match Self::get_node_at_path(tree, path) {
+            Some(Node::Condition { pattern, .. }) => match pattern {
+                Pattern::Literal(_) => 0,
+                Pattern::Wildcard => 1,
+                Pattern::Regex(_) => 2,
+                Pattern::Prefix(_) => 3,
+                _ => 0,
+            },
+            _ => 0,
+        }
+    }
+
+    /// Build sandbox options list and default selection index.
+    ///
+    /// Includes sandboxes from both inline policy and resolved `.star` includes.
+    /// Defaults to `default_sandbox` if set, otherwise "(none)".
+    fn build_sandbox_options_with_included(
+        manifest: &PolicyManifest,
+        included: Option<&crate::policy::match_tree::CompiledPolicy>,
+    ) -> (Vec<String>, usize) {
+        let mut opts = vec!["(none)".to_string()];
+        let mut names: Vec<String> = manifest.policy.sandboxes.keys().cloned().collect();
+        // Add included sandbox names
+        if let Some(inc) = included {
+            for k in inc.sandboxes.keys() {
+                if !manifest.policy.sandboxes.contains_key(k) {
+                    names.push(k.clone());
+                }
+            }
+        }
+        names.sort();
+        opts.extend(names);
+
+        let default_idx = manifest
+            .policy
+            .default_sandbox
+            .as_ref()
+            .and_then(|name| opts.iter().position(|s| s == name))
+            .unwrap_or(0);
+
+        (opts, default_idx)
+    }
+
+    /// Walk ancestor nodes to find the nearest ToolName condition's pattern value.
+    fn ancestor_tool_name(tree: &[Node], path: &[usize]) -> Option<String> {
+        for len in (1..=path.len()).rev() {
+            let sub_path = &path[..len];
+            if let Some(Node::Condition {
+                observe: Observable::ToolName,
+                pattern,
+                ..
+            }) = Self::get_node_at_path(tree, sub_path)
+            {
+                return Some(pattern_to_value_string(pattern));
+            }
+        }
+        None
+    }
+
+    fn get_node_at_path<'a>(tree: &'a [Node], path: &[usize]) -> Option<&'a Node> {
+        if path.is_empty() {
+            return None;
+        }
+        let mut current = tree.get(path[0])?;
+        for &idx in &path[1..] {
+            match current {
+                Node::Condition { children, .. } => {
+                    current = children.get(idx)?;
+                }
+                Node::Decision(_) => return None,
+            }
+        }
+        Some(current)
+    }
+
+    /// Rebuild a Select field's options/hints to match allowed effects for a tool.
+    fn rebuild_effect_select(field: &mut FormField, tool_name: Option<&str>) {
+        if let FormField::Select {
+            options,
+            hints,
+            selected,
+            ..
+        } = field
+        {
+            let (new_options, new_hints) =
+                tool_registry::effect_options_for_tool(tool_name);
+            if *options != new_options {
+                *options = new_options;
+                *hints = new_hints;
+                if *selected >= options.len() {
+                    *selected = options.len().saturating_sub(1);
+                }
+            }
+        }
+    }
+
+    /// Set the hint on a Text field. No-op for other field types.
+    fn set_text_hint(field: &mut FormField, h: &'static str) {
+        if let FormField::Text { hint, .. } = field {
+            *hint = if h.is_empty() { None } else { Some(h) };
+        }
+    }
+
+    /// Recompute which field indices are visible based on current selections.
+    fn recompute_visible(&mut self) {
+        match &self.kind {
+            FormKind::AddRule => {
+                let rule_type = match &self.fields[0] {
+                    FormField::Select { selected, .. } => *selected,
+                    _ => 0,
+                };
+
+                // Update tool context from typed tool name
+                if rule_type == 0 {
+                    let name = self.text_value(1);
+                    self.tool_context = if name.is_empty() {
+                        None
+                    } else {
+                        Some(name)
+                    };
+                } else {
+                    self.tool_context = None;
+                }
+
+                // Rebuild effect options based on tool context
+                Self::rebuild_effect_select(
+                    &mut self.fields[4],
+                    self.tool_context.as_deref(),
+                );
+
+                let effect = match &self.fields[4] {
+                    FormField::Select { selected, .. } => *selected,
+                    _ => 0,
+                };
+                let has_sandboxes = match &self.fields[5] {
+                    FormField::Select { options, .. } => options.len() > 1,
+                    _ => false,
+                };
+
+                let mut vis = vec![0]; // always show rule type
+                if rule_type == 0 {
+                    vis.push(1); // tool name
+                } else {
+                    vis.push(2); // binary
+                    vis.push(3); // args
+                }
+                vis.push(4); // effect
+                // Show sandbox only for allow/ask and when sandboxes exist
+                let canonical = tool_registry::filtered_effect_to_canonical(
+                    self.tool_context.as_deref(),
+                    effect,
+                );
+                if canonical != 1 && has_sandboxes {
+                    vis.push(5);
+                }
+                self.visible = vis;
+            }
+            FormKind::EditCondition { .. } => {
+                let obs_idx = self.select_value(0);
+                let pat_idx = self.select_value(2);
+                // Refresh dependent text hints
+                Self::set_text_hint(&mut self.fields[1], observable_param_hint(obs_idx));
+                Self::set_text_hint(&mut self.fields[3], pattern_value_hint(pat_idx));
+                let mut vis = vec![0]; // observable
+                if observable_needs_param(obs_idx) {
+                    vis.push(1); // parameter
+                }
+                vis.push(2); // pattern type
+                if pat_idx != 1 {
+                    // not wildcard
+                    vis.push(3); // pattern value
+                }
+                self.visible = vis;
+            }
+            FormKind::EditDecision { .. } => {
+                let effect_idx = self.select_value(0);
+                let canonical = tool_registry::filtered_effect_to_canonical(
+                    self.tool_context.as_deref(),
+                    effect_idx,
+                );
+                let has_sandboxes = match &self.fields[1] {
+                    FormField::Select { options, .. } => options.len() > 1,
+                    _ => false,
+                };
+                let mut vis = vec![0]; // effect
+                // Show sandbox for allow/ask when sandboxes exist
+                if canonical != 1 && has_sandboxes {
+                    vis.push(1);
+                }
+                self.visible = vis;
+            }
+            FormKind::AddChild { .. } => {
+                let child_type = self.select_value(0);
+                if child_type == 0 {
+                    // Condition
+                    let obs_idx = self.select_value(1);
+                    let pat_idx = self.select_value(3);
+                    // Refresh dependent text hints
+                    Self::set_text_hint(&mut self.fields[2], observable_param_hint(obs_idx));
+                    Self::set_text_hint(&mut self.fields[4], pattern_value_hint(pat_idx));
+                    let mut vis = vec![0, 1]; // type, observable
+                    if observable_needs_param(obs_idx) {
+                        vis.push(2); // parameter
+                    }
+                    vis.push(3); // pattern type
+                    if pat_idx != 1 {
+                        // not wildcard
+                        vis.push(4); // pattern value
+                    }
+                    self.visible = vis;
+                } else {
+                    // Decision — filter effects based on tool context
+                    Self::rebuild_effect_select(
+                        &mut self.fields[5],
+                        self.tool_context.as_deref(),
+                    );
+                    let effect_idx = self.select_value(5);
+                    let canonical = tool_registry::filtered_effect_to_canonical(
+                        self.tool_context.as_deref(),
+                        effect_idx,
+                    );
+                    let has_sandboxes = match &self.fields[6] {
+                        FormField::Select { options, .. } => options.len() > 1,
+                        _ => false,
+                    };
+                    let mut vis = vec![0, 5]; // type, effect
+                    if canonical != 1 && has_sandboxes {
+                        vis.push(6); // sandbox
+                    }
+                    self.visible = vis;
+                }
+            }
+            _ => {} // other forms have static visibility
+        }
+
+        // Clamp active
+        if self.active >= self.visible.len() {
+            self.active = self.visible.len().saturating_sub(1);
+        }
+    }
+
+    fn active_field_index(&self) -> usize {
+        self.visible[self.active]
+    }
+
+    /// Returns true if the currently active field is a Select (not a Text input).
+    pub fn active_field_is_select(&self) -> bool {
+        matches!(
+            self.fields[self.active_field_index()],
+            FormField::Select { .. }
+        )
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Key handling
+// ---------------------------------------------------------------------------
+
+impl FormState {
+    /// Process a key event. Returns a FormEvent indicating what happened.
+    pub fn handle_key(&mut self, key: KeyEvent) -> FormEvent {
+        match key.code {
+            KeyCode::Esc => return FormEvent::Cancel,
+            // Submit: Ctrl+Enter or Enter when not on a text/multiselect field
+            KeyCode::Enter
+                if key.modifiers.contains(KeyModifiers::CONTROL)
+                    || key.modifiers.contains(KeyModifiers::ALT) =>
+            {
+                return FormEvent::Submit;
+            }
+            _ => {}
+        }
+
+        let fi = self.active_field_index();
+
+        // Field-specific key handling
+        match &mut self.fields[fi] {
+            FormField::Text {
+                value,
+                cursor,
+                ..
+            } => match key.code {
+                KeyCode::Char(c) => {
+                    value.insert(*cursor, c);
+                    *cursor += 1;
+                    self.recompute_visible();
+                }
+                KeyCode::Backspace => {
+                    if *cursor > 0 {
+                        *cursor -= 1;
+                        value.remove(*cursor);
+                        self.recompute_visible();
+                    }
+                }
+                KeyCode::Delete => {
+                    if *cursor < value.len() {
+                        value.remove(*cursor);
+                        self.recompute_visible();
+                    }
+                }
+                KeyCode::Left => {
+                    *cursor = cursor.saturating_sub(1);
+                }
+                KeyCode::Right => {
+                    *cursor = (*cursor + 1).min(value.len());
+                }
+                KeyCode::Home => {
+                    *cursor = 0;
+                }
+                KeyCode::End => {
+                    *cursor = value.len();
+                }
+                KeyCode::Enter => {
+                    // Move to next field or submit
+                    if self.active + 1 < self.visible.len() {
+                        self.active += 1;
+                    } else {
+                        return FormEvent::Submit;
+                    }
+                }
+                KeyCode::BackTab => {
+                    self.active = self.active.saturating_sub(1);
+                }
+                KeyCode::Tab => {
+                    if self.active + 1 < self.visible.len() {
+                        self.active += 1;
+                    }
+                }
+                KeyCode::Down => {
+                    if self.active + 1 < self.visible.len() {
+                        self.active += 1;
+                    }
+                }
+                KeyCode::Up => {
+                    self.active = self.active.saturating_sub(1);
+                }
+                _ => {}
+            },
+            FormField::Select {
+                options, selected, ..
+            } => {
+                let len = options.len();
+                match key.code {
+                    KeyCode::Left | KeyCode::Char('h') => {
+                        *selected = if *selected == 0 { len - 1 } else { *selected - 1 };
+                        self.recompute_visible();
+                    }
+                    KeyCode::Right | KeyCode::Char('l') => {
+                        *selected = (*selected + 1) % len;
+                        self.recompute_visible();
+                    }
+                    KeyCode::Tab => {
+                        *selected = (*selected + 1) % len;
+                        self.recompute_visible();
+                    }
+                    KeyCode::BackTab => {
+                        *selected = if *selected == 0 { len - 1 } else { *selected - 1 };
+                        self.recompute_visible();
+                    }
+                    KeyCode::Enter => {
+                        if self.active + 1 < self.visible.len() {
+                            self.active += 1;
+                        } else {
+                            return FormEvent::Submit;
+                        }
+                    }
+                    KeyCode::Down => {
+                        if self.active + 1 < self.visible.len() {
+                            self.active += 1;
+                        }
+                    }
+                    KeyCode::Up => {
+                        self.active = self.active.saturating_sub(1);
+                    }
+                    _ => {}
+                }
+            }
+            FormField::MultiSelect {
+                options,
+                toggled,
+                cursor,
+                ..
+            } => match key.code {
+                KeyCode::Left | KeyCode::Char('h') => {
+                    *cursor = cursor.saturating_sub(1);
+                }
+                KeyCode::Right | KeyCode::Char('l') => {
+                    *cursor = (*cursor + 1).min(options.len().saturating_sub(1));
+                }
+                KeyCode::Char(' ') => {
+                    if *cursor < toggled.len() {
+                        toggled[*cursor] = !toggled[*cursor];
+                    }
+                }
+                KeyCode::Tab => {
+                    *cursor = (*cursor + 1).min(options.len().saturating_sub(1));
+                }
+                KeyCode::BackTab => {
+                    *cursor = cursor.saturating_sub(1);
+                }
+                KeyCode::Enter => {
+                    if self.active + 1 < self.visible.len() {
+                        self.active += 1;
+                    } else {
+                        return FormEvent::Submit;
+                    }
+                }
+                KeyCode::Down => {
+                    if self.active + 1 < self.visible.len() {
+                        self.active += 1;
+                    }
+                }
+                KeyCode::Up => {
+                    self.active = self.active.saturating_sub(1);
+                }
+                _ => {}
+            },
+        }
+
+        FormEvent::Continue
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Submission — apply form values to manifest
+// ---------------------------------------------------------------------------
+
+impl FormState {
+    /// Apply the form values to the manifest. Returns true if modified, or an error message.
+    pub fn apply(&self, manifest: &mut PolicyManifest) -> Result<bool, String> {
+        match &self.kind {
+            FormKind::AddRule => self.apply_add_rule(manifest),
+            FormKind::AddSandbox => self.apply_add_sandbox(manifest),
+            FormKind::AddSandboxRule { sandbox_name } => {
+                self.apply_add_sandbox_rule(manifest, sandbox_name)
+            }
+            FormKind::AddInclude => self.apply_add_include(manifest),
+            FormKind::EditCondition { path } => self.apply_edit_condition(manifest, path),
+            FormKind::EditDecision { path } => self.apply_edit_decision(manifest, path),
+            FormKind::AddChild { parent_path } => self.apply_add_child(manifest, parent_path),
+            FormKind::EditSandbox { sandbox_name } => {
+                self.apply_edit_sandbox(manifest, sandbox_name)
+            }
+            FormKind::EditSandboxRule {
+                sandbox_name,
+                rule_index,
+            } => self.apply_edit_sandbox_rule(manifest, sandbox_name, *rule_index),
+        }
+    }
+
+    fn apply_add_rule(&self, manifest: &mut PolicyManifest) -> Result<bool, String> {
+        let rule_type = self.select_value(0);
+        let effect_idx = tool_registry::filtered_effect_to_canonical(
+            self.tool_context.as_deref(),
+            self.select_value(4),
+        );
+
+        // Build sandbox ref
+        let sandbox_ref = if effect_idx != 1 {
+            // not deny
+            let sb_idx = self.select_value(5);
+            if sb_idx > 0 {
+                let sb_name = self.select_option_str(5, sb_idx);
+                Some(SandboxRef(sb_name))
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+
+        let decision = match effect_idx {
+            0 => Decision::Allow(sandbox_ref),
+            1 => Decision::Deny,
+            2 => Decision::Ask(sandbox_ref),
+            _ => Decision::Deny,
+        };
+
+        let node = if rule_type == 0 {
+            // Tool rule
+            let tool_name = self.text_value(1);
+            if tool_name.is_empty() {
+                return Err("Tool name is required".into());
+            }
+            manifest_edit::build_tool_rule(&tool_name, decision)
+        } else {
+            // Exec rule
+            let bin = self.text_value(2);
+            if bin.is_empty() {
+                return Err("Binary name is required".into());
+            }
+            let args_str = self.text_value(3);
+            let args: Vec<&str> = if args_str.is_empty() {
+                vec![]
+            } else {
+                args_str.split_whitespace().collect()
+            };
+            manifest_edit::build_exec_rule(&bin, &args, decision)
+        };
+
+        manifest_edit::upsert_rule(manifest, node);
+        Ok(true)
+    }
+
+    fn apply_add_sandbox(&self, manifest: &mut PolicyManifest) -> Result<bool, String> {
+        let name = self.text_value(0);
+        if name.is_empty() {
+            return Err("Sandbox name is required".into());
+        }
+
+        let caps = self.multi_select_caps(1);
+        let network = match self.select_value(2) {
+            0 => NetworkPolicy::Deny,
+            1 => NetworkPolicy::Allow,
+            2 => NetworkPolicy::Localhost,
+            _ => NetworkPolicy::Deny,
+        };
+
+        sandbox_edit::create_sandbox(manifest, &name, caps, network, None)
+            .map_err(|e| e.to_string())?;
+        Ok(true)
+    }
+
+    fn apply_add_sandbox_rule(
+        &self,
+        manifest: &mut PolicyManifest,
+        sandbox_name: &str,
+    ) -> Result<bool, String> {
+        let effect = match self.select_value(0) {
+            0 => RuleEffect::Allow,
+            _ => RuleEffect::Deny,
+        };
+        let caps = self.multi_select_caps(1);
+        let path = self.text_value(2);
+        if path.is_empty() {
+            return Err("Path is required".into());
+        }
+        let path_match = match self.select_value(3) {
+            0 => PathMatch::Subpath,
+            1 => PathMatch::Literal,
+            2 => PathMatch::Regex,
+            _ => PathMatch::Subpath,
+        };
+
+        sandbox_edit::add_rule(manifest, sandbox_name, effect, caps, path, path_match, None)
+            .map_err(|e| e.to_string())?;
+        Ok(true)
+    }
+
+    fn apply_add_include(&self, manifest: &mut PolicyManifest) -> Result<bool, String> {
+        let path = self.text_value(0);
+        if path.is_empty() {
+            return Err("Include path is required".into());
+        }
+        manifest.includes.push(IncludeEntry { path });
+        Ok(true)
+    }
+
+    fn apply_edit_condition(
+        &self,
+        manifest: &mut PolicyManifest,
+        path: &[usize],
+    ) -> Result<bool, String> {
+        let observable = self.build_observable(0, 1)?;
+        let pattern = self.build_pattern(2, 3)?;
+
+        let node = Self::get_node_at_path_mut(&mut manifest.policy.tree, path)
+            .ok_or_else(|| "Node not found".to_string())?;
+
+        match node {
+            Node::Condition {
+                observe,
+                pattern: pat,
+                ..
+            } => {
+                *observe = observable;
+                *pat = pattern;
+                Ok(true)
+            }
+            _ => Err("Not a condition node".into()),
+        }
+    }
+
+    fn apply_edit_decision(
+        &self,
+        manifest: &mut PolicyManifest,
+        path: &[usize],
+    ) -> Result<bool, String> {
+        let effect_idx = tool_registry::filtered_effect_to_canonical(
+            self.tool_context.as_deref(),
+            self.select_value(0),
+        );
+        let sandbox_ref = if effect_idx != 1 {
+            let sb_idx = self.select_value(1);
+            if sb_idx > 0 {
+                Some(SandboxRef(self.select_option_str(1, sb_idx)))
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+        let new_decision = match effect_idx {
+            0 => Decision::Allow(sandbox_ref),
+            1 => Decision::Deny,
+            2 => Decision::Ask(sandbox_ref),
+            _ => Decision::Deny,
+        };
+
+        let node = Self::get_node_at_path_mut(&mut manifest.policy.tree, path)
+            .ok_or_else(|| "Node not found".to_string())?;
+
+        match node {
+            Node::Decision(d) => {
+                *d = new_decision;
+                Ok(true)
+            }
+            // Inline leaf: condition with a single decision child
+            Node::Condition { children, .. } => {
+                if let Some(Node::Decision(d)) = children.first_mut() {
+                    *d = new_decision;
+                    Ok(true)
+                } else {
+                    Err("Not a decision node".into())
+                }
+            }
+        }
+    }
+
+    fn apply_edit_sandbox(
+        &self,
+        manifest: &mut PolicyManifest,
+        sandbox_name: &str,
+    ) -> Result<bool, String> {
+        let caps = self.multi_select_caps(0);
+        let network = match self.select_value(1) {
+            0 => NetworkPolicy::Deny,
+            1 => NetworkPolicy::Allow,
+            2 => NetworkPolicy::Localhost,
+            _ => NetworkPolicy::Deny,
+        };
+
+        let sb = manifest
+            .policy
+            .sandboxes
+            .get_mut(sandbox_name)
+            .ok_or_else(|| format!("Sandbox '{sandbox_name}' not found"))?;
+        sb.default = caps;
+        sb.network = network;
+        Ok(true)
+    }
+
+    fn apply_edit_sandbox_rule(
+        &self,
+        manifest: &mut PolicyManifest,
+        sandbox_name: &str,
+        rule_index: usize,
+    ) -> Result<bool, String> {
+        let effect = match self.select_value(0) {
+            0 => RuleEffect::Allow,
+            _ => RuleEffect::Deny,
+        };
+        let caps = self.multi_select_caps(1);
+        let path = self.text_value(2);
+        if path.is_empty() {
+            return Err("Path is required".into());
+        }
+        let path_match = match self.select_value(3) {
+            0 => PathMatch::Subpath,
+            1 => PathMatch::Literal,
+            2 => PathMatch::Regex,
+            _ => PathMatch::Subpath,
+        };
+
+        let sb = manifest
+            .policy
+            .sandboxes
+            .get_mut(sandbox_name)
+            .ok_or_else(|| format!("Sandbox '{sandbox_name}' not found"))?;
+        let rule = sb
+            .rules
+            .get_mut(rule_index)
+            .ok_or_else(|| format!("Rule index {rule_index} out of range"))?;
+        rule.effect = effect;
+        rule.caps = caps;
+        rule.path = path;
+        rule.path_match = path_match;
+        Ok(true)
+    }
+
+    fn apply_add_child(
+        &self,
+        manifest: &mut PolicyManifest,
+        parent_path: &[usize],
+    ) -> Result<bool, String> {
+        let child_type = self.select_value(0);
+
+        let child = if child_type == 0 {
+            // Condition
+            let observable = self.build_observable(1, 2)?;
+            let pattern = self.build_pattern(3, 4)?;
+            Node::Condition {
+                observe: observable,
+                pattern,
+                children: vec![Node::Decision(Decision::Ask(None))],
+                doc: None,
+                source: None,
+            }
+        } else {
+            // Decision
+            let effect_idx = tool_registry::filtered_effect_to_canonical(
+                self.tool_context.as_deref(),
+                self.select_value(5),
+            );
+            let sandbox_ref = if effect_idx != 1 {
+                let sb_idx = self.select_value(6);
+                if sb_idx > 0 {
+                    Some(SandboxRef(self.select_option_str(6, sb_idx)))
+                } else {
+                    None
+                }
+            } else {
+                None
+            };
+            let decision = match effect_idx {
+                0 => Decision::Allow(sandbox_ref),
+                1 => Decision::Deny,
+                2 => Decision::Ask(sandbox_ref),
+                _ => Decision::Deny,
+            };
+            Node::Decision(decision)
+        };
+
+        let parent = Self::get_node_at_path_mut(&mut manifest.policy.tree, parent_path)
+            .ok_or_else(|| "Parent node not found".to_string())?;
+
+        match parent {
+            Node::Condition { children, .. } => {
+                children.push(child);
+                Ok(true)
+            }
+            _ => Err("Parent is not a condition node".into()),
+        }
+    }
+
+    /// Build an Observable from field indices for observable-type select and param text.
+    fn build_observable(
+        &self,
+        obs_field: usize,
+        param_field: usize,
+    ) -> Result<Observable, String> {
+        let obs_idx = self.select_value(obs_field);
+        let param = self.text_value(param_field);
+        index_to_observable(obs_idx, &param)
+    }
+
+    /// Build a Pattern from field indices for pattern-type select and value text.
+    fn build_pattern(&self, type_field: usize, value_field: usize) -> Result<Pattern, String> {
+        let pat_idx = self.select_value(type_field);
+        let value = self.text_value(value_field);
+        index_to_pattern(pat_idx, &value)
+    }
+
+    fn get_node_at_path_mut<'a>(tree: &'a mut [Node], path: &[usize]) -> Option<&'a mut Node> {
+        if path.is_empty() {
+            return None;
+        }
+        let mut current = tree.get_mut(path[0])?;
+        for &idx in &path[1..] {
+            match current {
+                Node::Condition { children, .. } => {
+                    current = children.get_mut(idx)?;
+                }
+                Node::Decision(_) => return None,
+            }
+        }
+        Some(current)
+    }
+
+    // --- Helpers to extract field values ---
+
+    fn text_value(&self, field_idx: usize) -> String {
+        match &self.fields[field_idx] {
+            FormField::Text { value, .. } => value.trim().to_string(),
+            _ => String::new(),
+        }
+    }
+
+    fn select_value(&self, field_idx: usize) -> usize {
+        match &self.fields[field_idx] {
+            FormField::Select { selected, .. } => *selected,
+            _ => 0,
+        }
+    }
+
+    fn select_option_str(&self, field_idx: usize, option_idx: usize) -> String {
+        match &self.fields[field_idx] {
+            FormField::Select { options, .. } => {
+                options.get(option_idx).cloned().unwrap_or_default()
+            }
+            _ => String::new(),
+        }
+    }
+
+    fn multi_select_caps(&self, field_idx: usize) -> Cap {
+        match &self.fields[field_idx] {
+            FormField::MultiSelect { toggled, .. } => {
+                let mut caps = Cap::empty();
+                let all = [Cap::READ, Cap::WRITE, Cap::CREATE, Cap::DELETE, Cap::EXECUTE];
+                for (i, &on) in toggled.iter().enumerate() {
+                    if on {
+                        if let Some(&cap) = all.get(i) {
+                            caps |= cap;
+                        }
+                    }
+                }
+                if caps.is_empty() {
+                    Cap::READ // fallback
+                } else {
+                    caps
+                }
+            }
+            _ => Cap::READ,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Rendering
+// ---------------------------------------------------------------------------
+
+impl FormState {
+    /// Return the contextual hint for the given raw field index.
+    fn field_hint(&self, field_idx: usize) -> Option<&'static str> {
+        self.fields[field_idx].hint()
+    }
+
+    pub fn view(&self, frame: &mut Frame, area: Rect) {
+        let height = (self.visible.len() as u16 * 3) + 6; // fields + hint + spacing + title + footer
+        let height_pct = ((height as f32 / area.height as f32) * 100.0)
+            .ceil()
+            .max(30.0)
+            .min(80.0) as u16;
+
+        let popup = centered_rect(60, height_pct, area);
+        frame.render_widget(Clear, popup);
+
+        let block = Block::default()
+            .borders(Borders::ALL)
+            .border_style(Style::default().fg(Color::Cyan))
+            .title(format!(" {} ", self.title));
+
+        let inner = block.inner(popup);
+        frame.render_widget(block, popup);
+
+        let mut lines: Vec<Line> = Vec::new();
+        lines.push(Line::from(""));
+
+        for (vi, &fi) in self.visible.iter().enumerate() {
+            let is_active = vi == self.active;
+            let field = &self.fields[fi];
+
+            match field {
+                FormField::Text {
+                    label,
+                    value,
+                    cursor,
+                    placeholder,
+                    ..
+                } => {
+                    let label_style = if is_active {
+                        Style::default()
+                            .fg(Color::White)
+                            .add_modifier(Modifier::BOLD)
+                    } else {
+                        Style::default().fg(Color::Gray)
+                    };
+
+                    let display_value = if value.is_empty() && !is_active {
+                        placeholder.as_str()
+                    } else if value.is_empty() {
+                        ""
+                    } else {
+                        value.as_str()
+                    };
+
+                    let value_style = if value.is_empty() && !is_active {
+                        Style::default().fg(Color::DarkGray)
+                    } else if is_active {
+                        Style::default().fg(Color::White)
+                    } else {
+                        Style::default().fg(Color::Cyan)
+                    };
+
+                    if is_active && !value.is_empty() {
+                        // Render with cursor
+                        let before = &value[..*cursor];
+                        let cursor_char = value.chars().nth(*cursor).unwrap_or(' ');
+                        let after = if *cursor < value.len() {
+                            &value[*cursor + cursor_char.len_utf8()..]
+                        } else {
+                            ""
+                        };
+                        lines.push(Line::from(vec![
+                            Span::styled(format!("  {label}: "), label_style),
+                            Span::styled(before, value_style),
+                            Span::styled(
+                                cursor_char.to_string(),
+                                Style::default()
+                                    .fg(Color::Black)
+                                    .bg(Color::White),
+                            ),
+                            Span::styled(after, value_style),
+                        ]));
+                    } else if is_active && value.is_empty() {
+                        lines.push(Line::from(vec![
+                            Span::styled(format!("  {label}: "), label_style),
+                            Span::styled(
+                                " ",
+                                Style::default().fg(Color::Black).bg(Color::White),
+                            ),
+                        ]));
+                    } else {
+                        lines.push(Line::from(vec![
+                            Span::styled(format!("  {label}: "), label_style),
+                            Span::styled(display_value, value_style),
+                        ]));
+                    }
+                }
+                FormField::Select {
+                    label,
+                    options,
+                    selected,
+                    ..
+                } => {
+                    let label_style = if is_active {
+                        Style::default()
+                            .fg(Color::White)
+                            .add_modifier(Modifier::BOLD)
+                    } else {
+                        Style::default().fg(Color::Gray)
+                    };
+                    let option = &options[*selected];
+                    let arrows = if is_active { ("< ", " >") } else { ("  ", "  ") };
+                    let value_style = if is_active {
+                        Style::default()
+                            .fg(Color::Cyan)
+                            .add_modifier(Modifier::BOLD)
+                    } else {
+                        Style::default().fg(Color::Cyan)
+                    };
+
+                    lines.push(Line::from(vec![
+                        Span::styled(format!("  {label}: "), label_style),
+                        Span::styled(
+                            arrows.0,
+                            Style::default().fg(if is_active {
+                                Color::Yellow
+                            } else {
+                                Color::DarkGray
+                            }),
+                        ),
+                        Span::styled(option.as_str(), value_style),
+                        Span::styled(
+                            arrows.1,
+                            Style::default().fg(if is_active {
+                                Color::Yellow
+                            } else {
+                                Color::DarkGray
+                            }),
+                        ),
+                    ]));
+                }
+                FormField::MultiSelect {
+                    label,
+                    options,
+                    toggled,
+                    cursor,
+                    ..
+                } => {
+                    let label_style = if is_active {
+                        Style::default()
+                            .fg(Color::White)
+                            .add_modifier(Modifier::BOLD)
+                    } else {
+                        Style::default().fg(Color::Gray)
+                    };
+
+                    let mut spans = vec![Span::styled(format!("  {label}: "), label_style)];
+
+                    for (i, opt) in options.iter().enumerate() {
+                        let checked = if toggled[i] { "[x]" } else { "[ ]" };
+                        let is_cursor = is_active && i == *cursor;
+                        let style = if is_cursor {
+                            Style::default()
+                                .fg(Color::White)
+                                .bg(Color::DarkGray)
+                                .add_modifier(Modifier::BOLD)
+                        } else if toggled[i] {
+                            Style::default().fg(Color::Green)
+                        } else {
+                            Style::default().fg(Color::DarkGray)
+                        };
+                        spans.push(Span::styled(format!("{checked} {opt}"), style));
+                        if i + 1 < options.len() {
+                            spans.push(Span::raw("  "));
+                        }
+                    }
+
+                    lines.push(Line::from(spans));
+                }
+            }
+
+            // Context hint for active field
+            if is_active {
+                if let Some(hint) = self.field_hint(fi) {
+                    lines.push(Line::from(Span::styled(
+                        format!("    {hint}"),
+                        Style::default().fg(Color::DarkGray),
+                    )));
+                }
+            }
+
+            // Spacing between fields
+            lines.push(Line::from(""));
+        }
+
+        // Footer
+        lines.push(Line::from(vec![
+            Span::styled("  Enter", Style::default().fg(Color::Yellow)),
+            Span::styled(" submit  ", Style::default().fg(Color::Gray)),
+            Span::styled("Tab", Style::default().fg(Color::Yellow)),
+            Span::styled(" next field  ", Style::default().fg(Color::Gray)),
+            Span::styled("Esc", Style::default().fg(Color::Yellow)),
+            Span::styled(" cancel", Style::default().fg(Color::Gray)),
+        ]));
+
+        let para = Paragraph::new(lines);
+        frame.render_widget(para, inner);
+    }
+}
+
+fn centered_rect(percent_x: u16, percent_y: u16, area: Rect) -> Rect {
+    let vertical = Layout::vertical([
+        Constraint::Percentage((100 - percent_y) / 2),
+        Constraint::Percentage(percent_y),
+        Constraint::Percentage((100 - percent_y) / 2),
+    ])
+    .split(area);
+
+    Layout::horizontal([
+        Constraint::Percentage((100 - percent_x) / 2),
+        Constraint::Percentage(percent_x),
+        Constraint::Percentage((100 - percent_x) / 2),
+    ])
+    .split(vertical[1])[1]
+}
+
+// ---------------------------------------------------------------------------
+// Observable / Pattern helpers
+// ---------------------------------------------------------------------------
+
+/// Short human description of a pattern value, for use in titles.
+fn short_pattern_desc(pat: &Pattern) -> String {
+    match pat {
+        Pattern::Wildcard => "*".into(),
+        Pattern::Literal(v) => {
+            let s = v.resolve();
+            if s.len() > 30 {
+                format!("\"{}...\"", &s[..27])
+            } else {
+                format!("\"{s}\"")
+            }
+        }
+        Pattern::Regex(re) => format!("/{}/", re.as_str()),
+        Pattern::Prefix(v) => format!("{}/**", v.resolve()),
+        Pattern::AnyOf(pats) => format!("[{} values]", pats.len()),
+        Pattern::Not(inner) => format!("not {}", short_pattern_desc(inner)),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Observable registry — single source of truth for UI ↔ enum mapping
+// ---------------------------------------------------------------------------
+
+/// Declares an ordered registry of Observable variants with their UI metadata.
+/// Generates: observable_options(), observable_to_index(), index_to_observable(),
+/// observable_needs_param(), observable_hint(), observable_param_hint(),
+/// observable_param_placeholder(), pattern_value_placeholder().
+///
+/// Simple variants use `param: none`. Parameterized variants specify hint,
+/// placeholder, and a parse block that receives `_param: &str` and returns
+/// `Result<Observable, String>`.
+macro_rules! observable_registry {
+    // Entry: split into simple (param: none) and parameterized variants.
+    (
+        $( $variant:ident {
+            label: $label:expr,
+            hint: $hint:expr,
+            value_placeholder: $val_ph:expr,
+            param_hint: $ph:expr,
+            param_placeholder: $pp:expr,
+            parse($param_name:ident): $parse:expr,
+        } ),* $(,)?
+    ) => {
+        fn observable_options() -> Vec<String> {
+            vec![ $( $label.into() ),* ]
+        }
+
+        /// Per-option hint strings, parallel to `observable_options()`.
+        fn observable_option_hints() -> Vec<&'static str> {
+            vec![ $( $hint ),* ]
+        }
+
+        fn observable_to_index(obs: &Observable) -> usize {
+            let mut _i = 0usize;
+            $(
+                if observable_registry!(@matches obs, $variant) { return _i; }
+                _i += 1;
+            )*
+            unreachable!("all Observable variants covered")
+        }
+
+        fn observable_hint(idx: usize) -> &'static str {
+            const HINTS: &[&str] = &[ $( $hint ),* ];
+            HINTS.get(idx).copied().unwrap_or("")
+        }
+
+        fn observable_needs_param(idx: usize) -> bool {
+            const FLAGS: &[bool] = &[ $( !$ph.is_empty() ),* ];
+            FLAGS.get(idx).copied().unwrap_or(false)
+        }
+
+        fn observable_param_hint(idx: usize) -> &'static str {
+            const HINTS: &[&str] = &[ $( $ph ),* ];
+            HINTS.get(idx).copied().unwrap_or("")
+        }
+
+        fn observable_param_placeholder(idx: usize) -> &'static str {
+            const PHS: &[&str] = &[ $( $pp ),* ];
+            PHS.get(idx).copied().unwrap_or("")
+        }
+
+        fn pattern_value_placeholder(idx: usize) -> &'static str {
+            const PHS: &[&str] = &[ $( $val_ph ),* ];
+            PHS.get(idx).copied().unwrap_or("the value to match")
+        }
+
+        #[allow(unused_variables)]
+        fn index_to_observable(idx: usize, _param: &str) -> Result<Observable, String> {
+            let mut _i = 0usize;
+            $(
+                if idx == _i {
+                    let $param_name: &str = _param;
+                    return $parse;
+                }
+                _i += 1;
+            )*
+            Err("Unknown observable type".into())
+        }
+    };
+
+    // --- internal helpers ---
+
+    (@matches $obs:expr, ToolName) => { matches!($obs, Observable::ToolName) };
+    (@matches $obs:expr, HookType) => { matches!($obs, Observable::HookType) };
+    (@matches $obs:expr, AgentName) => { matches!($obs, Observable::AgentName) };
+    (@matches $obs:expr, PositionalArg) => { matches!($obs, Observable::PositionalArg(_)) };
+    (@matches $obs:expr, HasArg) => { matches!($obs, Observable::HasArg) };
+    (@matches $obs:expr, NamedArg) => { matches!($obs, Observable::NamedArg(_)) };
+    (@matches $obs:expr, NestedField) => { matches!($obs, Observable::NestedField(_)) };
+    (@matches $obs:expr, FsOp) => { matches!($obs, Observable::FsOp) };
+    (@matches $obs:expr, FsPath) => { matches!($obs, Observable::FsPath) };
+    (@matches $obs:expr, NetDomain) => { matches!($obs, Observable::NetDomain) };
+
+}
+
+observable_registry! {
+    ToolName {
+        label: "Tool Name",
+        hint: "Match by tool name: Read, Write, Bash, Edit, Glob, Grep, etc.",
+        value_placeholder: "e.g. Read, Write, Bash, Edit",
+        param_hint: "",
+        param_placeholder: "",
+        parse(s): Ok(Observable::ToolName),
+    },
+    HookType {
+        label: "Hook Type",
+        hint: "Match by hook type: PreToolUse, PostToolUse, etc.",
+        value_placeholder: "e.g. PreToolUse, PostToolUse",
+        param_hint: "",
+        param_placeholder: "",
+        parse(s): Ok(Observable::HookType),
+    },
+    AgentName {
+        label: "Agent Name",
+        hint: "Match by the name of the agent making the request",
+        value_placeholder: "e.g. my-agent",
+        param_hint: "",
+        param_placeholder: "",
+        parse(s): Ok(Observable::AgentName),
+    },
+    PositionalArg {
+        label: "Positional Arg",
+        hint: "Match a positional argument (e.g. arg[0] is the command in Bash)",
+        value_placeholder: "e.g. git, npm, gh",
+        param_hint: "Argument index (0 = command, 1 = first arg, etc.)",
+        param_placeholder: "e.g. 0 (command), 1 (first arg), 2 ...",
+        parse(s): {
+            let n: i32 = s.parse().map_err(|_| "Invalid arg index".to_string())?;
+            Ok(Observable::PositionalArg(n))
+        },
+    },
+    HasArg {
+        label: "Has Arg",
+        hint: "Match if any argument contains the pattern value",
+        value_placeholder: "the value to match",
+        param_hint: "",
+        param_placeholder: "",
+        parse(s): Ok(Observable::HasArg),
+    },
+    NamedArg {
+        label: "Named Arg",
+        hint: "Match a specific named argument by key",
+        value_placeholder: "the value to match",
+        param_hint: "The argument key name to match against",
+        param_placeholder: "e.g. file_path, content",
+        parse(s): {
+            if s.is_empty() {
+                return Err("Named arg requires a name".into());
+            }
+            Ok(Observable::NamedArg(s.to_string()))
+        },
+    },
+    NestedField {
+        label: "Nested Field",
+        hint: "Match a nested field in the tool's JSON input",
+        value_placeholder: "the value to match",
+        param_hint: "Dot-separated path into JSON, e.g. content.text",
+        param_placeholder: "e.g. content.text, options.mode",
+        parse(s): {
+            if s.is_empty() {
+                return Err("Nested field requires a path".into());
+            }
+            let parts: Vec<String> = s.split('.').map(|p| p.to_string()).collect();
+            Ok(Observable::NestedField(parts))
+        },
+    },
+    FsOp {
+        label: "FS Operation",
+        hint: "Match the filesystem operation type: read or write",
+        value_placeholder: "e.g. read, write",
+        param_hint: "",
+        param_placeholder: "",
+        parse(s): Ok(Observable::FsOp),
+    },
+    FsPath {
+        label: "FS Path",
+        hint: "Match the filesystem path being accessed",
+        value_placeholder: "e.g. /home/user/project, $PWD",
+        param_hint: "",
+        param_placeholder: "",
+        parse(s): Ok(Observable::FsPath),
+    },
+    NetDomain {
+        label: "Net Domain",
+        hint: "Match the network domain being accessed",
+        value_placeholder: "e.g. github.com, api.example.com",
+        param_hint: "",
+        param_placeholder: "",
+        parse(s): Ok(Observable::NetDomain),
+    },
+}
+
+/// Short human description of an observable, for use in form titles.
+/// This is outside the macro because it operates on `&Observable` (compiler-checked
+/// exhaustive match) rather than on indices, so it doesn't have the fragility problem.
+fn observable_short_desc(obs: &Observable) -> String {
+    match obs {
+        Observable::ToolName => "tool".into(),
+        Observable::HookType => "hook".into(),
+        Observable::AgentName => "agent".into(),
+        Observable::PositionalArg(n) => format!("arg[{n}]"),
+        Observable::HasArg => "any arg".into(),
+        Observable::NamedArg(name) => format!("arg \"{name}\""),
+        Observable::NestedField(parts) => format!("field {}", parts.join(".")),
+        Observable::FsOp => "fs operation".into(),
+        Observable::FsPath => "fs path".into(),
+        Observable::NetDomain => "network domain".into(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Pattern registry — single source of truth for UI ↔ enum mapping
+// ---------------------------------------------------------------------------
+
+macro_rules! pattern_registry {
+    (
+        $( $name:ident {
+            label: $label:expr,
+            hint: $hint:expr,
+            value_hint: $val_hint:expr,
+            parse($param_name:ident): $parse:expr,
+        } ),* $(,)?
+    ) => {
+        #[allow(dead_code)]
+        fn pattern_options() -> Vec<String> {
+            vec![ $( $label.into() ),* ]
+        }
+
+        /// Per-option hint strings, parallel to `pattern_options()`.
+        #[allow(dead_code)]
+        fn pattern_option_hints() -> Vec<&'static str> {
+            vec![ $( $hint ),* ]
+        }
+
+        fn pattern_hint(idx: usize) -> &'static str {
+            const HINTS: &[&str] = &[ $( $hint ),* ];
+            HINTS.get(idx).copied().unwrap_or("")
+        }
+
+        fn pattern_value_hint(idx: usize) -> &'static str {
+            const HINTS: &[&str] = &[ $( $val_hint ),* ];
+            HINTS.get(idx).copied().unwrap_or("")
+        }
+
+        fn index_to_pattern(idx: usize, _value: &str) -> Result<Pattern, String> {
+            let mut _i = 0usize;
+            $(
+                if idx == _i {
+                    let $param_name: &str = _value;
+                    return $parse;
+                }
+                _i += 1;
+            )*
+            Err("Unknown pattern type".into())
+        }
+    };
+}
+
+pattern_registry! {
+    Literal {
+        label: "exact value",
+        hint: "literal: match an exact string value",
+        value_hint: "The exact string to match",
+        parse(v): {
+            if v.is_empty() { return Err("Literal pattern requires a value".into()); }
+            Ok(Pattern::Literal(Value::Literal(v.to_string())))
+        },
+    },
+    Wildcard {
+        label: "anything",
+        hint: "wildcard: match anything (no value needed)",
+        value_hint: "",
+        parse(_v): Ok(Pattern::Wildcard),
+    },
+    Regex {
+        label: "regex",
+        hint: "regex: match against a regular expression",
+        value_hint: "A regex, e.g. ^git.* or deploy|release",
+        parse(v): {
+            if v.is_empty() { return Err("Regex pattern requires a value".into()); }
+            let re = regex::Regex::new(v).map_err(|e| format!("Invalid regex: {e}"))?;
+            Ok(Pattern::Regex(std::sync::Arc::new(re)))
+        },
+    },
+    Prefix {
+        label: "path prefix",
+        hint: "prefix: match a path and all its children",
+        value_hint: "A path prefix, e.g. /home/user or $PWD",
+        parse(v): {
+            if v.is_empty() { return Err("Prefix pattern requires a value".into()); }
+            Ok(Pattern::Prefix(Value::Literal(v.to_string())))
+        },
+    },
+}
+
+fn pattern_to_value_string(pat: &Pattern) -> String {
+    match pat {
+        Pattern::Wildcard => String::new(),
+        Pattern::Literal(v) => v.resolve(),
+        Pattern::Regex(re) => re.as_str().to_string(),
+        Pattern::Prefix(v) => v.resolve(),
+        Pattern::AnyOf(pats) => pats
+            .iter()
+            .map(pattern_to_value_string)
+            .collect::<Vec<_>>()
+            .join(", "),
+        Pattern::Not(inner) => format!("!{}", pattern_to_value_string(inner)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::policy::match_tree::*;
+    use crossterm::event::{KeyEvent, KeyModifiers};
+    use std::collections::HashMap;
+
+    fn empty_manifest() -> PolicyManifest {
+        PolicyManifest {
+            includes: vec![],
+            policy: CompiledPolicy {
+                sandboxes: HashMap::new(),
+                tree: vec![],
+                default_effect: crate::policy::Effect::Deny,
+                default_sandbox: None,
+            },
+        }
+    }
+
+    fn key(code: KeyCode) -> KeyEvent {
+        KeyEvent::new(code, KeyModifiers::empty())
+    }
+
+    #[test]
+    fn test_add_include_form() {
+        let manifest = empty_manifest();
+        let mut form = FormState::from_request(&FormRequest::AddInclude, &manifest, None);
+
+        // Type "test.star"
+        for c in "test.star".chars() {
+            form.handle_key(key(KeyCode::Char(c)));
+        }
+
+        // Submit
+        let result = form.handle_key(key(KeyCode::Enter));
+        assert!(matches!(result, FormEvent::Submit));
+
+        let mut manifest = empty_manifest();
+        assert!(form.apply(&mut manifest).is_ok());
+        assert_eq!(manifest.includes.len(), 1);
+        assert_eq!(manifest.includes[0].path, "test.star");
+    }
+
+    #[test]
+    fn test_add_tool_rule_form() {
+        let manifest = empty_manifest();
+        let mut form = FormState::from_request(&FormRequest::AddRule, &manifest, None);
+
+        // Field 0 is rule type select, default is "Tool rule" — press Enter to advance
+        form.handle_key(key(KeyCode::Enter));
+
+        // Field 1 is tool name text — type "Read"
+        for c in "Read".chars() {
+            form.handle_key(key(KeyCode::Char(c)));
+        }
+        form.handle_key(key(KeyCode::Enter));
+
+        // Field 4 is effect select — default "allow", press Enter to advance
+        // This should be the last visible field (no sandboxes defined) — submit
+        let result = form.handle_key(key(KeyCode::Enter));
+        assert!(matches!(result, FormEvent::Submit));
+
+        let mut manifest = empty_manifest();
+        assert!(form.apply(&mut manifest).is_ok());
+        assert!(!manifest.policy.tree.is_empty());
+    }
+
+    #[test]
+    fn test_cancel_form() {
+        let manifest = empty_manifest();
+        let mut form = FormState::from_request(&FormRequest::AddInclude, &manifest, None);
+
+        let result = form.handle_key(key(KeyCode::Esc));
+        assert!(matches!(result, FormEvent::Cancel));
+    }
+
+    #[test]
+    fn test_text_field_editing() {
+        let manifest = empty_manifest();
+        let mut form = FormState::from_request(&FormRequest::AddInclude, &manifest, None);
+
+        // Type "hello"
+        for c in "hello".chars() {
+            form.handle_key(key(KeyCode::Char(c)));
+        }
+        assert_eq!(form.text_value(0), "hello");
+
+        // Backspace
+        form.handle_key(key(KeyCode::Backspace));
+        assert_eq!(form.text_value(0), "hell");
+
+        // Left then insert
+        form.handle_key(key(KeyCode::Left));
+        form.handle_key(key(KeyCode::Char('X')));
+        assert_eq!(form.text_value(0), "helXl");
+    }
+
+    #[test]
+    fn test_empty_text_rejected() {
+        let manifest = empty_manifest();
+        let form = FormState::from_request(&FormRequest::AddInclude, &manifest, None);
+
+        let mut manifest = empty_manifest();
+        let result = form.apply(&mut manifest);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_edit_condition_form() {
+        use crate::policy::manifest_edit;
+
+        let mut manifest = empty_manifest();
+        manifest_edit::upsert_rule(
+            &mut manifest,
+            manifest_edit::build_tool_rule("Read", Decision::Allow(None)),
+        );
+
+        // Create edit form for the root condition
+        let mut form = FormState::from_request(
+            &FormRequest::EditCondition { path: vec![0] },
+            &manifest,
+            None,
+        );
+
+        // Observable should be pre-filled as tool_name (index 0)
+        assert_eq!(form.select_value(0), 0);
+        // Pattern value should be pre-filled as "Read"
+        assert_eq!(form.text_value(3), "Read");
+
+        // Change pattern value to "Write"
+        // Navigate to value field (field index 3)
+        // Use Enter to advance past Select fields (Tab now cycles options)
+        form.handle_key(key(KeyCode::Enter)); // -> pattern type
+        form.handle_key(key(KeyCode::Enter)); // -> value
+
+        // Clear existing text and type new value
+        // Select all and delete by using Home then deleting forward
+        form.handle_key(key(KeyCode::Home));
+        for _ in 0..10 {
+            form.handle_key(key(KeyCode::Delete));
+        }
+        for c in "Write".chars() {
+            form.handle_key(key(KeyCode::Char(c)));
+        }
+
+        let result = form.handle_key(key(KeyCode::Enter));
+        assert!(matches!(result, FormEvent::Submit));
+
+        assert!(form.apply(&mut manifest).is_ok());
+        // Verify the condition was updated
+        match &manifest.policy.tree[0] {
+            Node::Condition { pattern, .. } => match pattern {
+                Pattern::Literal(v) => assert_eq!(v.resolve(), "Write"),
+                _ => panic!("Expected literal pattern"),
+            },
+            _ => panic!("Expected condition node"),
+        }
+    }
+
+    #[test]
+    fn test_add_child_decision_form() {
+        use crate::policy::manifest_edit;
+
+        let mut manifest = empty_manifest();
+        // Create a condition with multiple children so it's expandable
+        manifest_edit::upsert_rule(
+            &mut manifest,
+            manifest_edit::build_exec_rule("gh", &["pr"], Decision::Allow(None)),
+        );
+
+        // Add a decision child under root (Bash condition)
+        let mut form = FormState::from_request(
+            &FormRequest::AddChild {
+                parent_path: vec![0],
+            },
+            &manifest,
+            None,
+        );
+
+        // Switch to Decision type
+        form.handle_key(key(KeyCode::Right)); // type: Condition -> Decision
+
+        // Effect should now be visible, default "allow"
+        // Navigate to effect and change to "deny"
+        form.handle_key(key(KeyCode::Enter)); // -> effect
+        form.handle_key(key(KeyCode::Right)); // allow -> deny
+
+        let result = form.handle_key(key(KeyCode::Enter));
+        assert!(matches!(result, FormEvent::Submit));
+
+        assert!(form.apply(&mut manifest).is_ok());
+        // Root condition should now have an extra child
+        match &manifest.policy.tree[0] {
+            Node::Condition { children, .. } => {
+                let has_deny = children
+                    .iter()
+                    .any(|c| matches!(c, Node::Decision(Decision::Deny)));
+                assert!(has_deny, "Should have a Deny decision child");
+            }
+            _ => panic!("Expected condition node"),
+        }
+    }
+
+    #[test]
+    fn test_add_sandbox_form() {
+        let manifest = empty_manifest();
+        let mut form = FormState::from_request(&FormRequest::AddSandbox, &manifest, None);
+
+        // Field 0: name text — type "dev"
+        for c in "dev".chars() {
+            form.handle_key(key(KeyCode::Char(c)));
+        }
+        form.handle_key(key(KeyCode::Tab));
+
+        // Field 1: multi-select caps — defaults are read + execute, skip
+        form.handle_key(key(KeyCode::Enter));
+
+        // Field 2: network select — default "deny", submit
+        let result = form.handle_key(key(KeyCode::Enter));
+        assert!(matches!(result, FormEvent::Submit));
+
+        let mut manifest = empty_manifest();
+        assert!(form.apply(&mut manifest).is_ok());
+        assert!(manifest.policy.sandboxes.contains_key("dev"));
+        let sb = &manifest.policy.sandboxes["dev"];
+        assert_eq!(sb.default, Cap::READ | Cap::EXECUTE);
+        assert_eq!(sb.network, NetworkPolicy::Deny);
+    }
+
+    #[test]
+    fn test_bash_tool_hides_ask_effect() {
+        let manifest = empty_manifest();
+        let mut form = FormState::from_request(&FormRequest::AddRule, &manifest, None);
+
+        // Type "Bash" into tool name field (field 1)
+        // First, advance to field 1 (it's a Text field, Tab advances)
+        form.handle_key(key(KeyCode::Enter)); // past rule type select -> tool name
+        for c in "Bash".chars() {
+            form.handle_key(key(KeyCode::Char(c)));
+        }
+
+        // Effect field (field 4) should now only have 2 options
+        match &form.fields[4] {
+            FormField::Select { options, .. } => {
+                assert_eq!(options.len(), 2, "Bash should only have allow/deny");
+                assert!(options[0].contains("allow"));
+                assert!(options[1].contains("deny"));
+            }
+            _ => panic!("Expected Select field"),
+        }
+    }
+
+    #[test]
+    fn test_non_bash_tool_has_ask_effect() {
+        let manifest = empty_manifest();
+        let mut form = FormState::from_request(&FormRequest::AddRule, &manifest, None);
+
+        // Type "Read" into tool name field
+        form.handle_key(key(KeyCode::Enter));
+        for c in "Read".chars() {
+            form.handle_key(key(KeyCode::Char(c)));
+        }
+
+        // Effect field should have all 3 options
+        match &form.fields[4] {
+            FormField::Select { options, .. } => {
+                assert_eq!(options.len(), 3, "Read should have allow/deny/ask");
+            }
+            _ => panic!("Expected Select field"),
+        }
+    }
+
+    #[test]
+    fn test_bash_add_rule_applies_deny() {
+        let manifest = empty_manifest();
+        let mut form = FormState::from_request(&FormRequest::AddRule, &manifest, None);
+
+        // Type "Bash" tool name
+        form.handle_key(key(KeyCode::Enter));
+        for c in "Bash".chars() {
+            form.handle_key(key(KeyCode::Char(c)));
+        }
+
+        // Advance to effect, select deny (index 1 in filtered = canonical 1)
+        form.handle_key(key(KeyCode::Enter)); // -> effect
+        form.handle_key(key(KeyCode::Right)); // allow -> deny
+
+        // Submit
+        let result = form.handle_key(key(KeyCode::Enter));
+        assert!(matches!(result, FormEvent::Submit));
+
+        let mut manifest = empty_manifest();
+        assert!(form.apply(&mut manifest).is_ok());
+
+        // Should have a Bash deny rule
+        assert!(!manifest.policy.tree.is_empty());
+    }
+
+    #[test]
+    fn test_edit_decision_under_bash_hides_ask() {
+        use crate::policy::manifest_edit;
+
+        let mut manifest = empty_manifest();
+        manifest_edit::upsert_rule(
+            &mut manifest,
+            manifest_edit::build_tool_rule("Bash", Decision::Allow(None)),
+        );
+
+        // The tool rule creates Condition(tool_name=Bash) -> Decision(Allow)
+        // Edit the decision at path [0, 0] (child of root condition)
+        let form = FormState::from_request(
+            &FormRequest::EditDecision { path: vec![0, 0] },
+            &manifest,
+            None,
+        );
+
+        assert_eq!(form.tool_context.as_deref(), Some("Bash"));
+        match &form.fields[0] {
+            FormField::Select { options, .. } => {
+                assert_eq!(options.len(), 2, "Under Bash, only allow/deny");
+            }
+            _ => panic!("Expected Select field"),
+        }
+    }
+
+    #[test]
+    fn test_edit_sandbox_prefills_and_applies() {
+        let mut manifest = empty_manifest();
+        sandbox_edit::create_sandbox(
+            &mut manifest,
+            "dev",
+            Cap::READ | Cap::WRITE,
+            NetworkPolicy::Localhost,
+            None,
+        )
+        .unwrap();
+
+        let form = FormState::from_request(
+            &FormRequest::EditSandbox {
+                sandbox_name: "dev".into(),
+            },
+            &manifest,
+            None,
+        );
+
+        // Check prefilled caps: read=true, write=true, rest=false
+        match &form.fields[0] {
+            FormField::MultiSelect { toggled, .. } => {
+                assert_eq!(toggled, &[true, true, false, false, false]);
+            }
+            _ => panic!("Expected MultiSelect"),
+        }
+        // Check prefilled network: localhost = index 2
+        match &form.fields[1] {
+            FormField::Select { selected, .. } => {
+                assert_eq!(*selected, 2);
+            }
+            _ => panic!("Expected Select"),
+        }
+
+        // Apply should update the sandbox
+        form.apply(&mut manifest).unwrap();
+        let sb = &manifest.policy.sandboxes["dev"];
+        assert_eq!(sb.default, Cap::READ | Cap::WRITE);
+        assert_eq!(sb.network, NetworkPolicy::Localhost);
+    }
+
+    #[test]
+    fn test_edit_sandbox_rule_prefills_and_applies() {
+        let mut manifest = empty_manifest();
+        sandbox_edit::create_sandbox(
+            &mut manifest,
+            "dev",
+            Cap::READ,
+            NetworkPolicy::Deny,
+            None,
+        )
+        .unwrap();
+        sandbox_edit::add_rule(
+            &mut manifest,
+            "dev",
+            RuleEffect::Deny,
+            Cap::WRITE | Cap::DELETE,
+            "/tmp".into(),
+            PathMatch::Literal,
+            None,
+        )
+        .unwrap();
+
+        let form = FormState::from_request(
+            &FormRequest::EditSandboxRule {
+                sandbox_name: "dev".into(),
+                rule_index: 0,
+            },
+            &manifest,
+            None,
+        );
+
+        // Effect: deny = index 1
+        assert_eq!(form.select_value(0), 1);
+        // Caps: write + delete
+        match &form.fields[1] {
+            FormField::MultiSelect { toggled, .. } => {
+                assert_eq!(toggled, &[false, true, false, true, false]);
+            }
+            _ => panic!("Expected MultiSelect"),
+        }
+        // Path prefilled
+        match &form.fields[2] {
+            FormField::Text { value, .. } => assert_eq!(value, "/tmp"),
+            _ => panic!("Expected Text"),
+        }
+        // Path match: literal = index 1
+        assert_eq!(form.select_value(3), 1);
+
+        // Apply should update the rule
+        form.apply(&mut manifest).unwrap();
+        let rule = &manifest.policy.sandboxes["dev"].rules[0];
+        assert_eq!(rule.effect, RuleEffect::Deny);
+        assert_eq!(rule.caps, Cap::WRITE | Cap::DELETE);
+        assert_eq!(rule.path, "/tmp");
+        assert_eq!(rule.path_match, PathMatch::Literal);
+    }
+}

--- a/clash/src/tui/mod.rs
+++ b/clash/src/tui/mod.rs
@@ -1,0 +1,56 @@
+//! Interactive policy editor TUI.
+//!
+//! Launches a ratatui-based terminal UI for browsing and editing policy.json.
+//! Uses the Elm Architecture (TEA) pattern: `Model -> update(Msg) -> view(Model)`.
+
+pub mod app;
+pub mod includes_view;
+pub mod inline_form;
+pub mod sandbox_view;
+pub mod settings_view;
+pub mod tea;
+pub mod tool_registry;
+pub mod tree_view;
+pub mod widgets;
+
+use std::path::Path;
+
+use anyhow::{Context, Result};
+use crossterm::event::{DisableMouseCapture, EnableMouseCapture};
+use crossterm::execute;
+use crossterm::terminal::{
+    EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode,
+};
+use ratatui::Terminal;
+use ratatui::backend::CrosstermBackend;
+
+use crate::policy_loader;
+
+/// Launch the interactive policy editor TUI.
+pub fn run(path: &Path) -> Result<()> {
+    let manifest = policy_loader::read_manifest(path)
+        .with_context(|| format!("failed to read {}", path.display()))?;
+
+    let mut app = app::App::new(path.to_path_buf(), manifest)?;
+
+    // Setup terminal
+    enable_raw_mode()?;
+    let mut stdout = std::io::stdout();
+    execute!(stdout, EnterAlternateScreen, EnableMouseCapture)?;
+    let backend = CrosstermBackend::new(stdout);
+    let mut terminal = Terminal::new(backend)?;
+
+    // Run the app (errors will be handled after cleanup)
+    let result = app.run(&mut terminal);
+
+    // Restore terminal
+    disable_raw_mode()?;
+    execute!(
+        terminal.backend_mut(),
+        LeaveAlternateScreen,
+        DisableMouseCapture
+    )?;
+    terminal.show_cursor()?;
+
+    result
+}

--- a/clash/src/tui/sandbox_view.rs
+++ b/clash/src/tui/sandbox_view.rs
@@ -1,0 +1,604 @@
+//! Sandbox view component for browsing and editing sandbox definitions.
+
+use crossterm::event::{KeyCode, KeyEvent};
+use ratatui::Frame;
+use ratatui::layout::{Constraint, Layout, Rect};
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, Paragraph};
+
+use super::tea::{Action, Component, FormRequest};
+use crate::policy::match_tree::{CompiledPolicy, PolicyManifest};
+use crate::policy::sandbox_types::{RuleEffect, SandboxPolicy};
+
+pub struct SandboxView {
+    sandbox_names: Vec<String>,
+    /// Names of sandboxes from includes — these are read-only.
+    included_names: HashSet<String>,
+    /// Merged sandbox policies (inline + included) for display.
+    all_sandboxes: std::collections::HashMap<String, SandboxPolicy>,
+    selected_sandbox: usize,
+    selected_rule: usize,
+    focus: Focus,
+}
+
+use std::collections::HashSet;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Focus {
+    SandboxList,
+    RuleList,
+}
+
+#[derive(Debug)]
+pub enum Msg {
+    MoveUp,
+    MoveDown,
+    JumpTop,
+    JumpBottom,
+    FocusRules,
+    FocusSandboxes,
+    AddSandbox,
+    AddRule,
+    Edit,
+    Delete,
+    CopyToInline,
+}
+
+impl SandboxView {
+    pub fn new(manifest: &PolicyManifest, included: &CompiledPolicy) -> Self {
+        let mut view = SandboxView {
+            sandbox_names: Vec::new(),
+            included_names: HashSet::new(),
+            all_sandboxes: std::collections::HashMap::new(),
+            selected_sandbox: 0,
+            selected_rule: 0,
+            focus: Focus::SandboxList,
+        };
+        view.rebuild_with_included(manifest, included);
+        view
+    }
+
+    pub fn rebuild(&mut self, manifest: &PolicyManifest) {
+        self.rebuild_with_included(
+            manifest,
+            &CompiledPolicy {
+                sandboxes: std::collections::HashMap::new(),
+                tree: vec![],
+                default_effect: manifest.policy.default_effect.clone(),
+                default_sandbox: None,
+            },
+        );
+    }
+
+    pub fn rebuild_with_included(&mut self, manifest: &PolicyManifest, included: &CompiledPolicy) {
+        let old_name = self.sandbox_names.get(self.selected_sandbox).cloned();
+
+        // Merge inline + included sandboxes (inline wins on conflict)
+        self.all_sandboxes = manifest.policy.sandboxes.clone();
+        self.included_names.clear();
+        for (k, v) in &included.sandboxes {
+            if !manifest.policy.sandboxes.contains_key(k) {
+                self.all_sandboxes.insert(k.clone(), v.clone());
+                self.included_names.insert(k.clone());
+            }
+        }
+
+        self.sandbox_names = self.all_sandboxes.keys().cloned().collect();
+        self.sandbox_names.sort();
+
+        // Try to keep the same sandbox selected
+        if let Some(name) = old_name {
+            if let Some(pos) = self.sandbox_names.iter().position(|n| *n == name) {
+                self.selected_sandbox = pos;
+            } else if self.selected_sandbox >= self.sandbox_names.len()
+                && !self.sandbox_names.is_empty()
+            {
+                self.selected_sandbox = self.sandbox_names.len() - 1;
+            }
+        }
+    }
+
+    fn is_selected_read_only(&self) -> bool {
+        self.sandbox_names
+            .get(self.selected_sandbox)
+            .is_some_and(|name| self.included_names.contains(name))
+    }
+
+    fn current_sandbox(&self) -> Option<(&str, &SandboxPolicy)> {
+        let name = self.sandbox_names.get(self.selected_sandbox)?;
+        self.all_sandboxes
+            .get(name.as_str())
+            .map(move |sb| (name.as_str(), sb))
+    }
+
+    fn current_sandbox_rule_count(&self) -> usize {
+        self.current_sandbox()
+            .map(|(_, sb)| sb.rules.len())
+            .unwrap_or(0)
+    }
+}
+
+impl Component for SandboxView {
+    type Msg = Msg;
+
+    fn handle_key(&self, key: KeyEvent) -> Option<Msg> {
+        match key.code {
+            KeyCode::Char('j') | KeyCode::Down => Some(Msg::MoveDown),
+            KeyCode::Char('k') | KeyCode::Up => Some(Msg::MoveUp),
+            KeyCode::Char('g') => Some(Msg::JumpTop),
+            KeyCode::Char('G') => Some(Msg::JumpBottom),
+            KeyCode::Char('l') | KeyCode::Right | KeyCode::Enter => Some(Msg::FocusRules),
+            KeyCode::Char('h') | KeyCode::Left | KeyCode::Esc => Some(Msg::FocusSandboxes),
+            KeyCode::Char('a') => match self.focus {
+                Focus::SandboxList => Some(Msg::AddSandbox),
+                Focus::RuleList => Some(Msg::AddRule),
+            },
+            KeyCode::Char('e') => Some(Msg::Edit),
+            KeyCode::Char('d') => Some(Msg::Delete),
+            KeyCode::Char('c') => Some(Msg::CopyToInline),
+            _ => None,
+        }
+    }
+
+    fn update(&mut self, msg: Msg, manifest: &mut PolicyManifest) -> Action {
+        match msg {
+            Msg::MoveDown => {
+                match self.focus {
+                    Focus::SandboxList => {
+                        if !self.sandbox_names.is_empty() {
+                            self.selected_sandbox =
+                                (self.selected_sandbox + 1).min(self.sandbox_names.len() - 1);
+                            self.selected_rule = 0;
+                        }
+                    }
+                    Focus::RuleList => {
+                        let count = self.current_sandbox_rule_count();
+                        if count > 0 {
+                            self.selected_rule = (self.selected_rule + 1).min(count - 1);
+                        }
+                    }
+                }
+                Action::None
+            }
+            Msg::MoveUp => {
+                match self.focus {
+                    Focus::SandboxList => {
+                        self.selected_sandbox = self.selected_sandbox.saturating_sub(1);
+                        self.selected_rule = 0;
+                    }
+                    Focus::RuleList => {
+                        self.selected_rule = self.selected_rule.saturating_sub(1);
+                    }
+                }
+                Action::None
+            }
+            Msg::JumpTop => {
+                match self.focus {
+                    Focus::SandboxList => {
+                        self.selected_sandbox = 0;
+                        self.selected_rule = 0;
+                    }
+                    Focus::RuleList => self.selected_rule = 0,
+                }
+                Action::None
+            }
+            Msg::JumpBottom => {
+                match self.focus {
+                    Focus::SandboxList => {
+                        if !self.sandbox_names.is_empty() {
+                            self.selected_sandbox = self.sandbox_names.len() - 1;
+                            self.selected_rule = 0;
+                        }
+                    }
+                    Focus::RuleList => {
+                        let count = self.current_sandbox_rule_count();
+                        if count > 0 {
+                            self.selected_rule = count - 1;
+                        }
+                    }
+                }
+                Action::None
+            }
+            Msg::FocusRules => {
+                if self.current_sandbox().is_some() {
+                    self.focus = Focus::RuleList;
+                    self.selected_rule = 0;
+                }
+                Action::None
+            }
+            Msg::FocusSandboxes => {
+                self.focus = Focus::SandboxList;
+                Action::None
+            }
+            Msg::AddSandbox => Action::RunForm(FormRequest::AddSandbox),
+            Msg::Edit => {
+                if self.is_selected_read_only() {
+                    return Action::Flash("Included sandboxes are read-only".into());
+                }
+                match self.focus {
+                    Focus::SandboxList => {
+                        if let Some(name) =
+                            self.sandbox_names.get(self.selected_sandbox).cloned()
+                        {
+                            Action::RunForm(FormRequest::EditSandbox {
+                                sandbox_name: name,
+                            })
+                        } else {
+                            Action::Flash("No sandbox selected".into())
+                        }
+                    }
+                    Focus::RuleList => {
+                        if let Some(name) =
+                            self.sandbox_names.get(self.selected_sandbox).cloned()
+                        {
+                            Action::RunForm(FormRequest::EditSandboxRule {
+                                sandbox_name: name,
+                                rule_index: self.selected_rule,
+                            })
+                        } else {
+                            Action::Flash("No sandbox selected".into())
+                        }
+                    }
+                }
+            }
+            Msg::AddRule => {
+                if self.is_selected_read_only() {
+                    return Action::Flash("Included sandboxes are read-only".into());
+                }
+                if let Some(name) = self.sandbox_names.get(self.selected_sandbox).cloned() {
+                    Action::RunForm(FormRequest::AddSandboxRule { sandbox_name: name })
+                } else {
+                    Action::Flash("No sandbox selected".into())
+                }
+            }
+            Msg::Delete => {
+                if self.is_selected_read_only() {
+                    return Action::Flash("Included sandboxes are read-only".into());
+                }
+                match self.focus {
+                    Focus::SandboxList => {
+                        if let Some(name) = self.sandbox_names.get(self.selected_sandbox).cloned() {
+                            if crate::policy::sandbox_edit::delete_sandbox(manifest, &name).is_ok()
+                            {
+                                self.rebuild(manifest);
+                                return Action::Modified;
+                            }
+                        }
+                    }
+                    Focus::RuleList => {
+                        if let Some((name, sb)) = self.current_sandbox() {
+                            if let Some(rule) = sb.rules.get(self.selected_rule) {
+                                let path = rule.path.clone();
+                                let name = name.to_string();
+                                if crate::policy::sandbox_edit::remove_rule(manifest, &name, &path)
+                                    .unwrap_or(false)
+                                {
+                                    self.selected_rule = self.selected_rule.saturating_sub(1);
+                                    return Action::Modified;
+                                }
+                            }
+                        }
+                    }
+                }
+                Action::None
+            }
+            Msg::CopyToInline => {
+                if !self.is_selected_read_only() {
+                    return Action::Flash("Already an inline sandbox".into());
+                }
+                let Some(name) = self.sandbox_names.get(self.selected_sandbox).cloned() else {
+                    return Action::None;
+                };
+                let Some(sb) = self.all_sandboxes.get(&name).cloned() else {
+                    return Action::None;
+                };
+                manifest.policy.sandboxes.insert(name.clone(), sb);
+                self.rebuild(manifest);
+                Action::Modified
+            }
+        }
+    }
+
+    fn view(&self, frame: &mut Frame, area: Rect, _manifest: &PolicyManifest) {
+        let chunks = Layout::horizontal([Constraint::Percentage(30), Constraint::Percentage(70)])
+            .split(area);
+
+        // Left pane: sandbox list
+        self.render_sandbox_list(frame, chunks[0]);
+
+        // Right pane: sandbox detail + rules
+        self.render_sandbox_detail(frame, chunks[1]);
+    }
+}
+
+impl SandboxView {
+    fn render_sandbox_list(&self, frame: &mut Frame, area: Rect) {
+        let border_color = if self.focus == Focus::SandboxList {
+            Color::Blue
+        } else {
+            Color::DarkGray
+        };
+        let block = Block::default()
+            .borders(Borders::ALL)
+            .border_style(Style::default().fg(border_color))
+            .title(" Sandboxes ");
+
+        let inner = block.inner(area);
+        frame.render_widget(block, area);
+
+        if self.sandbox_names.is_empty() {
+            let empty = Paragraph::new(Line::from(vec![
+                Span::styled(
+                    "  No sandboxes. Press ",
+                    Style::default().fg(Color::DarkGray),
+                ),
+                Span::styled(
+                    "a",
+                    Style::default()
+                        .fg(Color::Yellow)
+                        .add_modifier(Modifier::BOLD),
+                ),
+                Span::styled(" to add one.", Style::default().fg(Color::DarkGray)),
+            ]));
+            frame.render_widget(empty, inner);
+            return;
+        }
+
+        let lines: Vec<Line> = self
+            .sandbox_names
+            .iter()
+            .enumerate()
+            .map(|(i, name)| {
+                let is_included = self.included_names.contains(name);
+                let display = if is_included {
+                    format!("  {name} [included]")
+                } else {
+                    format!("  {name}")
+                };
+                let style = if i == self.selected_sandbox && self.focus == Focus::SandboxList {
+                    Style::default()
+                        .bg(Color::DarkGray)
+                        .fg(Color::White)
+                        .add_modifier(Modifier::BOLD)
+                } else if i == self.selected_sandbox {
+                    Style::default().fg(Color::Cyan)
+                } else if is_included {
+                    Style::default()
+                        .fg(Color::White)
+                        .add_modifier(Modifier::DIM)
+                } else {
+                    Style::default().fg(Color::White)
+                };
+                Line::from(Span::styled(display, style))
+            })
+            .collect();
+
+        let para = Paragraph::new(lines);
+        frame.render_widget(para, inner);
+    }
+
+    fn render_sandbox_detail(&self, frame: &mut Frame, area: Rect) {
+        let border_color = if self.focus == Focus::RuleList {
+            Color::Blue
+        } else {
+            Color::DarkGray
+        };
+        let block = Block::default()
+            .borders(Borders::ALL)
+            .border_style(Style::default().fg(border_color))
+            .title(" Details ");
+
+        let inner = block.inner(area);
+        frame.render_widget(block, area);
+
+        let Some((_name, sb)) = self.current_sandbox() else {
+            return;
+        };
+
+        let mut lines = Vec::new();
+
+        // Header info
+        lines.push(Line::from(vec![
+            Span::styled("  Default: ", Style::default().fg(Color::DarkGray)),
+            Span::styled(sb.default.display(), Style::default().fg(Color::Cyan)),
+        ]));
+        lines.push(Line::from(vec![
+            Span::styled("  Network: ", Style::default().fg(Color::DarkGray)),
+            Span::styled(
+                format_network(&sb.network),
+                Style::default().fg(Color::Cyan),
+            ),
+        ]));
+        if let Some(doc) = &sb.doc {
+            lines.push(Line::from(Span::styled(
+                format!("  Doc: {doc}"),
+                Style::default().fg(Color::DarkGray),
+            )));
+        }
+        lines.push(Line::from(""));
+        lines.push(Line::from(Span::styled(
+            "  Rules:",
+            Style::default()
+                .fg(Color::White)
+                .add_modifier(Modifier::BOLD),
+        )));
+
+        if sb.rules.is_empty() {
+            lines.push(Line::from(Span::styled(
+                "    (no rules)",
+                Style::default().fg(Color::DarkGray),
+            )));
+        } else {
+            for (i, rule) in sb.rules.iter().enumerate() {
+                let effect_color = match rule.effect {
+                    RuleEffect::Allow => Color::Green,
+                    RuleEffect::Deny => Color::Red,
+                };
+                let selected = i == self.selected_rule && self.focus == Focus::RuleList;
+                let style = if selected {
+                    Style::default()
+                        .bg(Color::DarkGray)
+                        .fg(Color::White)
+                        .add_modifier(Modifier::BOLD)
+                } else {
+                    Style::default().fg(effect_color)
+                };
+                let effect_str = match rule.effect {
+                    RuleEffect::Allow => "allow",
+                    RuleEffect::Deny => "deny",
+                };
+                lines.push(Line::from(Span::styled(
+                    format!(
+                        "    {effect_str} {} in {} ({})",
+                        rule.caps.display(),
+                        rule.path,
+                        format!("{:?}", rule.path_match).to_lowercase()
+                    ),
+                    style,
+                )));
+            }
+        }
+
+        let para = Paragraph::new(lines);
+        frame.render_widget(para, inner);
+    }
+}
+
+fn format_network(net: &crate::policy::sandbox_types::NetworkPolicy) -> String {
+    use crate::policy::sandbox_types::NetworkPolicy;
+    match net {
+        NetworkPolicy::Deny => "deny".into(),
+        NetworkPolicy::Allow => "allow".into(),
+        NetworkPolicy::Localhost => "localhost".into(),
+        NetworkPolicy::AllowDomains(domains) => format!("allow [{}]", domains.join(", ")),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::policy::match_tree::*;
+    use crate::policy::sandbox_edit;
+    use crate::policy::sandbox_types::{Cap, NetworkPolicy};
+    use std::collections::HashMap;
+
+    fn empty_manifest() -> PolicyManifest {
+        PolicyManifest {
+            includes: vec![],
+            policy: CompiledPolicy {
+                sandboxes: HashMap::new(),
+                tree: vec![],
+                default_effect: crate::policy::Effect::Deny,
+                default_sandbox: None,
+            },
+        }
+    }
+
+    fn empty_included() -> CompiledPolicy {
+        CompiledPolicy {
+            sandboxes: HashMap::new(),
+            tree: vec![],
+            default_effect: crate::policy::Effect::Deny,
+            default_sandbox: None,
+        }
+    }
+
+    #[test]
+    fn test_sandbox_navigation() {
+        let mut manifest = empty_manifest();
+        sandbox_edit::create_sandbox(&mut manifest, "alpha", Cap::READ, NetworkPolicy::Deny, None)
+            .unwrap();
+        sandbox_edit::create_sandbox(&mut manifest, "beta", Cap::READ, NetworkPolicy::Allow, None)
+            .unwrap();
+
+        let mut view = SandboxView::new(&manifest, &empty_included());
+        assert_eq!(view.sandbox_names.len(), 2);
+        assert_eq!(view.selected_sandbox, 0);
+
+        view.update(Msg::MoveDown, &mut manifest);
+        assert_eq!(view.selected_sandbox, 1);
+
+        view.update(Msg::MoveUp, &mut manifest);
+        assert_eq!(view.selected_sandbox, 0);
+    }
+
+    #[test]
+    fn test_edit_sandbox_from_list() {
+        let mut manifest = empty_manifest();
+        sandbox_edit::create_sandbox(&mut manifest, "dev", Cap::READ, NetworkPolicy::Deny, None)
+            .unwrap();
+
+        let mut view = SandboxView::new(&manifest, &empty_included());
+        let action = view.update(Msg::Edit, &mut manifest.clone());
+        match action {
+            Action::RunForm(FormRequest::EditSandbox { sandbox_name }) => {
+                assert_eq!(sandbox_name, "dev");
+            }
+            _ => panic!("Expected RunForm(EditSandbox), got {:?}", "other"),
+        }
+    }
+
+    #[test]
+    fn test_edit_sandbox_rule() {
+        let mut manifest = empty_manifest();
+        sandbox_edit::create_sandbox(&mut manifest, "dev", Cap::READ, NetworkPolicy::Deny, None)
+            .unwrap();
+        sandbox_edit::add_rule(
+            &mut manifest,
+            "dev",
+            crate::policy::sandbox_types::RuleEffect::Allow,
+            Cap::READ | Cap::WRITE,
+            "$PWD".into(),
+            crate::policy::sandbox_types::PathMatch::Subpath,
+            None,
+        )
+        .unwrap();
+
+        let mut view = SandboxView::new(&manifest, &empty_included());
+        // Focus on rules
+        view.update(Msg::FocusRules, &mut manifest);
+        let action = view.update(Msg::Edit, &mut manifest.clone());
+        match action {
+            Action::RunForm(FormRequest::EditSandboxRule {
+                sandbox_name,
+                rule_index,
+            }) => {
+                assert_eq!(sandbox_name, "dev");
+                assert_eq!(rule_index, 0);
+            }
+            _ => panic!("Expected RunForm(EditSandboxRule)"),
+        }
+    }
+
+    #[test]
+    fn test_edit_read_only_sandbox_blocked() {
+        let mut manifest = empty_manifest();
+        let mut included = empty_included();
+        included.sandboxes.insert(
+            "from_star".into(),
+            SandboxPolicy {
+                default: Cap::READ,
+                rules: vec![],
+                network: NetworkPolicy::Deny,
+                doc: None,
+            },
+        );
+
+        let mut view = SandboxView::new(&manifest, &included);
+        let action = view.update(Msg::Edit, &mut manifest);
+        assert!(matches!(action, Action::Flash(_)));
+    }
+
+    #[test]
+    fn test_delete_sandbox() {
+        let mut manifest = empty_manifest();
+        sandbox_edit::create_sandbox(&mut manifest, "test", Cap::READ, NetworkPolicy::Deny, None)
+            .unwrap();
+
+        let mut view = SandboxView::new(&manifest, &empty_included());
+        let action = view.update(Msg::Delete, &mut manifest);
+        assert!(matches!(action, Action::Modified));
+        assert!(manifest.policy.sandboxes.is_empty());
+    }
+}

--- a/clash/src/tui/settings_view.rs
+++ b/clash/src/tui/settings_view.rs
@@ -1,0 +1,247 @@
+//! Settings view component for editing default_effect and default_sandbox.
+
+use crossterm::event::{KeyCode, KeyEvent};
+use ratatui::Frame;
+use ratatui::layout::Rect;
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, Paragraph};
+
+use super::tea::{Action, Component};
+use crate::policy::Effect;
+use crate::policy::match_tree::PolicyManifest;
+
+pub struct SettingsView {
+    pub selected_field: usize,
+}
+
+#[derive(Debug)]
+pub enum Msg {
+    MoveUp,
+    MoveDown,
+    CycleValue,
+}
+
+impl SettingsView {
+    pub fn new() -> Self {
+        SettingsView { selected_field: 0 }
+    }
+
+    /// Number of editable fields.
+    const FIELD_COUNT: usize = 2;
+}
+
+impl Component for SettingsView {
+    type Msg = Msg;
+
+    fn handle_key(&self, key: KeyEvent) -> Option<Msg> {
+        match key.code {
+            KeyCode::Char('j') | KeyCode::Down => Some(Msg::MoveDown),
+            KeyCode::Char('k') | KeyCode::Up => Some(Msg::MoveUp),
+            KeyCode::Enter | KeyCode::Char('e') | KeyCode::Char(' ') => {
+                Some(Msg::CycleValue)
+            }
+            _ => None,
+        }
+    }
+
+    fn update(&mut self, msg: Msg, manifest: &mut PolicyManifest) -> Action {
+        match msg {
+            Msg::MoveDown => {
+                self.selected_field = (self.selected_field + 1).min(Self::FIELD_COUNT - 1);
+                Action::None
+            }
+            Msg::MoveUp => {
+                self.selected_field = self.selected_field.saturating_sub(1);
+                Action::None
+            }
+            Msg::CycleValue => {
+                match self.selected_field {
+                    0 => {
+                        // Cycle default_effect: allow -> deny -> ask -> allow
+                        manifest.policy.default_effect = match manifest.policy.default_effect {
+                            Effect::Allow => Effect::Deny,
+                            Effect::Deny => Effect::Ask,
+                            Effect::Ask => Effect::Allow,
+                        };
+                        Action::Modified
+                    }
+                    1 => {
+                        // Cycle default_sandbox through sandbox names + None
+                        let names: Vec<String> = {
+                            let mut n: Vec<String> =
+                                manifest.policy.sandboxes.keys().cloned().collect();
+                            n.sort();
+                            n
+                        };
+
+                        if names.is_empty() {
+                            manifest.policy.default_sandbox = None;
+                            return Action::Flash("No sandboxes defined".into());
+                        }
+
+                        let current = manifest.policy.default_sandbox.as_deref();
+                        let next = match current {
+                            None => Some(names[0].clone()),
+                            Some(name) => {
+                                if let Some(pos) = names.iter().position(|n| n == name) {
+                                    if pos + 1 < names.len() {
+                                        Some(names[pos + 1].clone())
+                                    } else {
+                                        None // wrap back to None
+                                    }
+                                } else {
+                                    Some(names[0].clone())
+                                }
+                            }
+                        };
+                        manifest.policy.default_sandbox = next;
+                        Action::Modified
+                    }
+                    _ => Action::None,
+                }
+            }
+        }
+    }
+
+    fn view(&self, frame: &mut Frame, area: Rect, manifest: &PolicyManifest) {
+        let block = Block::default()
+            .borders(Borders::LEFT | Borders::RIGHT)
+            .border_style(Style::default().fg(Color::DarkGray));
+
+        let inner = block.inner(area);
+        frame.render_widget(block, area);
+
+        let effect_str = manifest.policy.default_effect.to_string();
+        let effect_color = match manifest.policy.default_effect {
+            Effect::Allow => Color::Green,
+            Effect::Deny => Color::Red,
+            Effect::Ask => Color::Yellow,
+        };
+
+        let sandbox_str = manifest
+            .policy
+            .default_sandbox
+            .as_deref()
+            .unwrap_or("(none)");
+
+        let fields = [
+            ("default_effect", effect_str.as_str(), effect_color),
+            ("default_sandbox", sandbox_str, Color::Cyan),
+        ];
+
+        let lines: Vec<Line> = fields
+            .iter()
+            .enumerate()
+            .flat_map(|(i, (label, value, color))| {
+                let selected = i == self.selected_field;
+                let label_style = if selected {
+                    Style::default()
+                        .fg(Color::White)
+                        .add_modifier(Modifier::BOLD)
+                } else {
+                    Style::default().fg(Color::Gray)
+                };
+                let value_style = if selected {
+                    Style::default()
+                        .fg(*color)
+                        .bg(Color::DarkGray)
+                        .add_modifier(Modifier::BOLD)
+                } else {
+                    Style::default().fg(*color)
+                };
+
+                let hint = if selected {
+                    " (Enter/Space to cycle)"
+                } else {
+                    ""
+                };
+
+                vec![
+                    Line::from(""),
+                    Line::from(vec![
+                        Span::styled(format!("  {label}: "), label_style),
+                        Span::styled(*value, value_style),
+                        Span::styled(hint, Style::default().fg(Color::DarkGray)),
+                    ]),
+                ]
+            })
+            .collect();
+
+        let para = Paragraph::new(lines);
+        frame.render_widget(para, inner);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::policy::match_tree::*;
+    use std::collections::HashMap;
+
+    fn empty_manifest() -> PolicyManifest {
+        PolicyManifest {
+            includes: vec![],
+            policy: CompiledPolicy {
+                sandboxes: HashMap::new(),
+                tree: vec![],
+                default_effect: Effect::Deny,
+                default_sandbox: None,
+            },
+        }
+    }
+
+    #[test]
+    fn test_cycle_default_effect() {
+        let mut manifest = empty_manifest();
+        let mut view = SettingsView::new();
+
+        assert_eq!(manifest.policy.default_effect, Effect::Deny);
+
+        view.update(Msg::CycleValue, &mut manifest);
+        assert_eq!(manifest.policy.default_effect, Effect::Ask);
+
+        view.update(Msg::CycleValue, &mut manifest);
+        assert_eq!(manifest.policy.default_effect, Effect::Allow);
+
+        view.update(Msg::CycleValue, &mut manifest);
+        assert_eq!(manifest.policy.default_effect, Effect::Deny);
+    }
+
+    #[test]
+    fn test_cycle_default_sandbox() {
+        let mut manifest = empty_manifest();
+        manifest.policy.sandboxes.insert(
+            "alpha".into(),
+            crate::policy::sandbox_types::SandboxPolicy {
+                default: crate::policy::sandbox_types::Cap::READ,
+                rules: vec![],
+                network: crate::policy::sandbox_types::NetworkPolicy::Deny,
+                doc: None,
+            },
+        );
+        manifest.policy.sandboxes.insert(
+            "beta".into(),
+            crate::policy::sandbox_types::SandboxPolicy {
+                default: crate::policy::sandbox_types::Cap::READ,
+                rules: vec![],
+                network: crate::policy::sandbox_types::NetworkPolicy::Deny,
+                doc: None,
+            },
+        );
+
+        let mut view = SettingsView::new();
+        view.selected_field = 1; // default_sandbox
+
+        assert_eq!(manifest.policy.default_sandbox, None);
+
+        view.update(Msg::CycleValue, &mut manifest);
+        assert_eq!(manifest.policy.default_sandbox.as_deref(), Some("alpha"));
+
+        view.update(Msg::CycleValue, &mut manifest);
+        assert_eq!(manifest.policy.default_sandbox.as_deref(), Some("beta"));
+
+        view.update(Msg::CycleValue, &mut manifest);
+        assert_eq!(manifest.policy.default_sandbox, None);
+    }
+}

--- a/clash/src/tui/tea.rs
+++ b/clash/src/tui/tea.rs
@@ -1,0 +1,64 @@
+//! The Elm Architecture (TEA) trait for TUI components.
+//!
+//! Every tab/component implements [`Component`], enabling testable state
+//! transitions and composable rendering.
+
+use crossterm::event::KeyEvent;
+use ratatui::Frame;
+use ratatui::layout::Rect;
+
+use crate::policy::match_tree::PolicyManifest;
+
+/// An action returned from [`Component::update`] to signal the parent.
+pub enum Action {
+    /// No action needed.
+    None,
+    /// The component wants to quit.
+    Quit,
+    /// The manifest was modified — mark dirty.
+    Modified,
+    /// Request a dialoguer form (exits raw mode).
+    RunForm(FormRequest),
+    /// Show a flash message in the status bar.
+    Flash(String),
+}
+
+/// Requests for inline form overlays.
+pub enum FormRequest {
+    /// Add a new tree rule (tool or exec).
+    AddRule,
+    /// Add a new sandbox definition.
+    AddSandbox,
+    /// Add a rule to an existing sandbox.
+    AddSandboxRule { sandbox_name: String },
+    /// Add an include entry.
+    AddInclude,
+    /// Edit an existing condition node's observable and pattern.
+    EditCondition { path: Vec<usize> },
+    /// Edit an existing decision node's effect and sandbox.
+    EditDecision { path: Vec<usize> },
+    /// Add a child node under an existing condition.
+    AddChild { parent_path: Vec<usize> },
+    /// Edit an existing sandbox's properties (caps, network).
+    EditSandbox { sandbox_name: String },
+    /// Edit an existing sandbox rule.
+    EditSandboxRule {
+        sandbox_name: String,
+        rule_index: usize,
+    },
+}
+
+/// The Elm Architecture trait. Each tab/component implements this.
+pub trait Component {
+    /// The message type this component handles.
+    type Msg;
+
+    /// Map a crossterm KeyEvent to a message (or None to ignore).
+    fn handle_key(&self, key: KeyEvent) -> Option<Self::Msg>;
+
+    /// Pure state transition: apply a message, return an Action for the parent.
+    fn update(&mut self, msg: Self::Msg, manifest: &mut PolicyManifest) -> Action;
+
+    /// Render the component into a ratatui Frame area.
+    fn view(&self, frame: &mut Frame, area: Rect, manifest: &PolicyManifest);
+}

--- a/clash/src/tui/tool_registry.rs
+++ b/clash/src/tui/tool_registry.rs
@@ -1,0 +1,295 @@
+//! Well-known Claude Code tool metadata for the TUI policy editor.
+//!
+//! Provides contextual hints, effect filtering, and observable relevance
+//! based on the tool being configured. Unknown/MCP tools get permissive
+//! defaults (all effects allowed, all observables relevant).
+
+/// Which effects are valid for a tool.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EffectOption {
+    Allow,
+    Deny,
+    Ask,
+}
+
+/// Lightweight tag for Observable variants (no inner data).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ObservableTag {
+    ToolName,
+    HookType,
+    AgentName,
+    PositionalArg,
+    HasArg,
+    NamedArg,
+    NestedField,
+    FsOp,
+    FsPath,
+    NetDomain,
+}
+
+/// Metadata for a well-known Claude Code tool.
+pub struct ToolInfo {
+    /// Tool name as Claude sees it, e.g. "Bash", "Read".
+    pub name: &'static str,
+    /// Which effects are valid for rules targeting this tool.
+    pub allowed_effects: &'static [EffectOption],
+    /// Which observables are useful when adding child conditions.
+    pub relevant_observables: &'static [ObservableTag],
+    /// Hint shown when this tool is the target of a rule.
+    pub description: &'static str,
+    /// Named arguments this tool accepts, for autocomplete/hints.
+    pub args: &'static [(&'static str, &'static str)], // (name, description)
+}
+
+const ALL_EFFECTS: &[EffectOption] = &[EffectOption::Allow, EffectOption::Deny, EffectOption::Ask];
+const NO_ASK: &[EffectOption] = &[EffectOption::Allow, EffectOption::Deny];
+
+/// The registry of well-known Claude Code tools.
+pub const TOOLS: &[ToolInfo] = &[
+    ToolInfo {
+        name: "Bash",
+        allowed_effects: NO_ASK,
+        relevant_observables: &[
+            ObservableTag::PositionalArg,
+            ObservableTag::HasArg,
+            ObservableTag::NamedArg,
+        ],
+        description: "Execute shell commands",
+        args: &[
+            ("command", "The shell command to run"),
+            ("description", "What the command does"),
+            ("timeout", "Timeout in milliseconds"),
+        ],
+    },
+    ToolInfo {
+        name: "Read",
+        allowed_effects: ALL_EFFECTS,
+        relevant_observables: &[ObservableTag::FsPath, ObservableTag::FsOp],
+        description: "Read files from the filesystem",
+        args: &[
+            ("file_path", "Absolute path to the file"),
+            ("offset", "Line number to start reading from"),
+            ("limit", "Number of lines to read"),
+        ],
+    },
+    ToolInfo {
+        name: "Write",
+        allowed_effects: ALL_EFFECTS,
+        relevant_observables: &[ObservableTag::FsPath, ObservableTag::FsOp],
+        description: "Write/create files on the filesystem",
+        args: &[
+            ("file_path", "Absolute path to the file"),
+            ("content", "Content to write"),
+        ],
+    },
+    ToolInfo {
+        name: "Edit",
+        allowed_effects: ALL_EFFECTS,
+        relevant_observables: &[ObservableTag::FsPath, ObservableTag::FsOp],
+        description: "Edit files with string replacements",
+        args: &[
+            ("file_path", "Absolute path to the file"),
+            ("old_string", "Text to find"),
+            ("new_string", "Replacement text"),
+        ],
+    },
+    ToolInfo {
+        name: "MultiEdit",
+        allowed_effects: ALL_EFFECTS,
+        relevant_observables: &[ObservableTag::FsPath, ObservableTag::FsOp],
+        description: "Apply multiple edits to a file",
+        args: &[
+            ("file_path", "Absolute path to the file"),
+            ("edits", "Array of {old_string, new_string} edits"),
+        ],
+    },
+    ToolInfo {
+        name: "Glob",
+        allowed_effects: ALL_EFFECTS,
+        relevant_observables: &[ObservableTag::FsPath, ObservableTag::FsOp],
+        description: "Search for files by glob pattern",
+        args: &[
+            ("pattern", "Glob pattern, e.g. **/*.ts"),
+            ("path", "Directory to search in"),
+        ],
+    },
+    ToolInfo {
+        name: "Grep",
+        allowed_effects: ALL_EFFECTS,
+        relevant_observables: &[ObservableTag::FsPath, ObservableTag::FsOp],
+        description: "Search file contents by regex",
+        args: &[
+            ("pattern", "Regex to search for"),
+            ("path", "File or directory to search"),
+        ],
+    },
+    ToolInfo {
+        name: "WebFetch",
+        allowed_effects: ALL_EFFECTS,
+        relevant_observables: &[ObservableTag::NetDomain],
+        description: "Fetch content from a URL",
+        args: &[
+            ("url", "The URL to fetch"),
+            ("prompt", "Prompt to run on fetched content"),
+        ],
+    },
+    ToolInfo {
+        name: "WebSearch",
+        allowed_effects: ALL_EFFECTS,
+        relevant_observables: &[ObservableTag::NetDomain],
+        description: "Search the web",
+        args: &[
+            ("query", "Search query"),
+            ("allowed_domains", "Restrict to these domains"),
+            ("blocked_domains", "Exclude these domains"),
+        ],
+    },
+    ToolInfo {
+        name: "Agent",
+        allowed_effects: ALL_EFFECTS,
+        relevant_observables: &[ObservableTag::AgentName, ObservableTag::NamedArg],
+        description: "Spawn a sub-agent",
+        args: &[
+            ("description", "Short description of the task"),
+            ("prompt", "The task for the agent"),
+        ],
+    },
+    ToolInfo {
+        name: "NotebookEdit",
+        allowed_effects: ALL_EFFECTS,
+        relevant_observables: &[ObservableTag::FsPath],
+        description: "Edit Jupyter notebook cells",
+        args: &[
+            ("notebook_path", "Path to the notebook"),
+            ("cell_number", "Cell index (0-based)"),
+            ("new_source", "New cell content"),
+        ],
+    },
+];
+
+/// Look up a tool by name (case-insensitive). Returns None for unknown/MCP tools.
+pub fn lookup(name: &str) -> Option<&'static ToolInfo> {
+    TOOLS.iter().find(|t| t.name.eq_ignore_ascii_case(name))
+}
+
+/// Check whether an effect is allowed for a tool. Unknown tools allow all effects.
+pub fn is_effect_allowed(tool_name: &str, effect: EffectOption) -> bool {
+    match lookup(tool_name) {
+        Some(info) => info.allowed_effects.contains(&effect),
+        None => true,
+    }
+}
+
+/// Check whether an observable is relevant for a tool. Unknown tools allow all.
+pub fn is_observable_relevant(tool_name: &str, tag: ObservableTag) -> bool {
+    match lookup(tool_name) {
+        Some(info) => info.relevant_observables.contains(&tag),
+        None => true,
+    }
+}
+
+/// Build the effect options and hints for a given tool context.
+/// Returns (labels, hints) vecs filtered to allowed effects.
+pub fn effect_options_for_tool(tool_name: Option<&str>) -> (Vec<String>, Vec<&'static str>) {
+    let all = [
+        (EffectOption::Allow, "allow (permit)", ""),
+        (EffectOption::Deny, "deny (block)", ""),
+        (EffectOption::Ask, "ask (prompt)", ""),
+    ];
+    match tool_name.and_then(lookup) {
+        Some(info) => {
+            let mut labels = Vec::new();
+            let mut hints = Vec::new();
+            for &(effect, label, hint) in &all {
+                if info.allowed_effects.contains(&effect) {
+                    labels.push(label.into());
+                    hints.push(hint);
+                }
+            }
+            (labels, hints)
+        }
+        None => {
+            let labels = all.iter().map(|(_, l, _)| l.to_string()).collect();
+            let hints = all.iter().map(|(_, _, h)| *h).collect();
+            (labels, hints)
+        }
+    }
+}
+
+/// Map a filtered effect index back to the canonical 0/1/2 index
+/// (allow=0, deny=1, ask=2) used by apply functions.
+pub fn filtered_effect_to_canonical(
+    tool_name: Option<&str>,
+    filtered_idx: usize,
+) -> usize {
+    let all = [EffectOption::Allow, EffectOption::Deny, EffectOption::Ask];
+    match tool_name.and_then(lookup) {
+        Some(info) => {
+            let allowed: Vec<usize> = all
+                .iter()
+                .enumerate()
+                .filter(|(_, e)| info.allowed_effects.contains(e))
+                .map(|(i, _)| i)
+                .collect();
+            allowed.get(filtered_idx).copied().unwrap_or(filtered_idx)
+        }
+        None => filtered_idx,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_bash_no_ask() {
+        assert!(is_effect_allowed("Bash", EffectOption::Allow));
+        assert!(is_effect_allowed("Bash", EffectOption::Deny));
+        assert!(!is_effect_allowed("Bash", EffectOption::Ask));
+    }
+
+    #[test]
+    fn test_case_insensitive_lookup() {
+        assert!(lookup("bash").is_some());
+        assert!(lookup("BASH").is_some());
+        assert!(lookup("Bash").is_some());
+    }
+
+    #[test]
+    fn test_unknown_tool_permissive() {
+        assert!(is_effect_allowed("mcp__custom_tool", EffectOption::Ask));
+        assert!(is_observable_relevant("mcp__custom_tool", ObservableTag::FsPath));
+    }
+
+    #[test]
+    fn test_effect_filtering() {
+        let (labels, _) = effect_options_for_tool(Some("Bash"));
+        assert_eq!(labels.len(), 2);
+        assert!(labels.contains(&"allow (permit)".to_string()));
+        assert!(labels.contains(&"deny (block)".to_string()));
+        assert!(!labels.contains(&"ask (prompt)".to_string()));
+    }
+
+    #[test]
+    fn test_filtered_index_mapping() {
+        // Bash: [allow, deny] → canonical [0, 1]
+        assert_eq!(filtered_effect_to_canonical(Some("Bash"), 0), 0); // allow
+        assert_eq!(filtered_effect_to_canonical(Some("Bash"), 1), 1); // deny
+        // Unknown: identity
+        assert_eq!(filtered_effect_to_canonical(None, 2), 2);
+    }
+
+    #[test]
+    fn test_observable_relevance() {
+        assert!(is_observable_relevant("Bash", ObservableTag::PositionalArg));
+        assert!(is_observable_relevant("Bash", ObservableTag::HasArg));
+        assert!(!is_observable_relevant("Bash", ObservableTag::FsPath));
+        assert!(!is_observable_relevant("Bash", ObservableTag::NetDomain));
+
+        assert!(is_observable_relevant("Read", ObservableTag::FsPath));
+        assert!(!is_observable_relevant("Read", ObservableTag::NetDomain));
+
+        assert!(is_observable_relevant("WebSearch", ObservableTag::NetDomain));
+        assert!(!is_observable_relevant("WebSearch", ObservableTag::FsPath));
+    }
+}

--- a/clash/src/tui/tree_view.rs
+++ b/clash/src/tui/tree_view.rs
@@ -1,0 +1,870 @@
+//! Tree view component for browsing and editing policy rules.
+
+use std::collections::HashSet;
+
+use crossterm::event::{KeyCode, KeyEvent};
+use ratatui::Frame;
+use ratatui::layout::Rect;
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, Paragraph};
+
+use super::tea::{Action, Component, FormRequest};
+use crate::policy::match_tree::{
+    CompiledPolicy, Decision, Node, Observable, Pattern, PolicyManifest,
+};
+
+/// A flattened node in the tree for display purposes.
+pub struct FlatNode {
+    /// Indentation depth.
+    pub depth: usize,
+    /// Display label for this node.
+    pub label: String,
+    /// Path of child indices from root to this node.
+    /// Empty `node_path` means this is the synthetic root.
+    pub node_path: Vec<usize>,
+    /// Whether this node is a leaf (Decision or inline condition->decision).
+    pub is_leaf: bool,
+    /// Whether this node has children (for expand/collapse).
+    pub has_children: bool,
+    /// The decision at this node, if it's a leaf.
+    pub decision: Option<Decision>,
+    /// Whether this is the synthetic root node.
+    pub is_root: bool,
+    /// Whether this node came from an include file (read-only).
+    pub read_only: bool,
+    /// Source provenance for included rules (e.g. "rules.star").
+    pub source: Option<String>,
+}
+
+pub struct TreeView {
+    flat_nodes: Vec<FlatNode>,
+    pub selected: usize,
+    scroll_offset: usize,
+    collapsed: HashSet<Vec<usize>>,
+    /// Snapshot of included rules for rebuild after collapse/expand.
+    included: CompiledPolicy,
+}
+
+#[derive(Debug)]
+pub enum Msg {
+    MoveUp,
+    MoveDown,
+    JumpTop,
+    JumpBottom,
+    Expand,
+    Collapse,
+    ToggleExpand,
+    ExpandAll,
+    CollapseAll,
+    Edit,
+    Delete,
+    Add,
+    CopyToInline,
+}
+
+impl TreeView {
+    pub fn new(manifest: &PolicyManifest, included: &CompiledPolicy) -> Self {
+        let mut view = TreeView {
+            flat_nodes: Vec::new(),
+            selected: 0,
+            scroll_offset: 0,
+            collapsed: HashSet::new(),
+            included: included.clone(),
+        };
+        view.rebuild(manifest);
+        view
+    }
+
+    /// Rebuild the flat node list from the manifest's tree.
+    pub fn rebuild(&mut self, manifest: &PolicyManifest) {
+        let included = self.included.clone();
+        self.rebuild_inner(manifest, &included);
+    }
+
+    /// Update the included snapshot and rebuild.
+    pub fn rebuild_with_included(
+        &mut self,
+        manifest: &PolicyManifest,
+        included: &CompiledPolicy,
+    ) {
+        self.included = included.clone();
+        self.rebuild_inner(manifest, included);
+    }
+
+    fn rebuild_inner(&mut self, manifest: &PolicyManifest, included: &CompiledPolicy) {
+        self.flat_nodes.clear();
+
+        let has_any = !manifest.policy.tree.is_empty() || !included.tree.is_empty();
+
+        // Synthetic root node
+        let root_collapsed = self.collapsed.contains(&vec![]);
+        self.flat_nodes.push(FlatNode {
+            depth: 0,
+            label: "rules".to_string(),
+            node_path: vec![],
+            is_leaf: false,
+            has_children: has_any,
+            decision: None,
+            is_root: true,
+            read_only: false,
+            source: None,
+        });
+
+        if !root_collapsed {
+            for (i, node) in manifest.policy.tree.iter().enumerate() {
+                self.flatten_node(node, 1, vec![i], false);
+            }
+
+            // Append included rules as read-only
+            if !included.tree.is_empty() {
+                // Separator node for included rules
+                self.flat_nodes.push(FlatNode {
+                    depth: 1,
+                    label: "── included ──".to_string(),
+                    node_path: vec![],
+                    is_leaf: false,
+                    has_children: false,
+                    decision: None,
+                    is_root: false,
+                    read_only: true,
+                    source: None,
+                });
+
+                for (i, node) in included.tree.iter().enumerate() {
+                    // Use a high offset so paths don't collide with inline nodes
+                    self.flatten_node(node, 1, vec![10000 + i], true);
+                }
+            }
+        }
+
+        if self.selected >= self.flat_nodes.len() && !self.flat_nodes.is_empty() {
+            self.selected = self.flat_nodes.len() - 1;
+        }
+    }
+
+    fn flatten_node(&mut self, node: &Node, depth: usize, path: Vec<usize>, read_only: bool) {
+        match node {
+            Node::Decision(d) => {
+                self.flat_nodes.push(FlatNode {
+                    depth,
+                    label: format_decision(d),
+                    node_path: path,
+                    is_leaf: true,
+                    has_children: false,
+                    decision: Some(d.clone()),
+                    is_root: false,
+                    read_only,
+                    source: None,
+                });
+            }
+            Node::Condition {
+                observe,
+                pattern,
+                children,
+                source,
+                ..
+            } => {
+                let label = format_condition(observe, pattern);
+                let has_children = !children.is_empty();
+
+                // Check if this is a single-decision child (inline display)
+                let is_inline_leaf =
+                    children.len() == 1 && matches!(&children[0], Node::Decision(_));
+                let decision = if is_inline_leaf {
+                    if let Node::Decision(d) = &children[0] {
+                        Some(d.clone())
+                    } else {
+                        None
+                    }
+                } else {
+                    None
+                };
+
+                let display_label = if let Some(ref d) = decision {
+                    format!("{label} -> {}", format_decision(d))
+                } else {
+                    label
+                };
+
+                let is_collapsed = self.collapsed.contains(&path);
+                self.flat_nodes.push(FlatNode {
+                    depth,
+                    label: display_label,
+                    node_path: path.clone(),
+                    is_leaf: is_inline_leaf,
+                    has_children: has_children && !is_inline_leaf,
+                    decision,
+                    is_root: false,
+                    read_only,
+                    source: source.clone(),
+                });
+
+                // If it's an inline leaf (condition -> decision), don't recurse
+                if is_inline_leaf {
+                    return;
+                }
+
+                // Only show children if not collapsed
+                if !is_collapsed {
+                    for (i, child) in children.iter().enumerate() {
+                        let mut child_path = path.clone();
+                        child_path.push(i);
+                        self.flatten_node(child, depth + 1, child_path, read_only);
+                    }
+                }
+            }
+        }
+    }
+
+    /// Remove a node at a given path from the tree.
+    fn remove_node_at_path(tree: &mut Vec<Node>, path: &[usize]) {
+        if path.is_empty() {
+            return;
+        }
+        if path.len() == 1 {
+            if path[0] < tree.len() {
+                tree.remove(path[0]);
+            }
+            return;
+        }
+        let parent_path = &path[..path.len() - 1];
+        let child_idx = *path.last().unwrap();
+        if let Some(parent) = Self::get_node_at_path_mut(tree, parent_path) {
+            if let Node::Condition { children, .. } = parent {
+                if child_idx < children.len() {
+                    children.remove(child_idx);
+                }
+            }
+        }
+    }
+
+    /// Get a mutable node at a given path in the tree.
+    fn get_node_at_path_mut<'a>(tree: &'a mut [Node], path: &[usize]) -> Option<&'a mut Node> {
+        if path.is_empty() {
+            return None;
+        }
+        let mut current = tree.get_mut(path[0])?;
+        for &idx in &path[1..] {
+            match current {
+                Node::Condition { children, .. } => {
+                    current = children.get_mut(idx)?;
+                }
+                Node::Decision(_) => return None,
+            }
+        }
+        Some(current)
+    }
+
+    pub fn get_node_at_path_ref<'a>(tree: &'a [Node], path: &[usize]) -> Option<&'a Node> {
+        if path.is_empty() {
+            return None;
+        }
+        let mut current = tree.get(path[0])?;
+        for &idx in &path[1..] {
+            match current {
+                Node::Condition { children, .. } => {
+                    current = children.get(idx)?;
+                }
+                Node::Decision(_) => return None,
+            }
+        }
+        Some(current)
+    }
+}
+
+impl Component for TreeView {
+    type Msg = Msg;
+
+    fn handle_key(&self, key: KeyEvent) -> Option<Msg> {
+        match key.code {
+            KeyCode::Char('j') | KeyCode::Down => Some(Msg::MoveDown),
+            KeyCode::Char('k') | KeyCode::Up => Some(Msg::MoveUp),
+            KeyCode::Char('g') => Some(Msg::JumpTop),
+            KeyCode::Char('G') => Some(Msg::JumpBottom),
+            KeyCode::Char('h') | KeyCode::Left => Some(Msg::Collapse),
+            KeyCode::Char('l') | KeyCode::Right => Some(Msg::Expand),
+            KeyCode::Char(' ') => Some(Msg::ToggleExpand),
+            KeyCode::Char('[') => Some(Msg::CollapseAll),
+            KeyCode::Char(']') => Some(Msg::ExpandAll),
+            KeyCode::Char('e') => Some(Msg::Edit),
+            KeyCode::Char('d') => Some(Msg::Delete),
+            KeyCode::Char('a') => Some(Msg::Add),
+            KeyCode::Char('c') => Some(Msg::CopyToInline),
+            _ => None,
+        }
+    }
+
+    fn update(&mut self, msg: Msg, manifest: &mut PolicyManifest) -> Action {
+        match msg {
+            Msg::MoveDown => {
+                if !self.flat_nodes.is_empty() {
+                    self.selected = (self.selected + 1).min(self.flat_nodes.len() - 1);
+                }
+                Action::None
+            }
+            Msg::MoveUp => {
+                self.selected = self.selected.saturating_sub(1);
+                Action::None
+            }
+            Msg::JumpTop => {
+                self.selected = 0;
+                Action::None
+            }
+            Msg::JumpBottom => {
+                if !self.flat_nodes.is_empty() {
+                    self.selected = self.flat_nodes.len() - 1;
+                }
+                Action::None
+            }
+            Msg::Collapse => {
+                if let Some(node) = self.flat_nodes.get(self.selected) {
+                    if node.has_children {
+                        self.collapsed.insert(node.node_path.clone());
+                        self.rebuild_preserve_selection(manifest);
+                    }
+                }
+                Action::None
+            }
+            Msg::Expand => {
+                if let Some(node) = self.flat_nodes.get(self.selected) {
+                    self.collapsed.remove(&node.node_path);
+                    self.rebuild_preserve_selection(manifest);
+                }
+                Action::None
+            }
+            Msg::ToggleExpand => {
+                if let Some(node) = self.flat_nodes.get(self.selected) {
+                    let path = node.node_path.clone();
+                    if self.collapsed.contains(&path) {
+                        self.collapsed.remove(&path);
+                    } else if node.has_children {
+                        self.collapsed.insert(path);
+                    }
+                    self.rebuild_preserve_selection(manifest);
+                }
+                Action::None
+            }
+            Msg::ExpandAll => {
+                self.collapsed.clear();
+                self.rebuild_preserve_selection(manifest);
+                Action::None
+            }
+            Msg::CollapseAll => {
+                // Collapse all condition nodes that have expandable children
+                for i in 0..manifest.policy.tree.len() {
+                    if let Node::Condition { children, .. } = &manifest.policy.tree[i] {
+                        if children.len() > 1
+                            || (children.len() == 1
+                                && !matches!(&children[0], Node::Decision(_)))
+                        {
+                            self.collapsed.insert(vec![i]);
+                        }
+                    }
+                }
+                self.rebuild_preserve_selection(manifest);
+                Action::None
+            }
+            Msg::Edit => {
+                let Some(node) = self.flat_nodes.get(self.selected) else {
+                    return Action::None;
+                };
+                if node.is_root {
+                    return Action::Flash("Use 'a' to add rules".into());
+                }
+                if node.read_only {
+                    return Action::Flash("Included rules are read-only".into());
+                }
+                let path = node.node_path.clone();
+                if node.is_leaf {
+                    // Inline leaf (condition->decision) or bare decision: edit effect.
+                    Action::RunForm(FormRequest::EditDecision { path })
+                } else {
+                    // Non-leaf condition: edit the observable/pattern.
+                    Action::RunForm(FormRequest::EditCondition { path })
+                }
+            }
+            Msg::Delete => {
+                let Some(node) = self.flat_nodes.get(self.selected) else {
+                    return Action::None;
+                };
+                if node.is_root {
+                    return Action::Flash("Cannot delete root node".into());
+                }
+                if node.read_only {
+                    return Action::Flash("Included rules are read-only".into());
+                }
+                let path = node.node_path.clone();
+                if path.len() == 1 {
+                    // Top-level node — remove directly
+                    if path[0] < manifest.policy.tree.len() {
+                        manifest.policy.tree.remove(path[0]);
+                        self.rebuild(manifest);
+                        return Action::Modified;
+                    }
+                } else if path.len() >= 2 {
+                    // Child node — remove from parent's children
+                    let parent_path = &path[..path.len() - 1];
+                    let child_idx = *path.last().unwrap();
+                    if let Some(parent) =
+                        Self::get_node_at_path_mut(&mut manifest.policy.tree, parent_path)
+                    {
+                        if let Node::Condition { children, .. } = parent {
+                            if child_idx < children.len() {
+                                children.remove(child_idx);
+                                // If parent has no children left, remove the parent too
+                                if children.is_empty() {
+                                    Self::remove_node_at_path(
+                                        &mut manifest.policy.tree,
+                                        parent_path,
+                                    );
+                                }
+                                self.rebuild(manifest);
+                                return Action::Modified;
+                            }
+                        }
+                    }
+                }
+                Action::None
+            }
+            Msg::Add => {
+                let Some(node) = self.flat_nodes.get(self.selected) else {
+                    return Action::None;
+                };
+                if node.is_root {
+                    // Add a new top-level rule
+                    return Action::RunForm(FormRequest::AddRule);
+                }
+                if node.read_only {
+                    return Action::Flash("Cannot add to included rules".into());
+                }
+                let path = node.node_path.clone();
+                if let Some(tree_node) =
+                    Self::get_node_at_path_mut(&mut manifest.policy.tree, &path)
+                {
+                    if matches!(tree_node, Node::Condition { .. }) {
+                        // Condition node (including inline leaves) — add child
+                        return Action::RunForm(FormRequest::AddChild {
+                            parent_path: path,
+                        });
+                    }
+                }
+                // Bare Decision — add a sibling by targeting the parent condition
+                if path.len() >= 2 {
+                    let parent_path = path[..path.len() - 1].to_vec();
+                    return Action::RunForm(FormRequest::AddChild { parent_path });
+                }
+                Action::Flash("Select a condition node or root to add children".into())
+            }
+            Msg::CopyToInline => {
+                let Some(node) = self.flat_nodes.get(self.selected) else {
+                    return Action::None;
+                };
+                if node.is_root {
+                    return Action::Flash("Cannot copy root node".into());
+                }
+                let path = &node.node_path;
+                // Look up the node in included tree (paths >= 10000) or inline tree
+                let cloned = if path.first().is_some_and(|&i| i >= 10000) {
+                    let idx = path[0] - 10000;
+                    let tree = &self.included.tree;
+                    if path.len() == 1 {
+                        tree.get(idx).cloned()
+                    } else {
+                        let sub_path: Vec<usize> =
+                            std::iter::once(idx).chain(path[1..].iter().copied()).collect();
+                        Self::get_node_at_path_ref(tree, &sub_path).cloned()
+                    }
+                } else {
+                    Self::get_node_at_path_ref(&manifest.policy.tree, path).cloned()
+                };
+
+                match cloned {
+                    Some(mut copied) => {
+                        // Strip source provenance — it's now an inline rule
+                        if let Node::Condition {
+                            ref mut source, ..
+                        } = copied
+                        {
+                            *source = None;
+                        }
+                        manifest.policy.tree.push(copied);
+                        self.rebuild(manifest);
+                        Action::Modified
+                    }
+                    None => Action::Flash("Could not copy node".into()),
+                }
+            }
+        }
+    }
+
+    fn view(&self, frame: &mut Frame, area: Rect, _manifest: &PolicyManifest) {
+        let block = Block::default()
+            .borders(Borders::LEFT | Borders::RIGHT)
+            .border_style(Style::default().fg(Color::DarkGray));
+
+        let inner = block.inner(area);
+        frame.render_widget(block, area);
+
+        let visible_height = inner.height as usize;
+        // Adjust scroll offset to keep selected visible
+        let scroll = if self.selected < self.scroll_offset {
+            self.selected
+        } else if self.selected >= self.scroll_offset + visible_height {
+            self.selected - visible_height + 1
+        } else {
+            self.scroll_offset
+        };
+
+        let lines: Vec<Line> = self
+            .flat_nodes
+            .iter()
+            .enumerate()
+            .skip(scroll)
+            .take(visible_height)
+            .map(|(i, node)| {
+                let indent = if node.depth > 0 {
+                    "  ".repeat(node.depth)
+                } else {
+                    String::new()
+                };
+                let marker = if node.is_root {
+                    if node.has_children {
+                        if self.collapsed.contains(&node.node_path) {
+                            "▶ "
+                        } else {
+                            "▼ "
+                        }
+                    } else {
+                        "  "
+                    }
+                } else if node.has_children {
+                    if self.collapsed.contains(&node.node_path) {
+                        "▶ "
+                    } else {
+                        "▼ "
+                    }
+                } else {
+                    "  "
+                };
+
+                let style = if i == self.selected {
+                    Style::default()
+                        .bg(Color::DarkGray)
+                        .fg(Color::White)
+                        .add_modifier(Modifier::BOLD)
+                } else if node.is_root {
+                    Style::default()
+                        .fg(Color::Cyan)
+                        .add_modifier(Modifier::BOLD)
+                } else if node.read_only {
+                    // Included rules are dimmed
+                    decision_style(node.decision.as_ref())
+                        .add_modifier(Modifier::DIM)
+                } else {
+                    decision_style(node.decision.as_ref())
+                };
+
+                let mut spans = vec![Span::styled(
+                    format!("  {indent}{marker}{}", node.label),
+                    style,
+                )];
+                if let Some(ref src) = node.source {
+                    spans.push(Span::styled(
+                        format!("  ({src})"),
+                        Style::default().fg(Color::DarkGray),
+                    ));
+                }
+                Line::from(spans)
+            })
+            .collect();
+
+        let para = Paragraph::new(lines);
+        frame.render_widget(para, inner);
+    }
+}
+
+impl TreeView {
+    fn rebuild_preserve_selection(&mut self, manifest: &PolicyManifest) {
+        let old_path = self
+            .flat_nodes
+            .get(self.selected)
+            .map(|n| n.node_path.clone());
+        self.rebuild(manifest);
+        // Try to find the same path
+        if let Some(path) = old_path {
+            if let Some(pos) = self.flat_nodes.iter().position(|n| n.node_path == path) {
+                self.selected = pos;
+            }
+        }
+    }
+}
+
+fn format_decision(d: &Decision) -> String {
+    match d {
+        Decision::Allow(Some(sb)) => format!("allow [{}]", sb.0),
+        Decision::Allow(None) => "allow".to_string(),
+        Decision::Deny => "deny".to_string(),
+        Decision::Ask(Some(sb)) => format!("ask [{}]", sb.0),
+        Decision::Ask(None) => "ask".to_string(),
+    }
+}
+
+fn format_condition(obs: &Observable, pat: &Pattern) -> String {
+    let obs_str = match obs {
+        Observable::ToolName => "tool".to_string(),
+        Observable::HookType => "hook".to_string(),
+        Observable::AgentName => "agent".to_string(),
+        Observable::PositionalArg(n) => format!("arg[{n}]"),
+        Observable::HasArg => "has_arg".to_string(),
+        Observable::NamedArg(name) => format!("named({name})"),
+        Observable::NestedField(path) => format!("field({})", path.join(".")),
+        Observable::FsOp => "fs_op".to_string(),
+        Observable::FsPath => "fs_path".to_string(),
+        Observable::NetDomain => "net_domain".to_string(),
+    };
+    let pat_str = format_pattern(pat);
+    format!("{obs_str}={pat_str}")
+}
+
+fn format_pattern(pat: &Pattern) -> String {
+    match pat {
+        Pattern::Wildcard => "*".to_string(),
+        Pattern::Literal(v) => format!("\"{}\"", v.resolve()),
+        Pattern::Regex(re) => format!("/{}/", re.as_str()),
+        Pattern::AnyOf(pats) => {
+            let items: Vec<_> = pats.iter().map(|p| format_pattern(p)).collect();
+            format!("[{}]", items.join(", "))
+        }
+        Pattern::Not(inner) => format!("!{}", format_pattern(inner)),
+        Pattern::Prefix(v) => format!("{}/**", v.resolve()),
+    }
+}
+
+fn decision_style(decision: Option<&Decision>) -> Style {
+    match decision {
+        Some(Decision::Allow(_)) => Style::default().fg(Color::Green),
+        Some(Decision::Deny) => Style::default().fg(Color::Red),
+        Some(Decision::Ask(_)) => Style::default().fg(Color::Yellow),
+        None => Style::default().fg(Color::White),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::policy::manifest_edit;
+    use crate::policy::match_tree::*;
+    use std::collections::HashMap;
+
+    fn empty_manifest() -> PolicyManifest {
+        PolicyManifest {
+            includes: vec![],
+            policy: CompiledPolicy {
+                sandboxes: HashMap::new(),
+                tree: vec![],
+                default_effect: crate::policy::Effect::Deny,
+                default_sandbox: None,
+            },
+        }
+    }
+
+    fn empty_included() -> CompiledPolicy {
+        CompiledPolicy {
+            sandboxes: HashMap::new(),
+            tree: vec![],
+            default_effect: crate::policy::Effect::Deny,
+            default_sandbox: None,
+        }
+    }
+
+    #[test]
+    fn test_root_node_always_present() {
+        let manifest = empty_manifest();
+        let view = TreeView::new(&manifest, &empty_included());
+        assert_eq!(view.flat_nodes.len(), 1);
+        assert!(view.flat_nodes[0].is_root);
+        assert_eq!(view.flat_nodes[0].label, "rules");
+    }
+
+    #[test]
+    fn test_root_node_with_children() {
+        let mut manifest = empty_manifest();
+        manifest_edit::upsert_rule(
+            &mut manifest,
+            manifest_edit::build_tool_rule("Read", Decision::Allow(None)),
+        );
+
+        let view = TreeView::new(&manifest, &empty_included());
+        assert_eq!(view.flat_nodes.len(), 2); // root + one rule
+        assert!(view.flat_nodes[0].is_root);
+        assert!(view.flat_nodes[0].has_children);
+        assert!(!view.flat_nodes[1].is_root);
+    }
+
+    #[test]
+    fn test_edit_inline_leaf_opens_decision_form() {
+        let mut manifest = empty_manifest();
+        manifest_edit::upsert_rule(
+            &mut manifest,
+            manifest_edit::build_tool_rule("Read", Decision::Allow(None)),
+        );
+
+        let mut view = TreeView::new(&manifest, &empty_included());
+        // Select the rule node (index 1, after root) — it's an inline leaf
+        view.selected = 1;
+        assert!(view.flat_nodes[1].is_leaf);
+
+        let action = view.update(Msg::Edit, &mut manifest);
+        assert!(matches!(
+            action,
+            Action::RunForm(FormRequest::EditDecision { .. })
+        ));
+    }
+
+    #[test]
+    fn test_edit_on_root_flashes() {
+        let mut manifest = empty_manifest();
+        let mut view = TreeView::new(&manifest, &empty_included());
+        view.selected = 0; // root
+
+        let action = view.update(Msg::Edit, &mut manifest);
+        assert!(matches!(action, Action::Flash(_)));
+    }
+
+    #[test]
+    fn test_edit_condition_opens_edit_form() {
+        let mut manifest = empty_manifest();
+        manifest_edit::upsert_rule(
+            &mut manifest,
+            manifest_edit::build_exec_rule("gh", &["pr"], Decision::Allow(None)),
+        );
+
+        let mut view = TreeView::new(&manifest, &empty_included());
+        // Select the condition (index 1, after synthetic root)
+        view.selected = 1;
+        assert!(!view.flat_nodes[1].is_leaf);
+
+        let action = view.update(Msg::Edit, &mut manifest);
+        assert!(matches!(
+            action,
+            Action::RunForm(FormRequest::EditCondition { .. })
+        ));
+    }
+
+    #[test]
+    fn test_add_on_root_opens_add_rule_form() {
+        let mut manifest = empty_manifest();
+        let mut view = TreeView::new(&manifest, &empty_included());
+        view.selected = 0; // root
+
+        let action = view.update(Msg::Add, &mut manifest);
+        assert!(matches!(action, Action::RunForm(FormRequest::AddRule)));
+    }
+
+    #[test]
+    fn test_add_on_condition_opens_add_child_form() {
+        let mut manifest = empty_manifest();
+        manifest_edit::upsert_rule(
+            &mut manifest,
+            manifest_edit::build_exec_rule("gh", &["pr"], Decision::Allow(None)),
+        );
+
+        let mut view = TreeView::new(&manifest, &empty_included());
+        // Select the Bash condition (index 1)
+        view.selected = 1;
+
+        let action = view.update(Msg::Add, &mut manifest);
+        assert!(matches!(
+            action,
+            Action::RunForm(FormRequest::AddChild { .. })
+        ));
+    }
+
+    #[test]
+    fn test_delete_rule() {
+        let mut manifest = empty_manifest();
+        manifest_edit::upsert_rule(
+            &mut manifest,
+            manifest_edit::build_tool_rule("Read", Decision::Allow(None)),
+        );
+
+        let mut view = TreeView::new(&manifest, &empty_included());
+        assert_eq!(view.flat_nodes.len(), 2); // root + rule
+        view.selected = 1; // select the rule
+
+        let action = view.update(Msg::Delete, &mut manifest);
+        assert!(matches!(action, Action::Modified));
+        assert_eq!(view.flat_nodes.len(), 1); // just root
+        assert!(manifest.policy.tree.is_empty());
+    }
+
+    #[test]
+    fn test_delete_root_blocked() {
+        let mut manifest = empty_manifest();
+        let mut view = TreeView::new(&manifest, &empty_included());
+        view.selected = 0;
+
+        let action = view.update(Msg::Delete, &mut manifest);
+        assert!(matches!(action, Action::Flash(_)));
+    }
+
+    #[test]
+    fn test_delete_child_node() {
+        let mut manifest = empty_manifest();
+        manifest_edit::upsert_rule(
+            &mut manifest,
+            manifest_edit::build_exec_rule("gh", &[], Decision::Allow(None)),
+        );
+        manifest_edit::upsert_rule(
+            &mut manifest,
+            manifest_edit::build_exec_rule("rm", &[], Decision::Deny),
+        );
+
+        let mut view = TreeView::new(&manifest, &empty_included());
+
+        // Find the "gh" node
+        let gh_idx = view
+            .flat_nodes
+            .iter()
+            .position(|n| n.label.contains("gh"))
+            .expect("should find gh node");
+        view.selected = gh_idx;
+
+        let action = view.update(Msg::Delete, &mut manifest);
+        assert!(matches!(action, Action::Modified));
+
+        let has_gh = view.flat_nodes.iter().any(|n| n.label.contains("gh"));
+        assert!(!has_gh, "gh node should be deleted");
+        let has_rm = view.flat_nodes.iter().any(|n| n.label.contains("rm"));
+        assert!(has_rm, "rm node should still exist");
+    }
+
+    #[test]
+    fn test_navigation() {
+        let mut manifest = empty_manifest();
+        manifest_edit::upsert_rule(
+            &mut manifest,
+            manifest_edit::build_tool_rule("Read", Decision::Allow(None)),
+        );
+        manifest_edit::upsert_rule(
+            &mut manifest,
+            manifest_edit::build_tool_rule("Write", Decision::Deny),
+        );
+
+        let mut view = TreeView::new(&manifest, &empty_included());
+        assert_eq!(view.selected, 0);
+
+        view.update(Msg::MoveDown, &mut manifest);
+        assert_eq!(view.selected, 1);
+
+        view.update(Msg::MoveUp, &mut manifest);
+        assert_eq!(view.selected, 0);
+
+        view.update(Msg::JumpBottom, &mut manifest);
+        assert_eq!(view.selected, view.flat_nodes.len() - 1);
+
+        view.update(Msg::JumpTop, &mut manifest);
+        assert_eq!(view.selected, 0);
+    }
+}

--- a/clash/src/tui/widgets.rs
+++ b/clash/src/tui/widgets.rs
@@ -1,0 +1,283 @@
+//! Shared ratatui widgets: tab bar, status bar, overlays.
+
+use ratatui::Frame;
+use ratatui::layout::{Alignment, Constraint, Layout, Rect};
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, Clear, Paragraph};
+
+use super::app::Tab;
+
+/// Render the tab bar at the top of the screen.
+pub fn render_tab_bar(frame: &mut Frame, area: Rect, active_tab: &Tab, dirty: bool) {
+    let tabs = [
+        (Tab::Tree, "Tree"),
+        (Tab::Sandboxes, "Sandboxes"),
+        (Tab::Includes, "Includes"),
+        (Tab::Settings, "Settings"),
+    ];
+
+    let mut spans = Vec::new();
+    spans.push(Span::raw("  "));
+    for (i, (tab, label)) in tabs.iter().enumerate() {
+        if i > 0 {
+            spans.push(Span::styled("  ", Style::default().fg(Color::DarkGray)));
+        }
+        if tab == active_tab {
+            spans.push(Span::styled(
+                format!(" {label} "),
+                Style::default()
+                    .fg(Color::White)
+                    .bg(Color::Blue)
+                    .add_modifier(Modifier::BOLD),
+            ));
+        } else {
+            spans.push(Span::styled(
+                format!(" {label} "),
+                Style::default().fg(Color::Gray),
+            ));
+        }
+    }
+
+    let dirty_indicator = if dirty { " [modified]" } else { "" };
+    spans.push(Span::styled(
+        format!("    ? help{dirty_indicator}"),
+        Style::default().fg(Color::DarkGray),
+    ));
+
+    let bar = Paragraph::new(Line::from(spans)).style(Style::default().bg(Color::Black));
+    frame.render_widget(bar, area);
+}
+
+/// Render the status/hint bar at the bottom.
+pub fn render_status_bar(
+    frame: &mut Frame,
+    area: Rect,
+    hints: &[(&str, &str)],
+    flash: Option<&str>,
+) {
+    let line = if let Some(msg) = flash {
+        Line::from(Span::styled(
+            format!("  {msg}"),
+            Style::default()
+                .fg(Color::Green)
+                .add_modifier(Modifier::BOLD),
+        ))
+    } else {
+        let spans: Vec<Span> = hints
+            .iter()
+            .enumerate()
+            .flat_map(|(i, (key, desc))| {
+                let mut s = Vec::new();
+                if i > 0 {
+                    s.push(Span::styled("  ", Style::default().fg(Color::DarkGray)));
+                }
+                s.push(Span::styled(
+                    format!("{key}"),
+                    Style::default()
+                        .fg(Color::Yellow)
+                        .add_modifier(Modifier::BOLD),
+                ));
+                s.push(Span::styled(
+                    format!(" {desc}"),
+                    Style::default().fg(Color::Gray),
+                ));
+                s
+            })
+            .collect();
+        Line::from(spans)
+    };
+
+    let bar = Paragraph::new(line).style(Style::default().bg(Color::Black));
+    frame.render_widget(bar, area);
+}
+
+/// Render a centered help popup listing all keybindings.
+pub fn render_help_overlay(frame: &mut Frame, area: Rect) {
+    let popup = centered_rect(60, 70, area);
+    frame.render_widget(Clear, popup);
+
+    let help_text = vec![
+        Line::from(Span::styled(
+            "Keybindings",
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
+        )),
+        Line::from(""),
+        Line::from(vec![
+            Span::styled("1-4    ", Style::default().fg(Color::Yellow)),
+            Span::raw("Switch tabs"),
+        ]),
+        Line::from(vec![
+            Span::styled("j/k    ", Style::default().fg(Color::Yellow)),
+            Span::raw("Move down/up"),
+        ]),
+        Line::from(vec![
+            Span::styled("h/l    ", Style::default().fg(Color::Yellow)),
+            Span::raw("Collapse/expand (tree) or focus (sandboxes)"),
+        ]),
+        Line::from(vec![
+            Span::styled("g/G    ", Style::default().fg(Color::Yellow)),
+            Span::raw("Jump to top/bottom"),
+        ]),
+        Line::from(vec![
+            Span::styled("Space  ", Style::default().fg(Color::Yellow)),
+            Span::raw("Toggle expand/collapse"),
+        ]),
+        Line::from(vec![
+            Span::styled("e/Tab  ", Style::default().fg(Color::Yellow)),
+            Span::raw("Cycle effect on selected rule"),
+        ]),
+        Line::from(vec![
+            Span::styled("a      ", Style::default().fg(Color::Yellow)),
+            Span::raw("Add new item"),
+        ]),
+        Line::from(vec![
+            Span::styled("d      ", Style::default().fg(Color::Yellow)),
+            Span::raw("Delete selected item"),
+        ]),
+        Line::from(vec![
+            Span::styled("J/K    ", Style::default().fg(Color::Yellow)),
+            Span::raw("Move item up/down (includes)"),
+        ]),
+        Line::from(vec![
+            Span::styled("s      ", Style::default().fg(Color::Yellow)),
+            Span::raw("Save (review diff first)"),
+        ]),
+        Line::from(vec![
+            Span::styled("q/Esc  ", Style::default().fg(Color::Yellow)),
+            Span::raw("Quit (confirms if unsaved)"),
+        ]),
+        Line::from(vec![
+            Span::styled("?      ", Style::default().fg(Color::Yellow)),
+            Span::raw("Toggle this help"),
+        ]),
+        Line::from(""),
+        Line::from(Span::styled(
+            "Press any key to close",
+            Style::default().fg(Color::DarkGray),
+        )),
+    ];
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Color::Cyan))
+        .title(" Help ");
+
+    let para = Paragraph::new(help_text)
+        .block(block)
+        .alignment(Alignment::Left);
+    frame.render_widget(para, popup);
+}
+
+/// Render a confirmation dialog.
+pub fn render_confirm_overlay(frame: &mut Frame, area: Rect, prompt: &str) {
+    let popup = centered_rect(50, 20, area);
+    frame.render_widget(Clear, popup);
+
+    let text = vec![
+        Line::from(""),
+        Line::from(Span::raw(prompt)),
+        Line::from(""),
+        Line::from(vec![
+            Span::styled(
+                "y",
+                Style::default()
+                    .fg(Color::Green)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::raw(" yes  "),
+            Span::styled(
+                "n",
+                Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),
+            ),
+            Span::raw(" no"),
+        ]),
+    ];
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Color::Yellow))
+        .title(" Confirm ");
+
+    let para = Paragraph::new(text)
+        .block(block)
+        .alignment(Alignment::Center);
+    frame.render_widget(para, popup);
+}
+
+/// Render a scrollable diff overlay for save review.
+pub fn render_diff_overlay(frame: &mut Frame, area: Rect, diff_lines: &[DiffLine], scroll: usize) {
+    let popup = centered_rect(80, 80, area);
+    frame.render_widget(Clear, popup);
+
+    let visible_height = popup.height.saturating_sub(4) as usize; // borders + title + footer
+    let visible_lines: Vec<Line> = diff_lines
+        .iter()
+        .skip(scroll)
+        .take(visible_height)
+        .map(|dl| match dl {
+            DiffLine::Context(s) => {
+                Line::from(Span::styled(s.as_str(), Style::default().fg(Color::Gray)))
+            }
+            DiffLine::Add(s) => {
+                Line::from(Span::styled(s.as_str(), Style::default().fg(Color::Green)))
+            }
+            DiffLine::Remove(s) => {
+                Line::from(Span::styled(s.as_str(), Style::default().fg(Color::Red)))
+            }
+            DiffLine::Header(s) => Line::from(Span::styled(
+                s.as_str(),
+                Style::default()
+                    .fg(Color::Cyan)
+                    .add_modifier(Modifier::BOLD),
+            )),
+        })
+        .collect();
+
+    let scroll_info = if diff_lines.len() > visible_height {
+        format!(
+            " [{}-{}/{}] ",
+            scroll + 1,
+            (scroll + visible_height).min(diff_lines.len()),
+            diff_lines.len()
+        )
+    } else {
+        String::new()
+    };
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Color::Cyan))
+        .title(" Save Review — y to confirm, n/Esc to cancel ")
+        .title_bottom(Line::from(format!(" j/k scroll{scroll_info}")).alignment(Alignment::Right));
+
+    let para = Paragraph::new(visible_lines).block(block);
+    frame.render_widget(para, popup);
+}
+
+/// A line in a diff display.
+pub enum DiffLine {
+    Context(String),
+    Add(String),
+    Remove(String),
+    Header(String),
+}
+
+/// Compute a centered rect within `area`.
+pub fn centered_rect(percent_x: u16, percent_y: u16, area: Rect) -> Rect {
+    let vertical = Layout::vertical([
+        Constraint::Percentage((100 - percent_y) / 2),
+        Constraint::Percentage(percent_y),
+        Constraint::Percentage((100 - percent_y) / 2),
+    ])
+    .split(area);
+
+    Layout::horizontal([
+        Constraint::Percentage((100 - percent_x) / 2),
+        Constraint::Percentage(percent_x),
+        Constraint::Percentage((100 - percent_x) / 2),
+    ])
+    .split(vertical[1])[1]
+}


### PR DESCRIPTION
## Summary

- Adds a full ratatui-based TUI for `clash policy edit`, replacing the plain `$EDITOR` workflow as the default
- Four tabbed views cover all policy.json sections: **Tree**, **Sandboxes**, **Includes**, **Settings**
- Built on the Elm Architecture (TEA) `Component` trait (`handle_key → update → view`) for testable, composable UI components
- Inline form overlays for structured input — no raw-mode exit needed
- Included `.star` rules displayed read-only with source provenance; copy-to-inline (`c`) to promote them
- Tool-aware effect filtering (e.g. Bash only shows allow/deny, not ask)
- Diff review overlay before saving
- `--raw` flag falls back to `$EDITOR` for users who prefer it
- 43 unit tests covering component state transitions and form apply logic

## Test plan

- [x] `cargo build -p clash` compiles cleanly
- [x] `cargo test -p clash -- tui` — all 43 tests pass
- [x] `clash policy edit` launches the TUI with current policy
- [x] `clash policy edit --raw` falls back to $EDITOR
- [x] Navigate tree with j/k, expand/collapse with h/l/Space
- [x] Add/edit/delete tree rules, sandbox definitions, sandbox rules, includes
- [x] Included rules show source file and are read-only; `c` copies to inline
- [x] Save (s) shows diff review; confirm writes policy.json
- [x] Tab between Tree/Sandboxes/Includes/Settings views