### PR TITLE
refactor: unify session directory management behind SessionDir

### DIFF
--- a/clash/src/audit.rs
+++ b/clash/src/audit.rs
@@ -12,6 +12,7 @@ use tracing::{Level, instrument, warn};
 
 use crate::policy::Effect;
 use crate::policy::ir::DecisionTrace;
+use crate::session_dir::SessionDir;
 
 /// A single audit log entry.
 #[derive(Debug, Serialize)]
@@ -80,12 +81,12 @@ pub struct SessionStats {
 
 /// Return the session-specific temp directory for the given session ID.
 pub fn session_dir(session_id: &str) -> PathBuf {
-    std::env::temp_dir().join(format!("clash-{}", session_id))
+    SessionDir::new(session_id).root().to_path_buf()
 }
 
 /// Path to the session stats sidecar file.
 fn stats_path(session_id: &str) -> PathBuf {
-    session_dir(session_id).join("stats.json")
+    SessionDir::new(session_id).stats()
 }
 
 /// Errors that can occur when reading session stats.
@@ -168,7 +169,7 @@ pub fn update_session_stats(
 /// Persist stats atomically to prevent partial reads by concurrent renders.
 fn write_session_stats(session_id: &str, stats: &SessionStats) {
     let path = stats_path(session_id);
-    let tmp_path = session_dir(session_id).join(".stats.json.tmp");
+    let tmp_path = SessionDir::new(session_id).root().join(".stats.json.tmp");
 
     let json = match serde_json::to_string(stats) {
         Ok(j) => j,
@@ -264,7 +265,7 @@ pub fn log_decision(
     }
 
     // Always write to session-specific audit log so `clash debug log` has data.
-    let session_log = session_dir(session_id).join("audit.jsonl");
+    let session_log = SessionDir::new(session_id).audit_log();
     if let Err(e) = append_entry(&session_log, &entry) {
         warn!(error = %e, path = %session_log.display(), "Failed to write session audit entry");
     }
@@ -321,7 +322,7 @@ pub fn log_sandbox_violations(
         suggested_rules,
     };
 
-    let session_log = session_dir(session_id).join("audit.jsonl");
+    let session_log = SessionDir::new(session_id).audit_log();
     if let Some(parent) = session_log.parent() {
         let _ = std::fs::create_dir_all(parent);
     }
@@ -346,7 +347,7 @@ pub fn log_sandbox_violations(
 /// Returns the violations array from the most recent `sandbox_violation` entry
 /// matching the given tool_use_id.
 pub fn read_sandbox_violations(session_id: &str, tool_use_id: &str) -> Vec<SandboxViolation> {
-    let session_log = session_dir(session_id).join("audit.jsonl");
+    let session_log = SessionDir::new(session_id).audit_log();
     let content = match std::fs::read_to_string(&session_log) {
         Ok(c) => c,
         Err(_) => return Vec::new(),

--- a/clash/src/cmd/session.rs
+++ b/clash/src/cmd/session.rs
@@ -372,7 +372,7 @@ fn print_list_human(sessions: &[SessionInfo], active_id: &Option<String>) {
 
 fn run_dir(session: Option<String>) -> Result<()> {
     let session_id = resolve_session(session)?;
-    let dir = audit::session_dir(&session_id);
+    let dir = crate::session_dir::SessionDir::new(&session_id).root().to_path_buf();
     if !dir.exists() {
         anyhow::bail!("session directory does not exist: {}", dir.display());
     }
@@ -386,7 +386,7 @@ fn run_dir(session: Option<String>) -> Result<()> {
 
 fn run_show(session: Option<String>, json: bool) -> Result<()> {
     let session_id = resolve_session(session)?;
-    let dir = audit::session_dir(&session_id);
+    let dir = crate::session_dir::SessionDir::new(&session_id).root().to_path_buf();
 
     let meta_path = dir.join("metadata.json");
     let meta_str = std::fs::read_to_string(&meta_path)

--- a/clash/src/debug/log.rs
+++ b/clash/src/debug/log.rs
@@ -7,7 +7,6 @@ use std::path::Path;
 
 use anyhow::{Context, Result};
 
-use crate::audit;
 use crate::debug::AuditLogEntry;
 use crate::style;
 
@@ -50,7 +49,7 @@ pub fn read_log_file(path: &Path) -> Result<Vec<AuditLogEntry>> {
 
 /// Read audit log entries for a specific session.
 pub fn read_session_log(session_id: &str) -> Result<Vec<AuditLogEntry>> {
-    let path = audit::session_dir(session_id).join("audit.jsonl");
+    let path = crate::session_dir::SessionDir::new(session_id).audit_log();
     if !path.exists() {
         anyhow::bail!(
             "no audit log found for session {session_id} (expected {})",

--- a/clash/src/lib.rs
+++ b/clash/src/lib.rs
@@ -49,6 +49,7 @@ pub mod sandbox;
 pub mod sandbox_cmd;
 pub mod sandbox_hints;
 pub mod schema;
+pub mod session_dir;
 pub mod session_policy;
 pub mod settings;
 pub mod shell_cmd;

--- a/clash/src/session_dir.rs
+++ b/clash/src/session_dir.rs
@@ -1,0 +1,66 @@
+//! Typed handle for a clash session directory.
+//!
+//! Centralizes the session directory layout so that path construction
+//! lives in one place instead of being scattered across audit, trace,
+//! settings, and session_policy modules.
+
+use std::path::{Path, PathBuf};
+
+/// A session directory rooted at `<tmp>/clash-<session_id>/`.
+///
+/// Every session-scoped file (stats, audit log, trace, policy) is
+/// accessed through this struct, making the directory layout explicit
+/// and easy to change in one place.
+#[derive(Debug, Clone)]
+pub struct SessionDir {
+    root: PathBuf,
+}
+
+impl SessionDir {
+    /// Build the session directory path for the given session ID.
+    pub fn new(session_id: &str) -> Self {
+        Self {
+            root: std::env::temp_dir().join(format!("clash-{session_id}")),
+        }
+    }
+
+    /// The root directory path.
+    pub fn root(&self) -> &Path {
+        &self.root
+    }
+
+    /// `stats.json` — per-session decision counters.
+    pub fn stats(&self) -> PathBuf {
+        self.root.join("stats.json")
+    }
+
+    /// `audit.jsonl` — per-session audit log.
+    pub fn audit_log(&self) -> PathBuf {
+        self.root.join("audit.jsonl")
+    }
+
+    /// `trace.json` — session trace metadata + incremental state.
+    pub fn trace_meta(&self) -> PathBuf {
+        self.root.join("trace.json")
+    }
+
+    /// `trace.jsonl` — append-only toolpath steps.
+    pub fn trace_steps(&self) -> PathBuf {
+        self.root.join("trace.jsonl")
+    }
+
+    /// `policy.star` — session-level policy overrides.
+    pub fn policy(&self) -> PathBuf {
+        self.root.join("policy.star")
+    }
+
+    /// `metadata.json` — session metadata written at init.
+    pub fn metadata(&self) -> PathBuf {
+        self.root.join("metadata.json")
+    }
+
+    /// `pending/` — directory for pending session policy proposals.
+    pub fn pending_dir(&self) -> PathBuf {
+        self.root.join("pending")
+    }
+}

--- a/clash/src/session_policy.rs
+++ b/clash/src/session_policy.rs
@@ -147,7 +147,7 @@ pub fn suggest_rule_description(
 }
 
 fn pending_dir(session_id: &str) -> PathBuf {
-    crate::audit::session_dir(session_id).join(PENDING_DIR)
+    crate::session_dir::SessionDir::new(session_id).root().join(PENDING_DIR)
 }
 
 fn sanitize_id(id: &str) -> String {

--- a/clash/src/settings/discovery.rs
+++ b/clash/src/settings/discovery.rs
@@ -157,7 +157,7 @@ pub fn project_policy_file(project_root: &std::path::Path) -> PathBuf {
 
 /// Returns the session-level policy file path for the given session ID.
 pub fn session_policy_file(session_id: &str) -> PathBuf {
-    crate::audit::session_dir(session_id).join("policy.star")
+    crate::session_dir::SessionDir::new(session_id).policy()
 }
 
 /// Return `policy.json` if it exists in `dir`, otherwise `policy.star`.

--- a/clash/src/trace.rs
+++ b/clash/src/trace.rs
@@ -36,15 +36,15 @@ pub struct PolicyDecision {
 // ---------------------------------------------------------------------------
 
 fn session_dir(session_id: &str) -> PathBuf {
-    crate::audit::session_dir(session_id)
+    crate::session_dir::SessionDir::new(session_id).root().to_path_buf()
 }
 
 fn trace_meta_path(session_id: &str) -> PathBuf {
-    session_dir(session_id).join("trace.json")
+    crate::session_dir::SessionDir::new(session_id).trace_meta()
 }
 
 fn steps_path(session_id: &str) -> PathBuf {
-    session_dir(session_id).join("trace.jsonl")
+    crate::session_dir::SessionDir::new(session_id).trace_steps()
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- New `SessionDir` struct centralizing session directory layout in one place
- Replaces scattered path construction in `audit.rs`, `trace.rs`, `settings.rs`, `cmd/session.rs`, `debug/log.rs`, and `session_policy.rs`
- No behavior change — same paths, just a single source of truth

## Test plan
- [x] `cargo check -p clash` passes
- [x] `cargo test -p clash` passes