### PR TITLE
fix: less confusing default policy

### DIFF
--- a/clash/src/default_policy.star
+++ b/clash/src/default_policy.star
@@ -1,22 +1,45 @@
 load("@clash//builtin.star", "base")
-load("@clash//std.star", "tool", "policy", "sandbox", "cwd", "home")
-load("@clash//rust.star", "rust")
-load("@clash//python.star", "python")
-load("@clash//node.star", "node")
+load("@clash//std.star", "exe", "tool", "policy", "sandbox", "cwd", "home", "tempdir")
 
-_fs_access = sandbox(
+# Default sandbox for all Bash commands
+_default_box = sandbox(
+    name = "default",
+    default = deny,
+    fs = [
+        cwd(follow_worktrees = True).allow(read = True, write = True, execute = True),
+        tempdir().allow(),
+        home().allow(read = True, execute = True),
+    ],
+)
+
+# Tighter sandbox for Claude fs tools (no execute, scoped to cwd + ~/.claude)
+_fs_box = sandbox(
     name = "cwd",
     fs = [
         cwd(follow_worktrees = True).allow(read = True, write = True),
+        home().child(".claude").allow(read = True, write = True),
     ],
 )
 
 def main():
-    my_policy = policy(default = deny, rules = [
-        tool(["Read", "Glob", "Grep"]).sandbox(_fs_access).allow(),
-        tool(["Write", "Edit", "NotebookEdit"]).sandbox(_fs_access).allow(),
-        node,
-        python,
-        rust,
-    ])
+    my_policy = policy(
+        default = ask,
+        default_sandbox = _default_box,
+        rules = [
+            # Claude fs tools
+            tool(["Read", "Glob", "Grep"]).sandbox(_fs_box).allow(),
+            tool(["Write", "Edit", "NotebookEdit"]).sandbox(_fs_box).allow(),
+
+            # Network tools — prompt user
+            tool(["WebFetch", "WebSearch"]).ask(),
+
+            # Deny destructive git ops
+            exe("git", args=["push", "--force"]).deny(),
+            exe("git", args=["push", "--force-with-lease"]).deny(),
+            exe("git", args=["reset", "--hard"]).deny(),
+
+            # All other commands — sandboxed
+            exe().sandbox(_default_box).allow(),
+        ],
+    )
     return base.update(my_policy)

--- a/clash_starlark/src/lib.rs
+++ b/clash_starlark/src/lib.rs
@@ -908,4 +908,79 @@ def main():
             "sandbox rule doc should persist"
         );
     }
+
+    #[test]
+    fn test_sandbox_merge_via_varargs() {
+        let doc = eval_to_doc(
+            r#"
+load("@clash//std.star", "exe", "policy", "sandbox", "cwd", "home", "tempdir", "domains")
+
+fs_box = sandbox(
+    name = "fs",
+    default = deny,
+    fs = [
+        cwd().allow(read = True, write = True),
+    ],
+)
+
+net_box = sandbox(
+    name = "net",
+    default = deny,
+    net = [
+        domains({"github.com": allow}),
+    ],
+)
+
+extra_fs = sandbox(
+    name = "extra",
+    default = deny,
+    fs = [
+        home().child(".cargo").allow(read = True),
+        tempdir().allow(),
+    ],
+)
+
+def main():
+    return policy(
+        default = deny,
+        rules = [
+            exe("cargo").sandbox(fs_box, net_box, extra_fs).allow(),
+        ],
+    )
+"#,
+        );
+        assert_eq!(doc["schema_version"], 5);
+
+        // Should produce exactly one merged sandbox (named after the first: "fs")
+        let sandboxes = doc["sandboxes"].as_object().unwrap();
+        assert_eq!(sandboxes.len(), 1, "should have exactly 1 merged sandbox");
+        assert!(
+            sandboxes.contains_key("fs"),
+            "merged sandbox should keep first name"
+        );
+
+        let sb = &sandboxes["fs"];
+
+        // Should have network config from net_box
+        assert_ne!(
+            sb["network"], "deny",
+            "merged sandbox should have network from net_box"
+        );
+
+        // Should have fs rules from all three sandboxes (cwd + home/.cargo + tempdir + auto-injected)
+        let rules = sb["rules"].as_array().unwrap();
+        let paths: Vec<&str> = rules.iter().filter_map(|r| r["path"].as_str()).collect();
+        assert!(
+            paths.iter().any(|p| p.starts_with("$PWD")),
+            "should have cwd rule"
+        );
+        assert!(
+            paths.iter().any(|p| p.contains(".cargo")),
+            "should have .cargo rule"
+        );
+        assert!(
+            paths.iter().any(|p| p.starts_with("$TMPDIR")),
+            "should have tmpdir rule"
+        );
+    }
 }

