### PR TITLE
refactor: compact sandbox display with rwcdx table

### DIFF
--- a/clash/src/cmd/status.rs
+++ b/clash/src/cmd/status.rs
@@ -127,51 +127,16 @@ pub fn run(_json: bool, verbose: bool) -> Result<()> {
     };
     println!("\n  Everything else: {}", everything_else);
     println!();
-    println!("{}", style::header("Sandboxes"));
+    println!(
+        "{}  {}",
+        style::header("Sandboxes"),
+        style::dim("r=read w=write c=create d=delete x=execute")
+    );
     println!("{}", style::dim("─────────────────────────────────"));
     if policy.sandboxes.is_empty() {
         println!("  {}", style::dim("(no sandboxes defined)"));
-    }
-    for (name, sb) in policy.sandboxes.iter() {
-        let sb_doc = sb
-            .doc
-            .as_deref()
-            .map(|d| format!("  {}", style::dim(&format!("# {d}"))))
-            .unwrap_or_default();
-        println!("  {}{}", style::cyan(name), sb_doc);
-        println!("    default: {}", style::dim(&sb.default.display()));
-        for rule in &sb.rules {
-            let effect_str = match rule.effect {
-                crate::policy::sandbox_types::RuleEffect::Allow => style::green("allow"),
-                crate::policy::sandbox_types::RuleEffect::Deny => style::red("deny"),
-            };
-            let match_suffix = match rule.path_match {
-                crate::policy::sandbox_types::PathMatch::Subpath => "/**",
-                crate::policy::sandbox_types::PathMatch::Literal => "",
-                crate::policy::sandbox_types::PathMatch::Regex => " (regex)",
-            };
-            let rule_doc = rule
-                .doc
-                .as_deref()
-                .map(|d| format!("  {}", style::dim(&format!("# {d}"))))
-                .unwrap_or_default();
-            println!(
-                "    {} {} {}{}",
-                effect_str,
-                rule.caps.display(),
-                style::dim(&format!("{}{}", rule.path, match_suffix)),
-                rule_doc,
-            );
-        }
-        let net_str = match &sb.network {
-            crate::policy::sandbox_types::NetworkPolicy::Deny => style::red("deny"),
-            crate::policy::sandbox_types::NetworkPolicy::Allow => style::green("allow"),
-            crate::policy::sandbox_types::NetworkPolicy::Localhost => style::yellow("localhost"),
-            crate::policy::sandbox_types::NetworkPolicy::AllowDomains(domains) => {
-                style::green(&format!("allow [{}]", domains.join(", ")))
-            }
-        };
-        println!("    network: {}", net_str);
+    } else {
+        print_sandbox_table(&policy.sandboxes);
     }
 
     println!("{}", style::header("Potential issues"));
@@ -192,6 +157,141 @@ pub fn run(_json: bool, verbose: bool) -> Result<()> {
     }
 
     Ok(())
