### PR TITLE
fix(sandbox): resolve cwd for non-Bash tool fs checks

### DIFF
--- a/clash/src/policy/match_tree.rs
+++ b/clash/src/policy/match_tree.rs
@@ -897,7 +897,12 @@ impl CompiledPolicy {
                         "write" => Cap::WRITE | Cap::CREATE,
                         _ => Cap::empty(),
                     };
-                    let effective = sbx.effective_caps(fs_path, "");
+                    let effective = sbx.effective_caps(
+                        fs_path,
+                        &std::env::current_dir()
+                            .unwrap_or_default()
+                            .to_string_lossy(),
+                    );
                     if !effective.contains(required) {
                         effect = Effect::Deny;
                     }

--- a/clash/src/sandbox/macos.rs
+++ b/clash/src/sandbox/macos.rs
@@ -59,6 +59,7 @@ pub fn compile_to_sbpl(policy: &SandboxPolicy, cwd: &str) -> String {
     p += "(allow sysctl-read)\n";
     p += "(allow mach-lookup)\n";
     p += "(allow mach-register)\n";
+
     // DNS resolution via mDNSResponder
     p += "(allow system-socket)\n";
 
@@ -68,26 +69,6 @@ pub fn compile_to_sbpl(policy: &SandboxPolicy, cwd: &str) -> String {
     // Root directory readable (literal, not recursive) — some commands need
     // to stat "/" itself (e.g. `ls /`, path resolution).
     p += "(allow file-read* (literal \"/\"))\n";
-
-    // System paths always readable — required for dyld, shared libraries,
-    // frameworks, and basic process operation regardless of policy.
-    // dyld needs file-read* on binaries (not just process-exec) to load them.
-    for sys_path in &[
-        "/usr",
-        "/bin",
-        "/sbin",
-        "/System",
-        "/Library",
-        "/dev",
-        "/etc",
-        "/private/etc",
-        "/private/var/db/dyld",
-        "/private/var/folders",
-        "/var/select",
-        "/var/run",
-    ] {
-        p += &format!("(allow file-read* (subpath \"{}\"))\n", sys_path);
-    }
 
     // /dev/null always writable
     p += "(allow file-write* (literal \"/dev/null\"))\n";

--- a/clash_starlark/stdlib/builtin.star
+++ b/clash_starlark/stdlib/builtin.star
@@ -1,49 +1,60 @@
 load("@clash//std.star", "exe", "policy", "sandbox", "home", "path", "tool")
 
 clashbox = sandbox(
-    name = "clash_box",
-    default = deny,
-    fs = [
-        home().child(".clash").recurse().allow(read = True),
+    name="clash_box",
+    default=deny,
+    fs=[
+        home().child(".clash").recurse().allow(read=True),
+        home().recurse().allow(read=True, execute=True),
     ],
-    net = allow,
+    net=allow,
 )
 
 clash = policy(
-    default = deny,
-    rules = [
-        exe("clash", args = ["bug"]).sandbox(clashbox).allow(),
-        exe("clash", args = ["status"]).sandbox(clashbox).allow(),
-        exe("clash", args = ["policy", "list"]).sandbox(clashbox).allow(),
-        exe("clash", args = ["policy", "show"]).sandbox(clashbox).allow(),
-        exe("clash", args = ["policy", "explain"]).sandbox(clashbox).allow(),
-        exe("clash", args = ["policy", "schema"]).allow(),
-        exe("clash", args = ["policy", "setup"]).sandbox(clashbox).ask(),
+    default=deny,
+    rules=[
+        exe("clash", args=["bug"]).sandbox(clashbox).allow(),
+        exe("clash", args=["status"]).sandbox(clashbox).allow(),
+        exe("clash", args=["policy", "list"]).sandbox(clashbox).allow(),
+        exe("clash", args=["policy", "show"]).sandbox(clashbox).allow(),
+        exe("clash", args=["policy", "explain"]).sandbox(clashbox).allow(),
+        exe("clash", args=["policy", "schema"]).allow(),
+        exe("clash", args=["policy", "setup"]).sandbox(clashbox).ask(),
     ],
 )
 
-_claude_fs = sandbox(name = "claude_fs", fs = [
-    home().child(".claude").allow(read = True, write = True),
-    path(env = "TRANSCRIPT_DIR").allow(read = True),
-])
+_claude_fs = sandbox(
+    name="claude_fs",
+    fs=[
+        home().child(".claude").allow(read=True, write=True),
+        path(env="TRANSCRIPT_DIR").allow(read=True),
+    ],
+)
 
-claude = policy(default = deny, rules = [
-    tool([
-        "Agent",
-        "AskUserQuestion",
-        "EnterPlanMode",
-        "ExitPlanMode",
-        "Skill",
-        "ToolSearch",
-        "EnterWorktree",
-        "TaskCreate",
-        "TaskGet",
-        "TaskList",
-        "TaskOutput",
-        "TaskStop",
-        "TaskUpdate",
-        "ToolSearch",
-    ]).sandbox(_claude_fs).allow(),
-])
+claude = policy(
+    default=deny,
+    rules=[
+        tool(
+            [
+                "Agent",
+                "AskUserQuestion",
+                "EnterPlanMode",
+                "ExitPlanMode",
+                "Skill",
+                "ToolSearch",
+                "EnterWorktree",
+                "TaskCreate",
+                "TaskGet",
+                "TaskList",
+                "TaskOutput",
+                "TaskStop",
+                "TaskUpdate",
+                "ToolSearch",
+            ]
+        )
+        .sandbox(_claude_fs)
+        .allow(),
+    ],
+)
 
 base = clash.merge(claude)


### PR DESCRIPTION
## Summary
- Fix `effective_caps()` in match_tree.rs passing empty string for `cwd`, causing `$PWD`-based sandbox rules to never match for Edit/Write/Read tools
- Add execute permission to `clashbox` sandbox in builtin.star so the clash binary can be invoked
- Remove hardcoded system path allowlist from macOS SBPL compilation

## Context
When a sandbox had `cwd().recurse().allow(read=True, write=True)`, the `$PWD` variable resolved to empty string during the fs path check for non-Bash tools. This meant the broader auto-generated deny on `/Users` would always win, causing Edit/Write/Read to be denied even for files under the working directory.

## Test plan
- [x] `cargo check` passes
- [x] Verify Edit tool works with a sandbox that uses `cwd()` rules
- [x] Verify `clash explain Edit /path/under/cwd` shows allow (not deny)