### PR TITLE
feat: add intent-based sandbox presets stdlib

### DIFF
--- a/clash/src/default_policy.star
+++ b/clash/src/default_policy.star
@@ -1,16 +1,6 @@
 load("@clash//builtin.star", "base")
-load("@clash//std.star", "exe", "tool", "policy", "sandbox", "cwd", "home", "tempdir")
-
-# Default sandbox for all Bash commands
-_default_box = sandbox(
-    name = "default",
-    default = deny,
-    fs = [
-        cwd(follow_worktrees = True).allow(read = True, write = True, execute = True),
-        tempdir().allow(),
-        home().allow(read = True, execute = True),
-    ],
-)
+load("@clash//std.star", "exe", "tool", "policy", "sandbox", "cwd", "home")
+load("@clash//sandboxes.star", "dev")
 
 # Tighter sandbox for Claude fs tools (no execute, scoped to cwd + ~/.claude)
 _fs_box = sandbox(
@@ -24,7 +14,7 @@ _fs_box = sandbox(
 def main():
     my_policy = policy(
         default = ask,
-        default_sandbox = _default_box,
+        default_sandbox = dev,
         rules = [
             # Claude fs tools
             tool(["Read", "Glob", "Grep"]).sandbox(_fs_box).allow(),
@@ -39,7 +29,7 @@ def main():
             exe("git", args=["reset", "--hard"]).deny(),
 
             # All other commands — sandboxed
-            exe().sandbox(_default_box).allow(),
+            exe().sandbox(dev).allow(),
         ],
     )
     return base.update(my_policy)

--- a/clash_starlark/stdlib/node.star
+++ b/clash_starlark/stdlib/node.star
@@ -16,6 +16,7 @@ node_sandbox = sandbox(
             "github.com": allow,
         }),
     ],
+    doc = "Node.js development: project + npm cache, npm registry network",
 )
 
 node = exe(["node", "bun", "deno"]).sandbox(node_sandbox).allow()

--- a/clash_starlark/stdlib/python.star
+++ b/clash_starlark/stdlib/python.star
@@ -16,6 +16,7 @@ python_sandbox = sandbox(
             "github.com": allow,
         }),
     ],
+    doc = "Python development: project + pip cache, PyPI/GitHub network",
 )
 
 python = exe(regex("python3?")).sandbox(python_sandbox).allow()

--- a/clash_starlark/stdlib/rust.star
+++ b/clash_starlark/stdlib/rust.star
@@ -1,17 +1,16 @@
-load("@clash//std.star", "sandbox", "cwd", "home", "tempdir", "domains", "exe", "path")
+load("@clash//std.star", "sandbox", "cwd", "home", "tempdir", "exe", "path")
 
 rust_sandbox = sandbox(
     name = "rust_dev",
     default = deny,
     fs = [
-        cwd(follow_worktrees=True).recurse().allow(),
-        cwd().child("target").recurse().allow(),
-        home().child(".cargo").recurse().allow(),
-        home().child(".rustup").recurse().allow(),
-        tempdir().recurse().allow(),
-        path("/").allow(),
+        cwd(follow_worktrees = True).allow(),
+        home().child(".cargo").allow(),
+        home().child(".rustup").allow(),
+        tempdir().allow(),
     ],
     net = "allow",
+    doc = "Rust development: project + cargo/rustup toolchains, full network",
 )
 
 

--- a/clash_starlark/stdlib/sandboxes.star
+++ b/clash_starlark/stdlib/sandboxes.star
@@ -1,0 +1,68 @@
+# Clash sandbox presets — intent-based trust levels for Bash commands.
+#
+# These presets express what you trust a command to do, not what
+# the command literally says.  Pick a preset based on intent:
+#
+#   restricted   — untrusted scripts: read-only project, no network
+#   read_only    — linters, analyzers: read project + home, no writes
+#   dev          — build tools, git: read+write project, no network
+#   dev_network  — package managers, gh: read+write project + network
+#   unrestricted — fully trusted: all filesystem + network access
+
+load("@clash//std.star", "sandbox", "cwd", "home", "tempdir")
+
+restricted = sandbox(
+    name = "restricted",
+    default = deny,
+    fs = [
+        cwd().allow(read = True, execute = True),
+        tempdir().allow(read = True, execute = True),
+    ],
+    doc = "Minimal access: read-only project files, no network",
+)
+
+read_only = sandbox(
+    name = "read_only",
+    default = deny,
+    fs = [
+        cwd(follow_worktrees = True).allow(read = True, execute = True),
+        home().allow(read = True, execute = True),
+        tempdir().allow(),
+    ],
+    doc = "Read project and home, write only to temp, no network",
+)
+
+dev = sandbox(
+    name = "dev",
+    default = deny,
+    fs = [
+        cwd(follow_worktrees = True).allow(read = True, write = True, execute = True),
+        home().allow(read = True, execute = True),
+        tempdir().allow(),
+    ],
+    doc = "Development: read+write project, read home, no network",
+)
+
+dev_network = sandbox(
+    name = "dev_network",
+    default = deny,
+    fs = [
+        cwd(follow_worktrees = True).allow(read = True, write = True, execute = True),
+        home().allow(read = True, execute = True),
+        tempdir().allow(),
+    ],
+    net = "allow",
+    doc = "Development with network: read+write project, full network",
+)
+
+unrestricted = sandbox(
+    name = "unrestricted",
+    default = deny,
+    fs = [
+        cwd(follow_worktrees = True).allow(),
+        home().allow(),
+        tempdir().allow(),
+    ],
+    net = "allow",
+    doc = "Full access: all filesystem operations, full network",
+)