+}
+
+/// Right-pad a (possibly ANSI-colored) string to `width` visible characters.
+fn rpad(s: &str, width: usize) -> String {
+    console::pad_str(s, width, console::Alignment::Left, None).into_owned()
+}
+
+/// Left-pad a (possibly ANSI-colored) string to `width` visible characters.
+fn lpad(s: &str, width: usize) -> String {
+    console::pad_str(s, width, console::Alignment::Right, None).into_owned()
+}
+
+/// Print sandboxes as a compact matrix: paths down the left, sandbox names across the top.
+fn print_sandbox_table(
+    sandboxes: &std::collections::HashMap<String, crate::policy::sandbox_types::SandboxPolicy>,
+) {
+    use crate::policy::sandbox_types::{NetworkPolicy, RuleEffect};
+
+    let mut names: Vec<&str> = sandboxes.keys().map(|s| s.as_str()).collect();
+    names.sort();
+
+    // Collect unique path labels, then sort by specificity (general first).
+    let mut paths: Vec<String> = Vec::new();
+    for name in &names {
+        for rule in &sandboxes[*name].rules {
+            let suffix = match rule.path_match {
+                crate::policy::sandbox_types::PathMatch::Subpath => "/**",
+                crate::policy::sandbox_types::PathMatch::Literal => "",
+                crate::policy::sandbox_types::PathMatch::Regex => " (re)",
+            };
+            let key = format!("{}{}", rule.path, suffix);
+            if !paths.contains(&key) {
+                paths.push(key);
+            }
+        }
+    }
+    paths.sort_by_key(|p| {
+        let stripped = p.strip_suffix("/**").unwrap_or(p);
+        stripped.matches('/').count() + stripped.matches('$').count()
+    });
+
+    // Collect unique network domains across sandboxes.
+    let mut domains: Vec<String> = Vec::new();
+    for name in &names {
+        if let NetworkPolicy::AllowDomains(ds) = &sandboxes[*name].network {
+            for d in ds {
+                if !domains.contains(d) {
+                    domains.push(d.clone());
+                }
+            }
+        }
+    }
+
+    let col_w = names.iter().map(|n| n.len()).max().unwrap_or(5).max(5);
+    let domain_max = domains.iter().map(|d| d.len()).max().unwrap_or(0);
+    let path_w = paths
+        .iter()
+        .map(|p| p.len())
+        .max()
+        .unwrap_or(7)
+        .max(domain_max)
+        .max(7);
+
+    // Header row.
+    let hdr: Vec<String> = names.iter().map(|n| lpad(&style::cyan(n), col_w)).collect();
+    println!("  {} {}", rpad("", path_w), hdr.join(" "));
+
+    // Default row.
+    let def: Vec<String> = names
+        .iter()
+        .map(|n| lpad(&style::dim(&sandboxes[*n].default.short()), col_w))
+        .collect();
+    println!("  {} {}", rpad(&style::dim("default"), path_w), def.join(" "));
+
+    // Network row.
+    let net: Vec<String> = names
+        .iter()
+        .map(|n| {
+            let s = match &sandboxes[*n].network {
+                NetworkPolicy::Deny => style::red("deny"),
+                NetworkPolicy::Allow => style::green("allow"),
+                NetworkPolicy::Localhost => style::yellow("localhost"),
+                NetworkPolicy::AllowDomains(_) => style::yellow("proxy"),
+            };
+            lpad(&s, col_w)
+        })
+        .collect();
+    println!("  {} {}", rpad(&style::dim("net"), path_w), net.join(" "));
+
+    // Domain rows.
+    for domain in &domains {
+        let cells: Vec<String> = names
+            .iter()
+            .map(|n| {
+                let cell = match &sandboxes[*n].network {
+                    NetworkPolicy::Allow => style::green("allow"),
+                    NetworkPolicy::AllowDomains(ds) if ds.iter().any(|d| d == domain) => {
+                        style::green("allow")
+                    }
+                    _ => style::dim("·····"),
+                };
+                lpad(&cell, col_w)
+            })
+            .collect();
+        println!("  {} {}", rpad(&style::dim(domain), path_w), cells.join(" "));
+    }
+
+    // Path rows.
+    for path in &paths {
+        let cells: Vec<String> = names
+            .iter()
+            .map(|n| {
+                let matched = sandboxes[*n].rules.iter().find(|r| {
+                    let suffix = match r.path_match {
+                        crate::policy::sandbox_types::PathMatch::Subpath => "/**",
+                        crate::policy::sandbox_types::PathMatch::Literal => "",
+                        crate::policy::sandbox_types::PathMatch::Regex => " (re)",
+                    };
+                    format!("{}{}", r.path, suffix) == *path
+                });
+                let cell = match matched {
+                    Some(r) => {
+                        let s = r.caps.short();
+                        match r.effect {
+                            RuleEffect::Allow => style::green(&s),
+                            RuleEffect::Deny => style::red(&s),
+                        }
+                    }
+                    None => style::dim("·····"),
+                };
+                lpad(&cell, col_w)
+            })
+            .collect();
+        println!("  {} {}", rpad(&style::dim(path), path_w), cells.join(" "));
+    }
 }
 
 /// Colorize a tree line by highlighting the effect after the `→` separator.

--- a/clash/src/debug/sandbox.rs
+++ b/clash/src/debug/sandbox.rs
@@ -68,7 +68,7 @@ impl SandboxReport {
                         lines.push(format!(
                             "    {} {} in {} ({})",
                             eff,
-                            rule.caps.display(),
+                            rule.caps.short(),
                             rule.path,
                             format!("{:?}", rule.path_match).to_lowercase(),
                         ));
@@ -83,7 +83,7 @@ impl SandboxReport {
                         let caps_str = if caps.is_empty() {
                             style::red("none")
                         } else {
-                            caps.display()
+                            caps.short()
                         };
                         lines.push(format!("  {:<40}  {}", path, caps_str));
                     }
@@ -133,7 +133,7 @@ impl SandboxReport {
             "effective_caps": self.path_caps.iter().map(|(path, caps)| {
                 serde_json::json!({
                     "path": path,
-                    "caps": caps.display(),
+                    "caps": caps.short(),
                 })
             }).collect::<Vec<_>>(),
         });

