### PR TITLE
refactor: improve readability across policy, handlers, and cmd modules

### DIFF
--- a/clash/src/claude/tools.rs
+++ b/clash/src/claude/tools.rs
@@ -644,10 +644,7 @@ pub fn is_known(name: &str) -> bool {
 /// Auto-approving these would skip the interaction, so non-deny
 /// decisions are converted to passthrough.
 pub fn is_interactive(name: &str) -> bool {
-    matches!(
-        name,
-        "AskUserQuestion" | "EnterPlanMode" | "ExitPlanMode"
-    )
+    matches!(name, "AskUserQuestion" | "EnterPlanMode" | "ExitPlanMode")
 }
 
 // ---------------------------------------------------------------------------

--- a/clash/src/cmd/policy.rs
+++ b/clash/src/cmd/policy.rs
@@ -401,6 +401,63 @@ fn handle_edit(scope: Option<String>, raw: bool) -> Result<()> {
 // Allow / Deny / Remove handlers
 // ---------------------------------------------------------------------------
 
+/// The mutation to apply to a policy rule.
+enum PolicyMutation {
+    Allow { sandbox: Option<String> },
+    Deny,
+    Remove,
+}
+
+/// Shared pipeline for allow / deny / remove: resolve path, build node, mutate, write, report.
+fn apply_mutation(
+    command: Vec<String>,
+    tool: Option<String>,
+    bin: Option<String>,
+    scope: Option<String>,
+    mutation: PolicyMutation,
+) -> Result<()> {
+    let path = resolve_manifest_path(scope)?;
+    let mut manifest = crate::policy_loader::read_manifest(&path)?;
+
+    // For Remove we only need the observable chain — Decision::Deny is a dummy.
+    let dummy_decision = Decision::Deny;
+    let decision = match &mutation {
+        PolicyMutation::Allow { sandbox } => Decision::Allow(
+            sandbox
+                .as_deref()
+                .map(|s| crate::policy::match_tree::SandboxRef(s.to_string())),
+        ),
+        PolicyMutation::Deny | PolicyMutation::Remove => dummy_decision,
+    };
+
+    let node = build_rule_node(&command, tool, bin, decision)?;
+
+    let result_str = match mutation {
+        PolicyMutation::Remove => {
+            if manifest_edit::remove_rule(&mut manifest, &node) {
+                crate::policy_loader::write_manifest(&path, &manifest)?;
+                println!("{} Rule removed", style::green_bold("✓"));
+                println!("  {}", style::dim(&path.display().to_string()));
+            } else {
+                println!("No matching rule found");
+            }
+            return Ok(());
+        }
+        _ => {
+            let result = manifest_edit::upsert_rule(&mut manifest, node);
+            crate::policy_loader::write_manifest(&path, &manifest)?;
+            match result {
+                manifest_edit::UpsertResult::Inserted => "Rule added",
+                manifest_edit::UpsertResult::Replaced => "Rule updated (replaced existing)",
+            }
+        }
+    };
+
+    println!("{} {}", style::green_bold("✓"), result_str);
+    println!("  {}", style::dim(&path.display().to_string()));
+    Ok(())
+}
+
 /// Resolve the policy.json path for the given scope, creating it if needed.
 pub(crate) fn resolve_manifest_path(scope: Option<String>) -> Result<PathBuf> {
     let level = match scope.as_deref() {
@@ -505,23 +562,7 @@ fn handle_allow(
     sandbox: Option<String>,
     scope: Option<String>,
 ) -> Result<()> {
-    let path = resolve_manifest_path(scope)?;
-    let mut manifest = crate::policy_loader::read_manifest(&path)?;
-    let sandbox_ref = sandbox.map(crate::policy::match_tree::SandboxRef);
-    let node = build_rule_node(&command, tool, bin, Decision::Allow(sandbox_ref))?;
-    let result = manifest_edit::upsert_rule(&mut manifest, node);
-    crate::policy_loader::write_manifest(&path, &manifest)?;
-    match result {
-        manifest_edit::UpsertResult::Inserted => println!("{} Rule added", style::green_bold("✓")),
-        manifest_edit::UpsertResult::Replaced => {
-            println!(
-                "{} Rule updated (replaced existing)",
-                style::green_bold("✓")
-            )
-        }
-    }
-    println!("  {}", style::dim(&path.display().to_string()));
-    Ok(())
+    apply_mutation(command, tool, bin, scope, PolicyMutation::Allow { sandbox })
 }
 
 fn handle_deny(
@@ -530,22 +571,7 @@ fn handle_deny(
     bin: Option<String>,
     scope: Option<String>,
 ) -> Result<()> {
-    let path = resolve_manifest_path(scope)?;
-    let mut manifest = crate::policy_loader::read_manifest(&path)?;
-    let node = build_rule_node(&command, tool, bin, Decision::Deny)?;
-    let result = manifest_edit::upsert_rule(&mut manifest, node);
-    crate::policy_loader::write_manifest(&path, &manifest)?;
-    match result {
-        manifest_edit::UpsertResult::Inserted => println!("{} Rule added", style::green_bold("✓")),
-        manifest_edit::UpsertResult::Replaced => {
-            println!(
-                "{} Rule updated (replaced existing)",
-                style::green_bold("✓")
-            )
-        }
-    }
-    println!("  {}", style::dim(&path.display().to_string()));
-    Ok(())
+    apply_mutation(command, tool, bin, scope, PolicyMutation::Deny)
 }
 
 fn handle_remove(
@@ -554,18 +580,7 @@ fn handle_remove(
     bin: Option<String>,
     scope: Option<String>,
 ) -> Result<()> {
-    let path = resolve_manifest_path(scope)?;
-    let mut manifest = crate::policy_loader::read_manifest(&path)?;
-    // Decision doesn't matter for removal — only the observable chain is compared.
-    let node = build_rule_node(&command, tool, bin, Decision::Deny)?;
-    if manifest_edit::remove_rule(&mut manifest, &node) {
-        crate::policy_loader::write_manifest(&path, &manifest)?;
-        println!("{} Rule removed", style::green_bold("✓"));
-        println!("  {}", style::dim(&path.display().to_string()));
-    } else {
-        println!("No matching rule found");
-    }
-    Ok(())
+    apply_mutation(command, tool, bin, scope, PolicyMutation::Remove)
 }
 
 /// Extract a help hint from an anyhow error chain.

--- a/clash/src/handlers.rs
+++ b/clash/src/handlers.rs
@@ -135,42 +135,59 @@ fn resolve_via_desktop_then_continue(
     }
 }
 
+/// Build a [`notifications::PermissionRequest`] from a tool use hook input.
+fn build_permission_request(input: &ToolUseHookInput) -> notifications::PermissionRequest {
+    notifications::PermissionRequest {
+        tool_name: input.tool_name.clone(),
+        tool_input: input.tool_input.clone(),
+        session_id: input.session_id.clone(),
+        cwd: input.cwd.clone(),
+    }
+}
+
+/// Map a Zulip resolution result to a [`HookOutput`].
+///
+/// Returns `Some(output)` for a definitive approve/deny, or `None` when the
+/// resolution timed out or failed (caller should fall through to the next strategy).
+fn zulip_result_to_output(
+    result: anyhow::Result<Option<notifications::PermissionResponse>>,
+) -> Option<HookOutput> {
+    match result {
+        Ok(Some(notifications::PermissionResponse::Approve)) => {
+            Some(HookOutput::approve_permission(None))
+        }
+        Ok(Some(notifications::PermissionResponse::Deny(reason))) => {
+            Some(HookOutput::deny_permission(reason, false))
+        }
+        Ok(None) => None,
+        Err(_) => None,
+    }
+}
+
 fn start_zulip_background(input: &ToolUseHookInput, settings: &ClashSettings) {
     let Some(ref zulip_config) = settings.notifications.zulip else {
         return;
     };
 
-    let request = notifications::PermissionRequest {
-        tool_name: input.tool_name.clone(),
-        tool_input: input.tool_input.clone(),
-        session_id: input.session_id.clone(),
-        cwd: input.cwd.clone(),
-    };
-
+    let request = build_permission_request(input);
     let config = zulip_config.clone();
 
     std::thread::spawn(move || {
         let client = notifications::ZulipClient::new(&config);
-        match client.resolve_permission(&request) {
+        let result = client.resolve_permission(&request);
+        match &result {
             Ok(Some(notifications::PermissionResponse::Approve)) => {
                 info!("Permission approved via Zulip (background), exiting hook");
-                let output = HookOutput::approve_permission(None);
-                if output.write_stdout().is_ok() {
-                    std::process::exit(0);
-                }
             }
-            Ok(Some(notifications::PermissionResponse::Deny(reason))) => {
+            Ok(Some(notifications::PermissionResponse::Deny(_))) => {
                 info!("Permission denied via Zulip (background), exiting hook");
-                let output = HookOutput::deny_permission(reason, false);
-                if output.write_stdout().is_ok() {
-                    std::process::exit(0);
-                }
             }
-            Ok(None) => {
-                info!("Zulip resolution timed out (background)");
-            }
-            Err(e) => {
-                warn!(error = %e, "Zulip resolution failed (background)");
+            Ok(None) => info!("Zulip resolution timed out (background)"),
+            Err(e) => warn!(error = %e, "Zulip resolution failed (background)"),
+        }
+        if let Some(output) = zulip_result_to_output(result) {
+            if output.write_stdout().is_ok() {
+                std::process::exit(0);
             }
         }
     });
@@ -182,30 +199,14 @@ fn resolve_via_zulip_or_continue(input: &ToolUseHookInput, settings: &ClashSetti
         return HookOutput::continue_execution();
     };
 
-    let request = notifications::PermissionRequest {
-        tool_name: input.tool_name.clone(),
-        tool_input: input.tool_input.clone(),
-        session_id: input.session_id.clone(),
-        cwd: input.cwd.clone(),
-    };
-
     let client = notifications::ZulipClient::new(zulip_config);
-    match client.resolve_permission(&request) {
-        Ok(Some(notifications::PermissionResponse::Approve)) => {
-            HookOutput::approve_permission(None)
-        }
-        Ok(Some(notifications::PermissionResponse::Deny(reason))) => {
-            HookOutput::deny_permission(reason, false)
-        }
-        Ok(None) => {
-            info!("Zulip resolution timed out, falling through to terminal");
-            HookOutput::continue_execution()
-        }
-        Err(e) => {
-            warn!(error = %e, "Zulip resolution failed, falling through to terminal");
-            HookOutput::continue_execution()
-        }
+    let result = client.resolve_permission(&build_permission_request(input));
+
+    if result.is_err() || matches!(result, Ok(None)) {
+        info!("Zulip resolution timed out or failed, falling through to terminal");
     }
+
+    zulip_result_to_output(result).unwrap_or_else(HookOutput::continue_execution)
 }
 
 /// Handle a session start event — validate policy/settings and report status to Claude.

--- a/clash/src/hooks.rs
+++ b/clash/src/hooks.rs
@@ -135,9 +135,7 @@ impl ToolUseHookInput {
 
 // Typed tool input structs live in crate::claude::tools.
 // Re-export for backwards compatibility.
-pub use crate::claude::tools::{
-    BashInput, EditInput, ReadInput, ToolInput, WriteInput,
-};
+pub use crate::claude::tools::{BashInput, EditInput, ReadInput, ToolInput, WriteInput};
 
 /// Hook-specific output for PreToolUse
 #[derive(Debug, Clone, Serialize, PartialEq)]

--- a/clash/src/policy/compile.rs
+++ b/clash/src/policy/compile.rs
@@ -76,31 +76,17 @@ pub fn compile_multi_level_to_tree(
     };
 
     // Annotate root-level nodes from the first level with source provenance.
-    let first_source = sorted[0].2.to_string();
+    let first_source = sorted[0].2;
     for node in &mut merged.tree {
-        if let Node::Condition {
-            source: source @ None,
-            ..
-        } = node
-        {
-            *source = Some(first_source.clone());
-        }
+        node.stamp_source(first_source);
     }
 
     // Append rules from lower-precedence levels.
     for (level, src, path) in &sorted[1..] {
         let mut policy: CompiledPolicy = serde_json::from_str(src)
             .map_err(|e| anyhow::anyhow!("{} policy: invalid JSON: {}", level.name(), e))?;
-        // Annotate root-level nodes with source provenance.
-        let source_label = path.to_string();
         for node in &mut policy.tree {
-            if let Node::Condition {
-                source: source @ None,
-                ..
-            } = node
-            {
-                *source = Some(source_label.clone());
-            }
+            node.stamp_source(path);
         }
         merged.tree.extend(policy.tree);
         for (k, v) in policy.sandboxes {
@@ -129,15 +115,8 @@ fn compile_policy_with_source(source: &str, source_path: &str) -> Result<Compile
         .map_err(|e| anyhow::anyhow!("invalid match tree policy JSON: {e}"))?;
 
     if !source_path.is_empty() {
-        let label = source_path.to_string();
         for node in &mut policy.tree {
-            if let Node::Condition {
-                source: source @ None,
-                ..
-            } = node
-            {
-                *source = Some(label.clone());
-            }
+            node.stamp_source(source_path);
         }
     }
 

--- a/clash/src/policy/format.rs
+++ b/clash/src/policy/format.rs
@@ -1,0 +1,200 @@
+//! Human-readable formatting for policy IR types.
+//!
+//! Provides display rendering for [`CompiledPolicy`], [`Node`], [`Decision`],
+//! [`Observable`], and [`Pattern`] — kept separate from the IR definitions so
+//! `match_tree.rs` stays focused on types and evaluation.
+
+use crate::policy::match_tree::{CompiledPolicy, Decision, Node, Observable, Pattern, SandboxRef};
+
+// ---------------------------------------------------------------------------
+// Public entry points
+// ---------------------------------------------------------------------------
+
+/// Format all rules in a policy as flat, denormalized lines.
+pub fn format_rules(policy: &CompiledPolicy) -> Vec<String> {
+    let mut lines = Vec::new();
+    for node in &policy.tree {
+        format_node_flat(node, &mut Vec::new(), &mut lines);
+    }
+    lines
+}
+
+/// Format all rules in a policy as a tree with box-drawing characters.
+pub fn format_tree(policy: &CompiledPolicy) -> Vec<String> {
+    let mut lines = Vec::new();
+    let len = policy.tree.len();
+    for (i, node) in policy.tree.iter().enumerate() {
+        let is_last = i == len - 1;
+        format_tree_node(node, "", is_last, true, &mut lines);
+    }
+    lines
+}
+
+// ---------------------------------------------------------------------------
+// Node-level rendering
+// ---------------------------------------------------------------------------
+
+/// Recursively render a node as tree lines with box-drawing characters.
+pub fn format_tree_node(
+    node: &Node,
+    prefix: &str,
+    is_last: bool,
+    is_root: bool,
+    lines: &mut Vec<String>,
+) {
+    let connector = if is_root {
+        ""
+    } else if is_last {
+        "└── "
+    } else {
+        "├── "
+    };
+    let child_prefix = if is_root {
+        ""
+    } else if is_last {
+        "    "
+    } else {
+        "│   "
+    };
+
+    match node {
+        Node::Decision(d) => {
+            let effect = format_decision(d);
+            lines.push(format!("{prefix}{connector}{effect}"));
+        }
+        Node::Condition {
+            observe,
+            pattern,
+            children,
+            doc,
+            source,
+        } => {
+            let label = format_condition(observe, pattern);
+            let doc_suffix = doc
+                .as_deref()
+                .map(|d| format!("  # {d}"))
+                .unwrap_or_default();
+            let source_suffix = if is_root {
+                source
+                    .as_deref()
+                    .map(|s| format!("  [{s}]"))
+                    .unwrap_or_default()
+            } else {
+                String::new()
+            };
+
+            // Single decision child → show inline: "label → effect"
+            if children.len() == 1
+                && let Node::Decision(d) = &children[0]
+            {
+                let effect = format_decision(d);
+                lines.push(format!(
+                    "{prefix}{connector}{label} → {effect}{doc_suffix}{source_suffix}"
+                ));
+                return;
+            }
+
+            // Branch — show label, then children as sub-tree
+            lines.push(format!(
+                "{prefix}{connector}{label}{doc_suffix}{source_suffix}"
+            ));
+            let new_prefix = format!("{prefix}{child_prefix}");
+            let child_count = children.len();
+            for (i, child) in children.iter().enumerate() {
+                let child_is_last = i == child_count - 1;
+                format_tree_node(child, &new_prefix, child_is_last, false, lines);
+            }
+        }
+    }
+}
+
+/// Recursively format a node as a flat, denormalized rule line.
+fn format_node_flat(node: &Node, path: &mut Vec<String>, lines: &mut Vec<String>) {
+    match node {
+        Node::Decision(d) => {
+            let effect = format_decision(d);
+            if path.is_empty() {
+                lines.push(format!("{effect} *"));
+            } else {
+                lines.push(format!("{effect} {}", path.join(" → ")));
+            }
+        }
+        Node::Condition {
+            observe,
+            pattern,
+            children,
+            doc,
+            source: _,
+        } => {
+            let segment = format_condition(observe, pattern);
+            path.push(segment);
+            if children.is_empty() {
+                lines.push(format!("(no decision) {}", path.join(" → ")));
+            } else {
+                // Check if this is a leaf condition (all children are decisions)
+                let is_leaf = children.iter().all(|c| matches!(c, Node::Decision(_)));
+                for child in children {
+                    format_node_flat(child, path, lines);
+                }
+                // Append doc to the last line if this is the innermost condition
+                if is_leaf
+                    && let Some(doc_text) = doc
+                    && let Some(last) = lines.last_mut()
+                {
+                    last.push_str(&format!("  # {doc_text}"));
+                }
+            }
+            path.pop();
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Primitive renderers (pub for use in tui and other display code)
+// ---------------------------------------------------------------------------
+
+/// Render a [`Decision`] leaf as a short string (e.g. `"allow"`, `"deny"`,
+/// `"allow [sandbox: dev]"`).
+pub fn format_decision(d: &Decision) -> String {
+    match d {
+        Decision::Allow(Some(SandboxRef(name))) => format!("allow [sandbox: {name}]"),
+        Decision::Allow(None) => "allow".to_string(),
+        Decision::Deny => "deny".to_string(),
+        Decision::Ask(Some(SandboxRef(name))) => format!("ask [sandbox: {name}]"),
+        Decision::Ask(None) => "ask".to_string(),
+    }
+}
+
+/// Render an [`Observable`]+[`Pattern`] pair as a short condition string
+/// (e.g. `"tool=\"Bash\""`, `"arg[0]=\"git\""`).
+pub fn format_condition(obs: &Observable, pat: &Pattern) -> String {
+    let obs_str = match obs {
+        Observable::ToolName => "tool".to_string(),
+        Observable::HookType => "hook".to_string(),
+        Observable::AgentName => "agent".to_string(),
+        Observable::PositionalArg(n) => format!("arg[{n}]"),
+        Observable::HasArg => "has_arg".to_string(),
+        Observable::NamedArg(name) => format!("named({name})"),
+        Observable::NestedField(path) => format!("field({})", path.join(".")),
+        Observable::FsOp => "fs_op".to_string(),
+        Observable::FsPath => "fs_path".to_string(),
+        Observable::NetDomain => "net_domain".to_string(),
+    };
+    let pat_str = format_pattern(pat);
+    format!("{obs_str}={pat_str}")
+}
+
+/// Render a [`Pattern`] as a short string (e.g. `"*"`, `"\"git\""`, `"/re/"`).
+pub fn format_pattern(pat: &Pattern) -> String {
+    match pat {
+        Pattern::Wildcard => "*".to_string(),
+        Pattern::Literal(v) => format!("\"{}\"", v.resolve()),
+        Pattern::Regex(re) => format!("/{}/", re.as_str()),
+        Pattern::AnyOf(pats) => {
+            let items: Vec<_> = pats.iter().map(format_pattern).collect();
+            format!("{{{}}}", items.join("|"))
+        }
+        Pattern::Not(inner) => format!("!{}", format_pattern(inner)),
+        Pattern::Prefix(v) => format!("{}/**", v.resolve()),
+    }
+}

--- a/clash/src/policy/match_tree.rs
+++ b/clash/src/policy/match_tree.rs
@@ -256,6 +256,21 @@ pub enum Node {
     Decision(Decision),
 }
 
+impl Node {
+    /// Stamp source provenance on a root-level Condition node if it has none.
+    ///
+    /// Leaves (`Decision`) and already-stamped nodes are left unchanged.
+    pub fn stamp_source(&mut self, source: &str) {
+        if let Node::Condition {
+            source: slot @ None,
+            ..
+        } = self
+        {
+            *slot = Some(source.to_string());
+        }
+    }
+}
+
 // ---------------------------------------------------------------------------
 // CompiledPolicy
 // ---------------------------------------------------------------------------
@@ -311,179 +326,12 @@ impl CompiledPolicy {
 
     /// Format rules as human-readable lines for display (flat, denormalized).
     pub fn format_rules(&self) -> Vec<String> {
-        let mut lines = Vec::new();
-        for node in &self.tree {
-            format_node_flat(node, &mut Vec::new(), &mut lines);
-        }
-        lines
+        super::format::format_rules(self)
     }
 
     /// Format rules as a tree with box-drawing characters.
-    /// Merges duplicate condition nodes to show shared structure.
     pub fn format_tree(&self) -> Vec<String> {
-        let mut lines = Vec::new();
-        let len = self.tree.len();
-        for (i, node) in self.tree.iter().enumerate() {
-            let is_last = i == len - 1;
-            format_tree_node(node, "", is_last, true, &mut lines);
-        }
-        lines
-    }
-}
-
-/// Recursively render a node as tree lines with box-drawing characters.
-fn format_tree_node(
-    node: &Node,
-    prefix: &str,
-    is_last: bool,
-    is_root: bool,
-    lines: &mut Vec<String>,
-) {
-    let connector = if is_root {
-        ""
-    } else if is_last {
-        "└── "
-    } else {
-        "├── "
-    };
-    let child_prefix = if is_root {
-        ""
-    } else if is_last {
-        "    "
-    } else {
-        "│   "
-    };
-
-    match node {
-        Node::Decision(d) => {
-            let effect = format_decision(d);
-            lines.push(format!("{prefix}{connector}{effect}"));
-        }
-        Node::Condition {
-            observe,
-            pattern,
-            children,
-            doc,
-            source,
-        } => {
-            let label = format_condition(observe, pattern);
-            let doc_suffix = doc
-                .as_deref()
-                .map(|d| format!("  # {d}"))
-                .unwrap_or_default();
-            let source_suffix = if is_root {
-                source
-                    .as_deref()
-                    .map(|s| format!("  [{s}]"))
-                    .unwrap_or_default()
-            } else {
-                String::new()
-            };
-
-            // Single decision child → show inline: "label → effect"
-            if children.len() == 1
-                && let Node::Decision(d) = &children[0]
-            {
-                let effect = format_decision(d);
-                lines.push(format!(
-                    "{prefix}{connector}{label} → {effect}{doc_suffix}{source_suffix}"
-                ));
-                return;
-            }
-
-            // Branch — show label, then children as sub-tree
-            lines.push(format!(
-                "{prefix}{connector}{label}{doc_suffix}{source_suffix}"
-            ));
-            let new_prefix = format!("{prefix}{child_prefix}");
-            let child_count = children.len();
-            for (i, child) in children.iter().enumerate() {
-                let child_is_last = i == child_count - 1;
-                format_tree_node(child, &new_prefix, child_is_last, false, lines);
-            }
-        }
-    }
-}
-
-fn format_decision(d: &Decision) -> String {
-    match d {
-        Decision::Allow(Some(sb)) => format!("allow [sandbox: {}]", sb.0),
-        Decision::Allow(None) => "allow".to_string(),
-        Decision::Deny => "deny".to_string(),
-        Decision::Ask(Some(sb)) => format!("ask [sandbox: {}]", sb.0),
-        Decision::Ask(None) => "ask".to_string(),
-    }
-}
-
-/// Recursively format a node as a flat, denormalized rule line.
-fn format_node_flat(node: &Node, path: &mut Vec<String>, lines: &mut Vec<String>) {
-    match node {
-        Node::Decision(d) => {
-            let effect = format_decision(d);
-            if path.is_empty() {
-                lines.push(format!("{effect} *"));
-            } else {
-                lines.push(format!("{effect} {}", path.join(" → ")));
-            }
-        }
-        Node::Condition {
-            observe,
-            pattern,
-            children,
-            doc,
-            source: _,
-        } => {
-            let segment = format_condition(observe, pattern);
-            path.push(segment);
-            if children.is_empty() {
-                lines.push(format!("(no decision) {}", path.join(" → ")));
-            } else {
-                // Check if this is a leaf condition (all children are decisions)
-                let is_leaf = children.iter().all(|c| matches!(c, Node::Decision(_)));
-                for child in children {
-                    format_node_flat(child, path, lines);
-                }
-                // Append doc to the last line if this is the innermost condition
-                if is_leaf
-                    && let Some(doc_text) = doc
-                    && let Some(last) = lines.last_mut()
-                {
-                    last.push_str(&format!("  # {doc_text}"));
-                }
-            }
-            path.pop();
-        }
-    }
-}
-
-fn format_condition(obs: &Observable, pat: &Pattern) -> String {
-    let obs_str = match obs {
-        Observable::ToolName => "tool".to_string(),
-        Observable::HookType => "hook".to_string(),
-        Observable::AgentName => "agent".to_string(),
-        Observable::PositionalArg(n) => format!("arg[{n}]"),
-        Observable::HasArg => "has_arg".to_string(),
-        Observable::NamedArg(name) => format!("named({name})"),
-        Observable::NestedField(path) => format!("field({})", path.join(".")),
-        Observable::FsOp => "fs_op".to_string(),
-        Observable::FsPath => "fs_path".to_string(),
-        Observable::NetDomain => "net_domain".to_string(),
-    };
-    let pat_str = format_pattern(pat);
-    format!("{obs_str}={pat_str}")
-}
-
-fn format_pattern(pat: &Pattern) -> String {
-    match pat {
-        Pattern::Wildcard => "*".to_string(),
-        Pattern::Literal(v) => format!("\"{}\"", v.resolve()),
-        Pattern::Regex(re) => format!("/{}/", re.as_str()),
-        Pattern::AnyOf(pats) => {
-            let items: Vec<_> = pats.iter().map(format_pattern).collect();
-            format!("{{{}}}", items.join("|"))
-        }
-        Pattern::Not(inner) => format!("!{}", format_pattern(inner)),
-        Pattern::Prefix(v) => format!("{}/**", v.resolve()),
+        super::format::format_tree(self)
     }
 }
 
@@ -941,12 +789,9 @@ impl CompiledPolicy {
                         .to_string();
                     if let Some(explanation) = sbx.explain_denial(fs_path, &cwd, required) {
                         effect = Effect::Deny;
-                        let sandbox_name = d
-                            .sandbox_ref()
-                            .map(|sr| sr.0.as_str())
-                            .unwrap_or("unnamed");
-                        sandbox_denial =
-                            Some(format!("sandbox '{sandbox_name}': {explanation}"));
+                        let sandbox_name =
+                            d.sandbox_ref().map(|sr| sr.0.as_str()).unwrap_or("unnamed");
+                        sandbox_denial = Some(format!("sandbox '{sandbox_name}': {explanation}"));
                     }
                 }
 

--- a/clash/src/policy/mod.rs
+++ b/clash/src/policy/mod.rs
@@ -5,6 +5,7 @@
 
 pub mod compile;
 pub mod error;
+pub mod format;
 pub mod ir;
 pub mod manifest_edit;
 pub mod match_tree;

--- a/clash/src/policy_loader.rs
+++ b/clash/src/policy_loader.rs
@@ -152,15 +152,8 @@ pub fn resolve_includes(
         match evaluate_include(&include.path, base_dir) {
             Ok(json_source) => match serde_json::from_str::<CompiledPolicy>(&json_source) {
                 Ok(included) => {
-                    // Stamp source provenance on root-level condition nodes
                     for mut node in included.tree {
-                        if let crate::policy::match_tree::Node::Condition {
-                            ref mut source, ..
-                        } = node
-                            && source.is_none()
-                        {
-                            *source = Some(include.path.clone());
-                        }
+                        node.stamp_source(&include.path);
                         merged.tree.push(node);
                     }
                     for (k, v) in included.sandboxes {
@@ -197,39 +190,96 @@ pub fn write_manifest(path: &Path, manifest: &PolicyManifest) -> Result<()> {
 /// Returns `None` when the file is missing, is a directory, or exceeds the
 /// size limit.
 fn validate_policy_file(path: &Path, level: PolicyLevel) -> Option<std::fs::Metadata> {
+    match validate_policy_file_with_diagnostics(path) {
+        Ok(metadata) => {
+            #[cfg(unix)]
+            check_permissions_warning(path, level, &metadata);
+            Some(metadata)
+        }
+        Err(ValidationError::NotFound) => None,
+        Err(e) => {
+            warn!(path = %path.display(), level = %level, "Policy file invalid: {e}");
+            None
+        }
+    }
+}
+
+/// Validate a policy file with rich diagnostic messages suitable for user display.
+///
+/// Returns `Ok(metadata)` when the file is suitable for loading, or a
+/// [`ValidationError`] describing exactly what is wrong.
+fn validate_policy_file_with_diagnostics(
+    path: &Path,
+) -> Result<std::fs::Metadata, ValidationError> {
     let metadata = match std::fs::metadata(path) {
         Ok(m) => m,
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return None,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            return Err(ValidationError::NotFound);
+        }
         Err(e) => {
-            warn!(
-                path = %path.display(),
-                level = %level,
-                error = %e,
-                "Failed to stat policy file"
-            );
-            return None;
+            return Err(ValidationError::IoError(format!(
+                "Cannot read policy file at {}: {}",
+                path.display(),
+                e
+            )));
         }
     };
 
-    if metadata.is_dir() || metadata.len() > MAX_POLICY_SIZE {
-        return None;
+    if metadata.is_dir() {
+        return Err(ValidationError::IsDirectory(format!(
+            "{} is a directory, not a file. Remove it and run `clash init` to create a policy.",
+            path.display()
+        )));
     }
 
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        let mode = metadata.permissions().mode();
-        if mode & 0o044 != 0 {
-            warn!(
-                path = %path.display(),
-                level = %level,
-                mode = format!("{:o}", mode),
-                "policy file is readable by other users; consider `chmod 600`"
-            );
+    if metadata.len() > MAX_POLICY_SIZE {
+        return Err(ValidationError::TooLarge(format!(
+            "policy file is too large ({} bytes, max {} bytes). Check that {} is the correct file.",
+            metadata.len(),
+            MAX_POLICY_SIZE,
+            path.display()
+        )));
+    }
+
+    Ok(metadata)
+}
+
+/// Emit a warning if the policy file is readable by other users.
+#[cfg(unix)]
+fn check_permissions_warning(path: &Path, level: PolicyLevel, metadata: &std::fs::Metadata) {
+    use std::os::unix::fs::PermissionsExt;
+    let mode = metadata.permissions().mode();
+    if mode & 0o044 != 0 {
+        warn!(
+            path = %path.display(),
+            level = %level,
+            mode = format!("{:o}", mode),
+            "policy file is readable by other users; consider `chmod 600`"
+        );
+    }
+}
+
+/// Reason a policy file failed metadata validation.
+enum ValidationError {
+    /// File does not exist (not an error — just absent).
+    NotFound,
+    /// I/O error reading metadata.
+    IoError(String),
+    /// Path is a directory, not a file.
+    IsDirectory(String),
+    /// File exceeds the size limit.
+    TooLarge(String),
+}
+
+impl std::fmt::Display for ValidationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ValidationError::NotFound => write!(f, "file not found"),
+            ValidationError::IoError(msg)
+            | ValidationError::IsDirectory(msg)
+            | ValidationError::TooLarge(msg) => write!(f, "{msg}"),
         }
     }
-
-    Some(metadata)
 }
 
 /// Try to load and validate a policy file, returning the evaluated JSON source
@@ -302,63 +352,27 @@ pub fn compile_source(source: &str) -> Result<CompiledPolicy> {
 
 /// Validate and load a policy file with full diagnostics, then compile it.
 ///
-/// Unlike [`try_load_policy`], this function produces detailed error messages
-/// for directory files and oversized files, suitable for surfacing to users.
+/// Produces detailed error messages suitable for surfacing to users.
 /// Used by the test-only `load_policy_from_path` in settings.
 #[cfg(test)]
 pub fn load_and_compile_single(
     path: &Path,
     policy_error: &mut Option<String>,
 ) -> Option<CompiledPolicy> {
-    let metadata = match std::fs::metadata(path) {
+    let metadata = match validate_policy_file_with_diagnostics(path) {
         Ok(m) => m,
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return None,
+        Err(ValidationError::NotFound) => return None,
         Err(e) => {
-            warn!(path = %path.display(), error = %e, "Failed to stat policy file");
-            *policy_error = Some(format!(
-                "Cannot read policy file at {}: {}",
-                path.display(),
-                e
-            ));
+            warn!(path = %path.display(), "Policy file invalid: {e}");
+            *policy_error = Some(e.to_string());
             return None;
         }
     };
 
-    if metadata.is_dir() {
-        let msg = format!(
-            "{} is a directory, not a file. Remove it and run `clash init` to create a policy.",
-            path.display()
-        );
-        warn!(path = %path.display(), "policy file is a directory");
-        *policy_error = Some(msg);
-        return None;
-    }
-
-    if metadata.len() > MAX_POLICY_SIZE {
-        let msg = format!(
-            "policy file is too large ({} bytes, max {} bytes). \
-             Check that {} is the correct file.",
-            metadata.len(),
-            MAX_POLICY_SIZE,
-            path.display()
-        );
-        warn!(path = %path.display(), size = metadata.len(), "policy file exceeds size limit");
-        *policy_error = Some(msg);
-        return None;
-    }
-
     #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        let mode = metadata.permissions().mode();
-        if mode & 0o044 != 0 {
-            warn!(
-                path = %path.display(),
-                mode = format!("{:o}", mode),
-                "policy file is readable by other users; consider `chmod 600`"
-            );
-        }
-    }
+    check_permissions_warning(path, PolicyLevel::User, &metadata);
+    #[cfg(not(unix))]
+    let _ = metadata;
 
     let is_json = path.extension().is_some_and(|ext| ext == "json");
     let eval_result = if is_json {

--- a/clash/src/sandbox_cmd.rs
+++ b/clash/src/sandbox_cmd.rs
@@ -208,12 +208,7 @@ pub fn run_sandbox(cmd: SandboxCmd) -> Result<()> {
             eprintln!("  default: {}", sandbox_policy.default.display());
             eprintln!("  network: {:?}", sandbox_policy.network);
             for rule in &sandbox_policy.rules {
-                eprintln!(
-                    "  {:?} {} in {}",
-                    rule.effect,
-                    rule.caps.short(),
-                    rule.path
-                );
+                eprintln!("  {:?} {} in {}", rule.effect, rule.caps.short(), rule.path);
             }
             eprintln!("  command: {:?}", command);
             eprintln!("---");

--- a/clash/src/settings.rs
+++ b/clash/src/settings.rs
@@ -144,8 +144,9 @@ pub struct SandboxPreset {
 /// then evaluates the Starlark source and returns pretty-printed JSON.
 pub fn compile_default_policy_to_json_with_preset(preset: &str) -> Result<String> {
     let source = DEFAULT_POLICY_TEMPLATE.replace("{preset}", preset);
-    let output = clash_starlark::evaluate(&source, "<default_policy>", std::path::Path::new("."))
-        .with_context(|| format!("failed to compile default policy with preset '{preset}'"))?;
+    let output =
+        clash_starlark::evaluate(&source, "<default_policy>", std::path::Path::new("."))
+            .with_context(|| format!("failed to compile default policy with preset '{preset}'"))?;
     let value: serde_json::Value =
         serde_json::from_str(&output.json).context("default policy produced invalid JSON")?;
     serde_json::to_string_pretty(&value).context("failed to pretty-print default policy JSON")
@@ -714,11 +715,8 @@ mod test {
     #[test]
     fn default_policy_compiles() -> anyhow::Result<()> {
         let source = DEFAULT_POLICY_TEMPLATE.replace("{preset}", "dev");
-        let output = clash_starlark::evaluate(
-            &source,
-            "default_policy.star",
-            std::path::Path::new("."),
-        )?;
+        let output =
+            clash_starlark::evaluate(&source, "default_policy.star", std::path::Path::new("."))?;
         let tree = crate::policy::compile::compile_to_tree(&output.json)?;
         let _ = tree;
         Ok(())

--- a/clash/src/tui/tool_registry.rs
+++ b/clash/src/tui/tool_registry.rs
@@ -112,9 +112,7 @@ pub const TOOLS: &[ToolTuiInfo] = &[
 
 /// Look up TUI info by tool name (case-insensitive). Returns `None` for unknown/MCP tools.
 pub fn lookup(name: &str) -> Option<&'static ToolTuiInfo> {
-    TOOLS
-        .iter()
-        .find(|t| t.def.name.eq_ignore_ascii_case(name))
+    TOOLS.iter().find(|t| t.def.name.eq_ignore_ascii_case(name))
 }
 
 /// Check whether an effect is allowed for a tool. Unknown tools allow all effects.

--- a/clash/src/tui/tree_view.rs
+++ b/clash/src/tui/tree_view.rs
@@ -10,9 +10,8 @@ use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Paragraph};
 
 use super::tea::{Action, Component, FormRequest};
-use crate::policy::match_tree::{
-    CompiledPolicy, Decision, Node, Observable, Pattern, PolicyManifest,
-};
+use crate::policy::format::{format_condition, format_decision};
+use crate::policy::match_tree::{CompiledPolicy, Decision, Node, PolicyManifest};
 
 /// A flattened node in the tree for display purposes.
 pub struct FlatNode {
@@ -579,47 +578,6 @@ impl TreeView {
         {
             self.selected = pos;
         }
-    }
-}
-
-fn format_decision(d: &Decision) -> String {
-    match d {
-        Decision::Allow(Some(sb)) => format!("allow [{}]", sb.0),
-        Decision::Allow(None) => "allow".to_string(),
-        Decision::Deny => "deny".to_string(),
-        Decision::Ask(Some(sb)) => format!("ask [{}]", sb.0),
-        Decision::Ask(None) => "ask".to_string(),
-    }
-}
-
-fn format_condition(obs: &Observable, pat: &Pattern) -> String {
-    let obs_str = match obs {
-        Observable::ToolName => "tool".to_string(),
-        Observable::HookType => "hook".to_string(),
-        Observable::AgentName => "agent".to_string(),
-        Observable::PositionalArg(n) => format!("arg[{n}]"),
-        Observable::HasArg => "has_arg".to_string(),
-        Observable::NamedArg(name) => format!("named({name})"),
-        Observable::NestedField(path) => format!("field({})", path.join(".")),
-        Observable::FsOp => "fs_op".to_string(),
-        Observable::FsPath => "fs_path".to_string(),
-        Observable::NetDomain => "net_domain".to_string(),
-    };
-    let pat_str = format_pattern(pat);
-    format!("{obs_str}={pat_str}")
-}
-
-fn format_pattern(pat: &Pattern) -> String {
-    match pat {
-        Pattern::Wildcard => "*".to_string(),
-        Pattern::Literal(v) => format!("\"{}\"", v.resolve()),
-        Pattern::Regex(re) => format!("/{}/", re.as_str()),
-        Pattern::AnyOf(pats) => {
-            let items: Vec<_> = pats.iter().map(format_pattern).collect();
-            format!("[{}]", items.join(", "))
-        }
-        Pattern::Not(inner) => format!("!{}", format_pattern(inner)),
-        Pattern::Prefix(v) => format!("{}/**", v.resolve()),
     }
 }
 


### PR DESCRIPTION
## Summary

Four targeted refactors to improve code readability and maintainability — no behavioral changes.

- **Extract `policy/format.rs`** — move all display/formatting functions out of `match_tree.rs` into a dedicated module. Also removes duplicate `format_decision` / `format_condition` / `format_pattern` from `tui/tree_view.rs`, which had subtle inconsistencies with the originals (different `AnyOf` rendering, missing `"sandbox:"` label).

- **Deduplicate `cmd/policy.rs` handlers** — `handle_allow`, `handle_deny`, and `handle_remove` shared an identical load→build→mutate→write→report pipeline. Introduced a `PolicyMutation` enum and a single `apply_mutation` function; each handler is now a one-liner. Also eliminates the `Decision::Deny` dummy that was passed to `build_rule_node` during remove.

- **Consolidate validation in `policy_loader.rs`** — source provenance stamping was a 6-line `if let` loop copied in three places; replaced with `Node::stamp_source()`. File validation logic was duplicated between `try_load_policy` and `load_and_compile_single`; extracted `validate_policy_file_with_diagnostics` with a `ValidationError` enum that carries user-quality messages, shrinking `load_and_compile_single` from ~80 to ~25 lines.

- **Consolidate notification resolution in `handlers.rs`** — `PermissionRequest` was constructed identically in two functions; extracted `build_permission_request`. Zulip response→`HookOutput` mapping was duplicated across the foreground and background paths; extracted `zulip_result_to_output`. `resolve_via_zulip_or_continue` is now 5 lines.

## Test plan

- [x] `just check` passes (439 unit tests + 39 e2e clester tests)
- [ ] Review that formatting output is unchanged for `clash policy list` and `clash policy show`
- [ ] Review that `clash policy allow/deny/remove` behave identically to before