--- a/docs/policy-guide.md
+++ b/docs/policy-guide.md
@@ -272,7 +272,30 @@ When `cargo build` matches the exec rule, the `cargo_env` sandbox defines the re
 
 Note: `.sandbox(sb)` goes **before** `.allow()` / `.deny()` / `.ask()`.
 
-### Pre-built sandboxes
+### Sandbox presets
+
+Intent-based sandbox presets express what you trust a command to do:
+
+| Preset | Filesystem | Network | Use case |
+|---|---|---|---|
+| `restricted` | Read-only project | Deny | Untrusted scripts |
+| `read_only` | Read project + home, write temp | Deny | Linters, analyzers |
+| `dev` | Read+write project, read home | Deny | Build tools, git |
+| `dev_network` | Read+write project, read home | Allow | Package managers, gh |
+| `unrestricted` | Full project + home access | Allow | Fully trusted tools |
+
+```python
+load("@clash//sandboxes.star", "dev", "dev_network")
+
+def main():
+    return policy(default = deny, rules = [
+        exe("gh").sandbox(dev_network).allow(),
+        exe("git").sandbox(dev).allow(),
+        exe().sandbox(dev).allow(),
+    ])
+```
+
+### Language-specific sandboxes
 
 Load pre-built sandbox configurations for common toolchains:
 
@@ -590,6 +613,7 @@ clash policy show
 
 - `@clash//std.star` -- built-in standard library (loaded via `load()` in policy files)
 - `@clash//builtin.star` -- built-in policy for clash CLI and Claude Code tools (exports `base`)
-- `@clash//rust.star`, `@clash//python.star` -- pre-built sandbox configurations for common toolchains
+- `@clash//sandboxes.star` -- intent-based sandbox presets: `restricted`, `read_only`, `dev`, `dev_network`, `unrestricted`
+- `@clash//rust.star`, `@clash//python.star`, `@clash//node.star` -- pre-built sandbox configurations for common toolchains
 - [Policy Semantics](./policy-semantics.md) -- compilation pipeline and evaluation algorithm
 - [CLI Reference](./cli-reference.md) -- full command documentation


### PR DESCRIPTION
## Summary
- Adds `@clash//sandboxes.star` with five intent-based sandbox presets: `restricted`, `read_only`, `dev`, `dev_network`, `unrestricted`
- Updates default policy to import and use the `dev` preset instead of inline sandbox definitions
- Adds `doc` strings to language-specific sandboxes (rust, python, node) and cleans up redundant rules in rust.star

## Motivation

Sandboxes restrict what a Bash child process can access, but users can't infer the right sandbox from the command string alone — they need to express **intent** (what they trust the command to do). These presets provide a clear menu of trust levels instead of requiring users to reason about paths and capabilities directly.

| Preset | Filesystem | Network | Use case |
|---|---|---|---|
| `restricted` | Read-only project | Deny | Untrusted scripts |
| `read_only` | Read project + home, write temp | Deny | Linters, analyzers |
| `dev` | Read+write project, read home | Deny | Build tools, git |
| `dev_network` | Read+write project, read home | Allow | Package managers, gh |
| `unrestricted` | Full project + home access | Allow | Fully trusted tools |

## Test plan
- [x] `just check` passes (437 unit tests + 39 e2e steps)
- [x] `default_policy_compiles` test validates the new preset import
- [ ] Manual: `clash init` produces a working policy using the `dev` preset