--- a/clash/src/display.rs
+++ b/clash/src/display.rs
@@ -72,7 +72,7 @@ pub fn format_sandbox_summary(sandbox: &SandboxPolicy) -> Vec<String> {
     lines.push(format!(
         "  {}: {}",
         style::cyan("default"),
-        sandbox.default.display()
+        sandbox.default.short()
     ));
     lines.push(format!(
         "  {}: {:?}",
@@ -83,7 +83,7 @@ pub fn format_sandbox_summary(sandbox: &SandboxPolicy) -> Vec<String> {
         lines.push(format!(
             "  {:?} {} in {}",
             rule.effect,
-            rule.caps.display(),
+            rule.caps.short(),
             rule.path
         ));
     }

--- a/clash/src/policy/match_tree.rs
+++ b/clash/src/policy/match_tree.rs
@@ -480,7 +480,7 @@ fn format_pattern(pat: &Pattern) -> String {
         Pattern::Regex(re) => format!("/{}/", re.as_str()),
         Pattern::AnyOf(pats) => {
             let items: Vec<_> = pats.iter().map(format_pattern).collect();
-            format!("[{}]", items.join(", "))
+            format!("{{{}}}", items.join("|"))
         }
         Pattern::Not(inner) => format!("!{}", format_pattern(inner)),
         Pattern::Prefix(v) => format!("{}/**", v.resolve()),

--- a/clash/src/policy/sandbox_types.rs
+++ b/clash/src/policy/sandbox_types.rs
@@ -126,6 +126,22 @@ impl Cap {
         }
         parts.join(" + ")
     }
+
+    /// Compact `ls -l`-style capability string: `rwcdx`.
+    ///
+    /// Each position is the capability letter when set, or `-` when absent:
+    /// `r`ead `w`rite `c`reate `d`elete e`x`ecute.
+    ///
+    /// Examples: `rwcdx` (all), `rw---` (read+write), `r---x` (read+exec).
+    pub fn short(&self) -> String {
+        let mut s = String::with_capacity(5);
+        s.push(if self.contains(Cap::READ) { 'r' } else { '-' });
+        s.push(if self.contains(Cap::WRITE) { 'w' } else { '-' });
+        s.push(if self.contains(Cap::CREATE) { 'c' } else { '-' });
+        s.push(if self.contains(Cap::DELETE) { 'd' } else { '-' });
+        s.push(if self.contains(Cap::EXECUTE) { 'x' } else { '-' });
+        s
+    }
 }
 
 impl Serialize for Cap {
@@ -503,6 +519,15 @@ mod tests {
             Cap::parse("all-write").unwrap(),
             Cap::READ | Cap::CREATE | Cap::DELETE | Cap::EXECUTE
         );
+    }
+
+    #[test]
+    fn test_cap_short() {
+        assert_eq!(Cap::READ.short(), "r----");
+        assert_eq!((Cap::READ | Cap::WRITE).short(), "rw---");
+        assert_eq!((Cap::READ | Cap::EXECUTE).short(), "r---x");
+        assert_eq!(Cap::all().short(), "rwcdx");
+        assert_eq!(Cap::empty().short(), "-----");
     }
 
     #[test]

--- a/clash/src/sandbox_cmd.rs
+++ b/clash/src/sandbox_cmd.rs
@@ -211,7 +211,7 @@ pub fn run_sandbox(cmd: SandboxCmd) -> Result<()> {
                 eprintln!(
                     "  {:?} {} in {}",
                     rule.effect,
-                    rule.caps.display(),
+                    rule.caps.short(),
                     rule.path
                 );
             }
@@ -326,7 +326,7 @@ fn handle_list_sandboxes(json: bool) -> Result<()> {
                 println!(
                     "    {:?} {} in {}{}",
                     rule.effect,
-                    rule.caps.display(),
+                    rule.caps.short(),
                     rule.path,
                     match rule.path_match {
                         PathMatch::Subpath => "",

--- a/clash/src/sandbox_fs_hints.rs
+++ b/clash/src/sandbox_fs_hints.rs
@@ -446,7 +446,7 @@ fn build_fs_hint(blocked: &[BlockedPath]) -> String {
         let caps_display = if bp.current_caps.is_empty() {
             "none".to_string()
         } else {
-            bp.current_caps.display()
+            bp.current_caps.short()
         };
         lines.push(format!(
             "  - {} (sandbox grants: {})",
@@ -668,7 +668,7 @@ mod tests {
         assert!(hint.contains("SANDBOX_FS_HINT"));
         assert!(hint.contains("/Users/user/.fly/perms.123"));
         assert!(hint.contains("/Users/user/.fly"));
-        assert!(hint.contains("read + execute"));
+        assert!(hint.contains("r---x"));
         assert!(hint.contains("/clash:edit"));
         assert!(hint.contains("Do NOT retry"));
     }

--- a/clash/src/tui/sandbox_view.rs
+++ b/clash/src/tui/sandbox_view.rs
@@ -444,7 +444,7 @@ impl SandboxView {
                 lines.push(Line::from(Span::styled(
                     format!(
                         "    {effect_str} {} in {} ({})",
-                        rule.caps.display(),
+                        rule.caps.short(),
                         rule.path,
                         format!("{:?}", rule.path_match).to_lowercase()
                     ),


### PR DESCRIPTION
## Summary

- Add `Cap::short()` for ls-style capability strings (`rwcdx`, dashes for absent)
- Replace per-sandbox listing in `clash status` with a cross-reference matrix: paths/domains as rows, sandbox names as columns, `rwcdx` capability strings in cells (green=allow, red=deny)
- Show allowed network domains as rows alongside filesystem paths
- Sort paths by specificity (most general at top)
- Use `{a|b|c}` syntax for AnyOf patterns instead of `["a", "b", "c"]`
- Switch all human-readable sandbox display sites to short form

## Test plan
- [x] `cargo test -p clash` — 437 tests pass
- [x] `clash status` renders aligned table with correct colors
- [x] `clash explain` uses short form for sandbox output