### PR TITLE
fix: interactive shell hangs when run as a child process

### DIFF
--- a/clash-brush-core/src/terminal.rs
+++ b/clash-brush-core/src/terminal.rs
@@ -12,15 +12,17 @@ impl TerminalControl {
     pub fn acquire() -> Result<Self, error::Error> {
         let prev_fg_pid = sys::terminal::get_foreground_pid();
 
+        // Mask SIGTTOU before any process-group manipulation. After
+        // lead_new_process_group() we are in a background group, so the
+        // subsequent tcsetpgrp in move_self_to_foreground() would deliver
+        // SIGTTOU and stop the process if the signal is not already ignored.
+        sys::signal::mask_sigttou()?;
+
         // Break out into new process group.
-        // TODO(jobs): Investigate why this sometimes fails with EPERM.
         let _ = sys::signal::lead_new_process_group();
 
-        // Take ownership.
+        // Take ownership of the terminal foreground.
         sys::terminal::move_self_to_foreground()?;
-
-        // Mask out SIGTTOU.
-        sys::signal::mask_sigttou()?;
 
         Ok(Self { prev_fg_pid })
     }

--- a/clash-brush-interactive/src/interactive_shell.rs
+++ b/clash-brush-interactive/src/interactive_shell.rs
@@ -55,6 +55,10 @@ pub struct InteractiveShell<'a, IB: InputBackend, SE: brush_core::ShellExtension
     shell: crate::ShellRef<SE>,
     /// The input backend to use.
     input: &'a mut IB,
+    /// Terminal control guard — keeps this process as the foreground process group
+    /// for the lifetime of the interactive session. Dropped on exit to restore the
+    /// previous foreground group.
+    _terminal_control: Option<brush_core::terminal::TerminalControl>,
     /// Terminal integration utility, if any.
     terminal_integration: Option<crate::term_integration::TerminalIntegration>,
     /// Options.
@@ -76,10 +80,16 @@ impl<'a, IB: InputBackend, SE: brush_core::ShellExtensions> InteractiveShell<'a,
     ) -> Result<Self, ShellError> {
         let stdin_is_terminal = std::io::stdin().is_terminal();
 
-        // Acquire terminal control if stdin is a terminal.
-        if stdin_is_terminal {
-            brush_core::terminal::TerminalControl::acquire()?;
-        }
+        // Acquire terminal control if stdin is a terminal. The guard must be
+        // stored so the process stays in the foreground group for the entire
+        // interactive session; dropping it immediately would restore the parent's
+        // group and leave this process reading from the terminal as a background
+        // job (hanging on SIGTTIN).
+        let terminal_control = if stdin_is_terminal {
+            Some(brush_core::terminal::TerminalControl::acquire()?)
+        } else {
+            None
+        };
 
         // Set up terminal integration if enabled *and* if stdin is a terminal.
         let terminal_integration = if options.terminal_shell_integration && stdin_is_terminal {
@@ -97,6 +107,7 @@ impl<'a, IB: InputBackend, SE: brush_core::ShellExtensions> InteractiveShell<'a,
         Ok(Self {
             shell: shell.clone(),
             input,
+            _terminal_control: terminal_control,
             terminal_integration,
             options: options.clone(),
         })


### PR DESCRIPTION
## Summary

- **SIGTTOU race:** `TerminalControl::acquire()` masked SIGTTOU *after* calling `move_self_to_foreground()`, but `setpgid(0,0)` already moved the process to a background group — so `tcsetpgrp` delivered SIGTTOU and stopped the process before the mask took effect. Fixed by masking SIGTTOU first.
- **Dropped guard:** `InteractiveShell::new()` called `TerminalControl::acquire()` without binding the result, so the guard was immediately dropped — restoring the parent's foreground group and leaving the shell as a background job. Fixed by storing the guard in the struct for the session lifetime.

## Test plan

- [x] `just clash shell` starts, shows prompt, responds to input
- [x] `exit` and Ctrl+D cleanly terminate the shell
- [x] Ctrl+C resets the line (does not hang)
- [x] `cargo test -p clash-brush-interactive -p clash-brush-core -p clash` passes