### PR TITLE
refactor(trace): replace stringly-typed effect with policy::Effect enum

### DIFF
--- a/clash/src/cmd/hooks.rs
+++ b/clash/src/cmd/hooks.rs
@@ -99,19 +99,14 @@ impl HooksCmd {
                         }
 
                         // Sync trace with the policy decision for this tool use.
-                        let decision = input.tool_use_id.as_ref().map(|id| {
-                            let effect_str = match extract_effect(&output) {
-                                Some(Effect::Allow) => "allow",
-                                Some(Effect::Deny) => "deny",
-                                Some(Effect::Ask) => "ask",
-                                None => "unknown",
-                            };
-                            trace::PolicyDecision {
+                        let decision = input.tool_use_id.as_ref().and_then(|id| {
+                            let effect = extract_effect(&output)?;
+                            Some(trace::PolicyDecision {
                                 tool_use_id: id.clone(),
                                 tool_name: Some(input.tool_name.clone()),
-                                effect: effect_str.to_string(),
+                                effect,
                                 reason: None,
-                            }
+                            })
                         });
                         if let Err(e) = trace::sync_trace(&input.session_id, decision) {
                             tracing::warn!(error = %e, "Failed to sync trace (PreToolUse)");

--- a/clash/src/trace.rs
+++ b/clash/src/trace.rs
@@ -27,8 +27,7 @@ use toolpath_claude::types::ContentPart;
 pub struct PolicyDecision {
     pub tool_use_id: String,
     pub tool_name: Option<String>,
-    /// "allow", "deny", or "ask"
-    pub effect: String,
+    pub effect: crate::policy::Effect,
     pub reason: Option<String>,
 }
 
@@ -214,7 +213,7 @@ pub fn sync_trace(session_id: &str, decision: Option<PolicyDecision>) -> anyhow:
         if let Some(ref name) = dec.tool_name {
             extra.insert("tool_name".to_string(), serde_json::json!(name));
         }
-        extra.insert("effect".to_string(), serde_json::json!(dec.effect));
+        extra.insert("effect".to_string(), serde_json::json!(dec.effect.to_string()));
         if let Some(ref reason) = dec.reason {
             extra.insert("reason".to_string(), serde_json::json!(reason));
         }
@@ -230,7 +229,7 @@ pub fn sync_trace(session_id: &str, decision: Option<PolicyDecision>) -> anyhow:
             },
         );
 
-        if dec.effect == "deny" {
+        if dec.effect == crate::policy::Effect::Deny {
             // Denials are dead ends: rewind last_step_id to the tool_use step's
             // parent so both the tool_use and denial sit on a dead-end branch.
             meta.state.last_step_id = denied_tool_use_parent.clone();
@@ -656,7 +655,7 @@ mod tests {
             Some(PolicyDecision {
                 tool_use_id: "tu-123".into(),
                 tool_name: Some("Bash".into()),
-                effect: "allow".into(),
+                effect: crate::policy::Effect::Allow,
                 reason: Some("matched rule: exe(\"*\").allow()".into()),
             }),
         )
@@ -716,7 +715,7 @@ mod tests {
             Some(PolicyDecision {
                 tool_use_id: "tu-789".into(),
                 tool_name: None,
-                effect: "deny".into(),
+                effect: crate::policy::Effect::Deny,
                 reason: None,
             }),
         )
@@ -818,7 +817,7 @@ mod tests {
             Some(PolicyDecision {
                 tool_use_id: "tu-denied".into(),
                 tool_name: Some("Bash".into()),
-                effect: "deny".into(),
+                effect: crate::policy::Effect::Deny,
                 reason: Some("not allowed".into()),
             }),
         )
@@ -943,7 +942,7 @@ mod tests {
             Some(PolicyDecision {
                 tool_use_id: "tu-bash-1".into(),
                 tool_name: Some("Bash".into()),
-                effect: "allow".into(),
+                effect: crate::policy::Effect::Allow,
                 reason: Some("matched rule: exe(\"*\").allow()".into()),
             }),
         )
@@ -988,7 +987,7 @@ mod tests {
             Some(PolicyDecision {
                 tool_use_id: "tu-read-1".into(),
                 tool_name: Some("Read".into()),
-                effect: "allow".into(),
+                effect: crate::policy::Effect::Allow,
                 reason: None,
             }),
         )


### PR DESCRIPTION
## Summary
- Replace `pub effect: String` with `pub effect: crate::policy::Effect` in `trace::PolicyDecision`
- Update all call sites to pass `Effect` enum values instead of strings
- Enables compile-time enforcement that only valid effects flow through the trace system

## Test plan
- [x] `cargo check -p clash` passes
- [x] `cargo test -p clash` passes