--- a/clash_starlark/stdlib/std.star
+++ b/clash_starlark/stdlib/std.star
@@ -535,6 +535,16 @@ def _expand_children(children):
     return expanded
 
 
+def _merge_sandboxes(*sandboxes):
+    """Merge multiple sandboxes into one, combining fs rules and net policies."""
+    if len(sandboxes) == 0:
+        fail("sandbox() requires at least one sandbox argument")
+    merged = sandboxes[0]
+    for i in range(1, len(sandboxes)):
+        merged = merged.update(sandboxes[i])
+    return merged
+
+
 def _with_sandbox_support(node):
     """Wrap a match tree node with .sandbox(), .on(), and decision support."""
 
@@ -550,8 +560,8 @@ def _with_sandbox_support(node):
         result = node.ask()
         return struct(_node=result, _sandbox=None)
 
-    def _set_sandbox(sb):
-        return _with_sandbox_and_node(node, sb)
+    def _set_sandbox(*sandboxes):
+        return _with_sandbox_and_node(node, _merge_sandboxes(*sandboxes))
 
     def _on(children):
         expanded = _expand_children(children)
@@ -584,8 +594,8 @@ def _with_sandbox_and_node(node, sb):
         result = node.ask(sandbox=sb._name)
         return struct(_node=result, _sandbox=sb)
 
-    def _set_sandbox(new_sb):
-        return _with_sandbox_and_node(node, new_sb)
+    def _set_sandbox(*sandboxes):
+        return _with_sandbox_and_node(node, _merge_sandboxes(*sandboxes))
 
     def _on(children):
         expanded = _expand_children(children)

--- a/clester/tests/scripts/star_sandbox_merge.yaml
+++ b/clester/tests/scripts/star_sandbox_merge.yaml
@@ -1,0 +1,81 @@
+meta:
+  name: starlark policy — sandbox merge via varargs
+  description: Test merging multiple sandboxes with .sandbox(a, b, c)
+
+clash:
+  policy_star: |
+    load("@clash//std.star", "exe", "tool", "policy", "sandbox", "cwd", "home", "tempdir")
+
+    fs_box = sandbox(
+        name = "fs",
+        default = deny,
+        fs = [
+            cwd().allow(read = True, write = True),
+        ],
+    )
+
+    home_box = sandbox(
+        name = "home",
+        default = deny,
+        fs = [
+            home().child(".cargo").allow(read = True),
+            tempdir().allow(),
+        ],
+    )
+
+    def main():
+        return policy(default=deny, rules=[
+            exe("cargo").sandbox(fs_box, home_box).allow(),
+            exe("git").sandbox(fs_box).allow(),
+            tool("Read").sandbox(fs_box).allow(),
+        ])
+
+steps:
+  - name: cargo allowed with merged sandbox
+    hook: pre-tool-use
+    tool_name: Bash
+    tool_input:
+      command: cargo build
+    expect:
+      decision: allow
+
+  - name: cargo test allowed with merged sandbox
+    hook: pre-tool-use
+    tool_name: Bash
+    tool_input:
+      command: cargo test
+    expect:
+      decision: allow
+
+  - name: git allowed with single sandbox
+    hook: pre-tool-use
+    tool_name: Bash
+    tool_input:
+      command: git status
+    expect:
+      decision: allow
+
+  - name: read tool allowed
+    hook: pre-tool-use
+    tool_name: Read
+    tool_input:
+      file_path: /tmp/somefile.txt
+    expect:
+      decision: allow
+
+  - name: npm denied by default
+    hook: pre-tool-use
+    tool_name: Bash
+    tool_input:
+      command: npm install
+    expect:
+      decision: deny
+
+  - name: write denied by default
+    hook: pre-tool-use
+    tool_name: Write
+    tool_input:
+      file_path: /tmp/output.txt
+      content: hello
+    expect:
+      decision: deny


### PR DESCRIPTION
## Summary
- Rewrites the default policy to be more intuitive and less confusing for new users
- Changes the default effect from `deny` to `ask`, so unmatched tool uses prompt the user instead of silently blocking
- Adds a `default_sandbox` for all Bash commands (cwd + tempdir writable, home readable)
- Adds explicit deny rules for destructive git operations (`push --force`, `reset --hard`)
- Adds `ask` rules for network tools (`WebFetch`, `WebSearch`)
- Supports merging multiple sandboxes via varargs (`.sandbox(a, b, c)`) in the Starlark stdlib
- Adds unit and e2e tests for sandbox merging

## Test plan
- [x] `just check` passes (unit tests + linting)
- [x] `just clester` passes (e2e tests including new `star_sandbox_merge.yaml`)
- [ ] Verify default policy produces expected decisions for common tool uses