### PR TITLE
docs: replace s-expression references with Starlark syntax

### DIFF
--- a/clash/src/audit.rs
+++ b/clash/src/audit.rs
@@ -378,7 +378,7 @@ fn deduplicated_suggestions(violations: &[SandboxViolation]) -> Vec<String> {
         let dir = parent_dir_suggestion(&v.path);
         if seen_dirs.insert(dir.clone()) {
             suggestions.push(format!(
-                "(allow (fs (or read write create) (subpath \"{}\")))",
+                "path(\"{}\").allow(read=True, write=True, create=True)",
                 dir
             ));
         }

--- a/clash/src/network_hints.rs
+++ b/clash/src/network_hints.rs
@@ -139,14 +139,15 @@ fn build_network_hint() -> String {
         "This is likely because the command ran inside a clash sandbox that blocks network access by default.",
         "",
         "How to fix:",
-        "- Add `(net allow)` to the relevant sandbox block in the policy file",
+        "- Add `net = allow` to the relevant sandbox() in the policy file",
         "- Or run: `clash allow web` to broadly enable network access",
         "- Use `/clash:edit` to help the user modify their policy interactively",
         "",
         "Example sandbox policy with network enabled:",
-        "  (sandbox \"my-sandbox\"",
-        "    (fs read (subpath (env PWD)))",
-        "    (net allow))",
+        "  my_sandbox = sandbox(",
+        "    fs = [cwd().allow(read=True)],",
+        "    net = allow,",
+        "  )",
         "",
         "Agent instructions:",
         "- Tell the user the network error is likely caused by the clash sandbox",
@@ -233,7 +234,7 @@ mod tests {
     fn test_build_network_hint_contains_key_info() {
         let hint = build_network_hint();
         assert!(hint.contains("SANDBOX_NETWORK_HINT"));
-        assert!(hint.contains("net allow"));
+        assert!(hint.contains("net = allow"));
         assert!(hint.contains("clash allow web"));
         assert!(hint.contains("/clash:edit"));
         assert!(hint.contains("Do NOT retry"));

--- a/clash/src/sandbox_fs_hints.rs
+++ b/clash/src/sandbox_fs_hints.rs
@@ -459,7 +459,7 @@ fn build_fs_hint(blocked: &[BlockedPath]) -> String {
 
     for bp in blocked {
         lines.push(format!(
-            "  (allow (fs (or read write create) (subpath \"{}\")))",
+            "  path(\"{}\").allow(read=True, write=True, create=True)",
             bp.suggested_dir
         ));
     }

--- a/clash/src/schema.rs
+++ b/clash/src/schema.rs
@@ -82,27 +82,27 @@ fn policy_section() -> SchemaSection {
         description: "Starlark policy file (policy.star) — defines rules compiled to JSON IR",
         fields: vec![
             SchemaField {
-                key: "(default effect \"policy-name\")",
+                key: "policy(default=effect)",
                 type_name: "form",
-                description: "Sets the default effect (allow/deny/ask) and names the active policy",
-                default: Some(serde_json::json!("(default deny \"main\")")),
+                description: "Sets the default effect (allow/deny/ask) via the policy() constructor",
+                default: Some(serde_json::json!("policy(default=deny)")),
                 values: None,
                 required: true,
                 fields: None,
             },
             SchemaField {
-                key: "(policy \"name\" ...rules)",
+                key: "def main(): return policy(...)",
                 type_name: "form",
-                description: "A named policy block containing rules and (include ...) directives",
+                description: "A main() function that returns a policy() value with rules",
                 default: None,
                 values: None,
                 required: true,
                 fields: None,
             },
             SchemaField {
-                key: "(include \"other-policy\")",
+                key: "load(\"@clash//lib.star\", ...)",
                 type_name: "form",
-                description: "Import rules from another policy block by name",
+                description: "Import rules or helpers from another Starlark module",
                 default: None,
                 values: None,
                 required: false,
@@ -232,13 +232,13 @@ fn audit_section() -> SchemaSection {
 
 fn rule_syntax() -> RuleSyntax {
     RuleSyntax {
-        format: "(effect (capability ...))",
+        format: "exe(\"bin\").allow() / cwd().allow(read=True) / domains({...})",
         effects: vec!["allow", "deny", "ask"],
         domains: vec![
             SchemaField {
                 key: "exec",
                 type_name: "capability",
-                description: "Command execution: (exec [binary] [args...]). Matches Bash tool invocations.",
+                description: "Command execution: exe(\"binary\", args=[...]). Matches Bash tool invocations.",
                 default: None,
                 values: None,
                 required: false,
@@ -247,7 +247,7 @@ fn rule_syntax() -> RuleSyntax {
             SchemaField {
                 key: "fs",
                 type_name: "capability",
-                description: "Filesystem access: (fs [operation] [path-filter]). Matches Read, Write, Edit, Glob, Grep tools.",
+                description: "Filesystem access: cwd().allow(read=True, write=True). Matches Read, Write, Edit, Glob, Grep tools.",
                 default: None,
                 values: None,
                 required: false,
@@ -256,7 +256,7 @@ fn rule_syntax() -> RuleSyntax {
             SchemaField {
                 key: "net",
                 type_name: "capability",
-                description: "Network access: (net [domain-pattern]). Matches WebFetch and WebSearch tools.",
+                description: "Network access: domains({\"example.com\": allow}). Matches WebFetch and WebSearch tools.",
                 default: None,
                 values: None,
                 required: false,
@@ -265,7 +265,7 @@ fn rule_syntax() -> RuleSyntax {
             SchemaField {
                 key: "tool",
                 type_name: "capability",
-                description: "Agent tool access: (tool [name-pattern]). Matches tools not covered by exec/fs/net (e.g. Skill, Task, AskUserQuestion, EnterPlanMode, ExitPlanMode).",
+                description: "Agent tool access: tool([\"Name\"]). Matches tools not covered by exec/fs/net (e.g. Skill, Task, AskUserQuestion, EnterPlanMode, ExitPlanMode).",
                 default: None,
                 values: None,
                 required: false,
@@ -301,7 +301,7 @@ fn rule_syntax() -> RuleSyntax {
                 fields: None,
             },
             SchemaField {
-                key: "(or p1 p2 ...)",
+                key: "any_of([p1, p2, ...])",
                 type_name: "combinator",
                 description: "Match any of the listed patterns",
                 default: None,
@@ -310,7 +310,7 @@ fn rule_syntax() -> RuleSyntax {
                 fields: None,
             },
             SchemaField {
-                key: "(not p)",
+                key: "not_(p)",
                 type_name: "combinator",
                 description: "Negate a pattern",
                 default: None,
@@ -321,9 +321,9 @@ fn rule_syntax() -> RuleSyntax {
         ],
         path_filters: vec![
             SchemaField {
-                key: "(subpath expr)",
+                key: "path(\"/dir\").recurse()",
                 type_name: "filter",
-                description: "Recursive subtree match. expr can be \"path\" or (env VAR).",
+                description: "Recursive subtree match. Use path(env=\"VAR\") for environment variables.",
                 default: None,
                 values: None,
                 required: false,

--- a/clash/src/trace.rs
+++ b/clash/src/trace.rs
@@ -658,7 +658,7 @@ mod tests {
                 tool_use_id: "tu-123".into(),
                 tool_name: Some("Bash".into()),
                 effect: "allow".into(),
-                reason: Some("matched rule: (allow (exec *))".into()),
+                reason: Some("matched rule: exe(\"*\").allow()".into()),
             }),
         )
         .unwrap();
@@ -945,7 +945,7 @@ mod tests {
                 tool_use_id: "tu-bash-1".into(),
                 tool_name: Some("Bash".into()),
                 effect: "allow".into(),
-                reason: Some("matched rule: (allow (exec *))".into()),
+                reason: Some("matched rule: exe(\"*\").allow()".into()),
             }),
         )
         .unwrap();

--- a/clester/src/assertions.rs
+++ b/clester/src/assertions.rs
@@ -320,13 +320,13 @@ mod tests {
             exit_code: None,
             no_decision: None,
             reason_contains: None,
-            stdout_contains: Some("(allow".into()),
+            stdout_contains: Some("allow".into()),
             stderr_contains: None,
         };
         let result = HookResult {
             exit_code: 0,
             output: None,
-            stdout: "(allow (exec \"git\" *))".into(),
+            stdout: "exe(\"git\").allow()".into(),
             stderr: String::new(),
         };
 
@@ -341,13 +341,13 @@ mod tests {
             exit_code: None,
             no_decision: None,
             reason_contains: None,
-            stdout_contains: Some("(allow".into()),
+            stdout_contains: Some("allow".into()),
             stderr_contains: None,
         };
         let result = HookResult {
             exit_code: 0,
             output: None,
-            stdout: "(deny (exec \"git\" *))".into(),
+            stdout: "exe(\"git\").deny()".into(),
             stderr: String::new(),
         };
 

--- a/clester/src/environment.rs
+++ b/clester/src/environment.rs
@@ -275,45 +275,45 @@ mod tests {
     #[test]
     fn test_project_policy_star_file_written() {
         let config = SettingsConfig::default();
-        let user_sexpr = r#"(default deny "main")
-(policy "main"
-  (allow (exec "git" *)))"#;
-        let project_sexpr = r#"(default deny "proj")
-(policy "proj"
-  (deny (exec "git" "push" *)))"#;
+        let user_star = r#"load("@clash//std.star", "exe", "policy")
+def main():
+    return policy(default=deny, rules=[exe("git").allow()])"#;
+        let project_star = r#"load("@clash//std.star", "exe", "policy")
+def main():
+    return policy(default=deny, rules=[exe("git", args=["push"]).deny()])"#;
         let clash = ClashConfig {
             policy: None,
             policy_raw: None,
-            policy_star: Some(user_sexpr.to_string()),
-            project_policy_star: Some(project_sexpr.to_string()),
+            policy_star: Some(user_star.to_string()),
+            project_policy_star: Some(project_star.to_string()),
         };
 
         let env = TestEnvironment::setup(&config, Some(&clash)).unwrap();
         let user_content =
             std::fs::read_to_string(env.home_dir.join(".clash/policy.star")).unwrap();
-        assert!(user_content.contains("(allow (exec"));
+        assert!(user_content.contains("exe(\"git\").allow()"));
 
         let project_content =
             std::fs::read_to_string(env.project_dir.join(".clash/policy.star")).unwrap();
-        assert!(project_content.contains("(deny (exec"));
+        assert!(project_content.contains("exe(\"git\""));
     }
 
     #[test]
     fn test_policy_star_file_written() {
         let config = SettingsConfig::default();
-        let sexpr = r#"(default deny "main")
-(policy "main"
-  (allow (exec "git" *)))"#;
+        let star = r#"load("@clash//std.star", "exe", "policy")
+def main():
+    return policy(default=deny, rules=[exe("git").allow()])"#;
         let clash = ClashConfig {
             policy: None,
             policy_raw: None,
-            policy_star: Some(sexpr.to_string()),
+            policy_star: Some(star.to_string()),
             project_policy_star: None,
         };
 
         let env = TestEnvironment::setup(&config, Some(&clash)).unwrap();
         let content = std::fs::read_to_string(env.home_dir.join(".clash/policy.star")).unwrap();
-        assert!(content.contains("(default deny"));
-        assert!(content.contains("(allow (exec"));
+        assert!(content.contains("default=deny"));
+        assert!(content.contains("exe(\"git\").allow()"));
     }
 }

--- a/clester/src/script.rs
+++ b/clester/src/script.rs
@@ -41,13 +41,11 @@ pub struct ClashConfig {
     /// Starlark policy string written to ~/.clash/policy.star.
     /// When present, this is the primary policy engine input.
     #[serde(default)]
-    #[serde(alias = "policy_sexpr")]
     pub policy_star: Option<String>,
 
     /// Starlark policy string written to <project>/.clash/policy.star (project-level).
     /// When present alongside `policy_star`, enables multi-level policy testing.
     #[serde(default)]
-    #[serde(alias = "project_policy_sexpr")]
     pub project_policy_star: Option<String>,
 }
 
@@ -478,16 +476,16 @@ clash:
 
 steps:
   - name: add allow rule
-    command: policy allow '(exec "npm" *)' --dry-run
+    command: policy allow --bin npm --dry-run
     expect:
       exit_code: 0
-      stdout_contains: "(allow (exec"
+      stdout_contains: "allow"
 "#;
 
         let script = TestScript::from_str(yaml).unwrap();
         assert_eq!(
             script.steps[0].command.as_deref(),
-            Some("policy allow '(exec \"npm\" *)' --dry-run")
+            Some("policy allow --bin npm --dry-run")
         );
         assert!(script.steps[0].hook.is_none());
         assert!(script.steps[0].expect.stdout_contains.is_some());


### PR DESCRIPTION
## Summary
- Update schema.rs policy section and rule syntax descriptions from s-expression format to Starlark
- Update sandbox fs/network hint suggestions shown to agents (audit.rs, sandbox_fs_hints.rs, network_hints.rs)
- Update clester test fixtures (environment.rs, assertions.rs, script.rs) to use Starlark syntax
- Remove unused `policy_sexpr` / `project_policy_sexpr` serde aliases from clester

Excludes `site/versions/`, brush projects, migration guides, and ADRs (which intentionally document the old format).

## Test plan
- [x] `cargo check` passes
- [x] `cargo test` passes (updated test strings)
- [x] `just clester` passes