### PR TITLE
refactor(settings): split into module hierarchy

### DIFF
--- a/clash/src/settings/discovery.rs
+++ b/clash/src/settings/discovery.rs
@@ -1,0 +1,323 @@
+//! Policy file discovery and default policy compilation.
+
+use std::path::PathBuf;
+
+use anyhow::{Context, Result};
+use dirs::home_dir;
+use serde::{Deserialize, Serialize};
+
+/// Policy level — where a policy file lives in the precedence hierarchy.
+///
+/// Higher-precedence levels override lower ones: Session > Project > User.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+pub enum PolicyLevel {
+    /// User-level policy: `~/.clash/policy.json` (or `policy.star`)
+    User = 0,
+    /// Project-level policy: `<project_root>/.clash/policy.json` (or `policy.star`)
+    Project = 1,
+    /// Session-level policy: `/tmp/clash-<session_id>/policy.star`
+    /// Temporary rules that last only for the current Claude Code session.
+    Session = 2,
+}
+
+impl PolicyLevel {
+    /// All persistent levels in precedence order (highest first).
+    /// Session is excluded because it requires a session_id to resolve.
+    pub fn all_by_precedence() -> &'static [PolicyLevel] {
+        &[PolicyLevel::Project, PolicyLevel::User]
+    }
+
+    /// Display name for this level.
+    pub fn name(&self) -> &'static str {
+        match self {
+            PolicyLevel::User => "user",
+            PolicyLevel::Project => "project",
+            PolicyLevel::Session => "session",
+        }
+    }
+}
+
+impl std::fmt::Display for PolicyLevel {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.name())
+    }
+}
+
+impl std::str::FromStr for PolicyLevel {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self> {
+        match s {
+            "user" => Ok(PolicyLevel::User),
+            "project" => Ok(PolicyLevel::Project),
+            "session" => Ok(PolicyLevel::Session),
+            _ => anyhow::bail!(
+                "unknown policy level: {s} (expected 'user', 'project', or 'session')"
+            ),
+        }
+    }
+}
+
+/// Default policy source template embedded at compile time.
+/// Contains `{preset}` placeholders for the sandbox preset name.
+pub const DEFAULT_POLICY_TEMPLATE: &str = include_str!("../default_policy.star");
+
+/// Available sandbox presets for `clash init`.
+pub const SANDBOX_PRESETS: &[SandboxPreset] = &[
+    SandboxPreset {
+        name: "dev",
+        description: "Build tools, git — read+write project, read home, no network",
+    },
+    SandboxPreset {
+        name: "dev_network",
+        description: "Package managers, gh — read+write project, full network",
+    },
+    SandboxPreset {
+        name: "read_only",
+        description: "Linters, analyzers — read project + home, no writes outside temp",
+    },
+    SandboxPreset {
+        name: "restricted",
+        description: "Untrusted scripts — read-only project, no network",
+    },
+    SandboxPreset {
+        name: "unrestricted",
+        description: "Fully trusted — all filesystem + network access",
+    },
+];
+
+/// A sandbox preset that can be selected during `clash init`.
+pub struct SandboxPreset {
+    pub name: &'static str,
+    pub description: &'static str,
+}
+
+impl crate::dialog::SelectItem for SandboxPreset {
+    fn label(&self) -> &str {
+        self.name
+    }
+    fn description(&self) -> &str {
+        self.description
+    }
+    fn variants() -> &'static [Self] {
+        SANDBOX_PRESETS
+    }
+}
+
+/// Compile the default policy with the given sandbox preset to JSON.
+///
+/// Substitutes `{preset}` in the template with the chosen preset name,
+/// then evaluates the Starlark source and returns pretty-printed JSON.
+pub fn compile_default_policy_to_json_with_preset(preset: &str) -> Result<String> {
+    let source = DEFAULT_POLICY_TEMPLATE.replace("{preset}", preset);
+    let output =
+        clash_starlark::evaluate(&source, "<default_policy>", std::path::Path::new("."))
+            .with_context(|| format!("failed to compile default policy with preset '{preset}'"))?;
+    let value: serde_json::Value =
+        serde_json::from_str(&output.json).context("default policy produced invalid JSON")?;
+    serde_json::to_string_pretty(&value).context("failed to pretty-print default policy JSON")
+}
+
+/// Compile the default policy with the `dev` preset (used for auto-creation).
+pub fn compile_default_policy_to_json() -> Result<String> {
+    compile_default_policy_to_json_with_preset("dev")
+}
+
+/// Returns the clash settings directory (`~/.clash/`).
+///
+/// Respects `CLASH_HOME` env var for override, otherwise defaults to `$HOME/.clash`.
+pub fn settings_dir() -> Result<PathBuf> {
+    if let Ok(p) = std::env::var("CLASH_HOME") {
+        return Ok(PathBuf::from(p));
+    }
+    home_dir()
+        .map(|h| h.join(".clash"))
+        .ok_or_else(|| anyhow::anyhow!("$HOME is not set; cannot determine settings directory"))
+}
+
+/// Returns the user-level policy file path.
+///
+/// Respects `CLASH_POLICY_FILE` env var for override.
+/// Prefers `policy.json` over `policy.star` when both exist.
+pub fn policy_file() -> Result<PathBuf> {
+    if let Ok(p) = std::env::var("CLASH_POLICY_FILE") {
+        return Ok(PathBuf::from(p));
+    }
+    let dir = settings_dir()?;
+    Ok(prefer_json_over_star(&dir))
+}
+
+/// Returns the project-level policy file path.
+///
+/// Prefers `policy.json` over `policy.star` when both exist.
+pub fn project_policy_file(project_root: &std::path::Path) -> PathBuf {
+    let dir = project_root.join(".clash");
+    prefer_json_over_star(&dir)
+}
+
+/// Returns the session-level policy file path for the given session ID.
+pub fn session_policy_file(session_id: &str) -> PathBuf {
+    crate::audit::session_dir(session_id).join("policy.star")
+}
+
+/// Return `policy.json` if it exists in `dir`, otherwise `policy.star`.
+pub(crate) fn prefer_json_over_star(dir: &std::path::Path) -> PathBuf {
+    let json_path = dir.join("policy.json");
+    if json_path.exists() {
+        json_path
+    } else {
+        dir.join("policy.star")
+    }
+}
+
+/// Shorten a path by replacing the home directory prefix with `~`.
+pub(crate) fn tilde_path(path: &std::path::Path) -> String {
+    if let Some(home) = home_dir()
+        && let Ok(rest) = path.strip_prefix(&home)
+    {
+        return format!("~/{}", rest.display());
+    }
+    path.display().to_string()
+}
+
+/// Find the nearest ancestor directory containing the given name.
+///
+/// If `stop_at` is provided, stops searching before checking that directory.
+/// This prevents `~/.clash/` from being mistaken for a project root.
+pub(crate) fn find_ancestor_with(
+    start: &std::path::Path,
+    name: &str,
+    stop_at: Option<&std::path::Path>,
+) -> Option<PathBuf> {
+    let mut current = start.to_path_buf();
+    loop {
+        if let Some(boundary) = stop_at
+            && current == boundary
+        {
+            return None;
+        }
+        if current.join(name).exists() {
+            return Some(current);
+        }
+        if !current.pop() {
+            return None;
+        }
+    }
+}
+
+/// Evaluate a `.star` policy file and return the compiled JSON source.
+///
+/// Delegates to [`policy_loader::evaluate_star_policy`]. This wrapper is kept
+/// for backward compatibility with callers that import from `settings`.
+pub fn evaluate_star_policy(path: &std::path::Path) -> Result<String> {
+    crate::policy_loader::evaluate_star_policy(path)
+}
+
+/// Evaluate a policy file (`.json` or `.star`) and return the compiled JSON source.
+///
+/// Dispatches based on file extension: `.json` → [`policy_loader::load_json_policy`],
+/// `.star` (or anything else) → [`policy_loader::evaluate_star_policy`].
+pub fn evaluate_policy_file(path: &std::path::Path) -> Result<String> {
+    if path.extension().is_some_and(|ext| ext == "json") {
+        crate::policy_loader::load_json_policy(path)
+    } else {
+        crate::policy_loader::evaluate_star_policy(path)
+    }
+}
+
+/// Extract the `notifications:` section from a YAML string.
+///
+/// Returns the parsed config (falling back to defaults on error) and an
+/// optional warning message if parsing failed.
+pub fn parse_notification_config(yaml_str: &str) -> (crate::notifications::NotificationConfig, Option<String>) {
+    use serde::Deserialize;
+    use tracing::warn;
+
+    #[derive(Deserialize)]
+    struct RawYaml {
+        #[serde(default)]
+        notifications: Option<crate::notifications::NotificationConfig>,
+    }
+
+    match serde_yaml::from_str::<RawYaml>(yaml_str) {
+        Ok(raw) => (raw.notifications.unwrap_or_default(), None),
+        Err(e) => {
+            let warning = format!("notifications config parse error: {}", e);
+            warn!(error = %e, "Failed to parse notifications config");
+            (crate::notifications::NotificationConfig::default(), Some(warning))
+        }
+    }
+}
+
+/// Extract the `audit:` section from a YAML string.
+///
+/// Returns the parsed config, falling back to defaults on error.
+pub(crate) fn parse_audit_config(yaml_str: &str) -> crate::audit::AuditConfig {
+    use serde::Deserialize;
+
+    #[derive(Deserialize)]
+    struct RawYaml {
+        #[serde(default)]
+        audit: Option<crate::audit::AuditConfig>,
+    }
+
+    match serde_yaml::from_str::<RawYaml>(yaml_str) {
+        Ok(raw) => raw.audit.unwrap_or_default(),
+        Err(_) => crate::audit::AuditConfig::default(),
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[allow(dead_code)]
+    struct TestEnv;
+    impl crate::policy::compile::EnvResolver for TestEnv {
+        fn resolve(&self, name: &str) -> anyhow::Result<String> {
+            match name {
+                "PWD" => Ok("/tmp".into()),
+                "HOME" => Ok("/tmp/home".into()),
+                "TMPDIR" => Ok("/tmp".into()),
+                other => anyhow::bail!("unknown env var in test: {other}"),
+            }
+        }
+    }
+
+    #[test]
+    fn default_policy_compiles() -> anyhow::Result<()> {
+        let source = DEFAULT_POLICY_TEMPLATE.replace("{preset}", "dev");
+        let output =
+            clash_starlark::evaluate(&source, "default_policy.star", std::path::Path::new("."))?;
+        let tree = crate::policy::compile::compile_to_tree(&output.json)?;
+        let _ = tree;
+        Ok(())
+    }
+
+    #[test]
+    fn default_policy_compiles_all_presets() -> anyhow::Result<()> {
+        for preset in SANDBOX_PRESETS {
+            compile_default_policy_to_json_with_preset(preset.name)?;
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn default_policy_cwd_sandbox_uses_subpath() -> anyhow::Result<()> {
+        let json_str = compile_default_policy_to_json_with_preset("dev")?;
+        let policy: serde_json::Value = serde_json::from_str(&json_str)?;
+        let cwd_sandbox = &policy["sandboxes"]["cwd"];
+        let rules = cwd_sandbox["rules"].as_array().unwrap();
+        // The $PWD rule should be subpath (from .recurse()), not literal.
+        let pwd_rule = rules
+            .iter()
+            .find(|r| r["path"].as_str() == Some("$PWD"))
+            .expect("should have a $PWD rule");
+        assert_eq!(
+            pwd_rule["path_match"].as_str(),
+            Some("subpath"),
+            "cwd() with .recurse() should produce subpath match, got: {pwd_rule}"
+        );
+        Ok(())
+    }
+}

--- a/clash/src/settings/env.rs
+++ b/clash/src/settings/env.rs
@@ -1,0 +1,73 @@
+//! Environment variable checks for clash mode control.
+
+/// The environment variable that disables all clash hooks.
+///
+/// When set to any non-empty value (except `"0"` or `"false"`), clash becomes a
+/// pass-through — all hooks return immediately without evaluating policy.
+/// This is naturally session-scoped when set in the shell that launches Claude Code.
+pub const CLASH_DISABLE_ENV: &str = "CLASH_DISABLE";
+
+/// The environment variable that enables passthrough mode.
+///
+/// When set, clash defers all permission decisions to Claude Code's native permission
+/// system — hooks return `continue_execution()` ("no opinion") instead of evaluating policy.
+/// Tracing still syncs conversation turns, but there are no policy decisions, audit logs,
+/// or session stats (since clash doesn't know what Claude decided).
+/// If both `CLASH_DISABLE` and `CLASH_PASSTHROUGH` are set, `CLASH_DISABLE` takes priority.
+pub const CLASH_PASSTHROUGH_ENV: &str = "CLASH_PASSTHROUGH";
+
+/// Check whether clash is disabled via the [`CLASH_DISABLE`](CLASH_DISABLE_ENV) environment variable.
+///
+/// Returns `true` when the variable is set to any non-empty value except `"0"` or `"false"`.
+pub fn is_disabled() -> bool {
+    std::env::var(CLASH_DISABLE_ENV)
+        .ok()
+        .is_some_and(|v| is_truthy_disable_value(&v))
+}
+
+/// Check whether clash is in passthrough mode via the [`CLASH_PASSTHROUGH`](CLASH_PASSTHROUGH_ENV)
+/// environment variable.
+///
+/// Returns `true` when the variable is set to any non-empty value except `"0"` or `"false"`.
+pub fn is_passthrough() -> bool {
+    std::env::var(CLASH_PASSTHROUGH_ENV)
+        .ok()
+        .is_some_and(|v| is_truthy_disable_value(&v))
+}
+
+/// Returns `true` when `value` should be interpreted as "disabled".
+///
+/// A non-empty string that is not `"0"` or `"false"` means disabled.
+pub(crate) fn is_truthy_disable_value(value: &str) -> bool {
+    !value.is_empty() && value != "0" && value != "false"
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    //
+    // These test `is_truthy_disable_value` directly to avoid env var races.
+    // `env::set_var` is process-wide and Rust runs tests on parallel threads,
+    // so multiple tests mutating the same env var is inherently racy.
+
+    #[test]
+    fn is_truthy_disable_value_not_set() {
+        // Empty string = not disabled (matches env var missing or empty).
+        assert!(!is_truthy_disable_value(""));
+    }
+
+    #[test]
+    fn is_truthy_disable_value_falsy() {
+        assert!(!is_truthy_disable_value("0"));
+        assert!(!is_truthy_disable_value("false"));
+    }
+
+    #[test]
+    fn is_truthy_disable_value_truthy() {
+        assert!(is_truthy_disable_value("1"));
+        assert!(is_truthy_disable_value("true"));
+        assert!(is_truthy_disable_value("yes"));
+        assert!(is_truthy_disable_value("anything"));
+    }
+}

--- a/clash/src/settings/loader.rs
+++ b/clash/src/settings/loader.rs
@@ -1,243 +1,27 @@
+//! Policy loading, compilation, and ClashSettings construction.
+
 use std::path::PathBuf;
+
+use anyhow::{Context, Result};
+use dirs::home_dir;
+use tracing::{info, instrument, Level, warn};
 
 use crate::policy::match_tree::CompiledPolicy;
 use crate::policy_loader;
-use anyhow::{Context, Result};
-use dirs::home_dir;
-use serde::{Deserialize, Serialize};
-use tracing::{Level, info, instrument, warn};
 
-use crate::audit::AuditConfig;
-use crate::notifications::NotificationConfig;
-
-/// The environment variable that disables all clash hooks.
-///
-/// When set to any non-empty value (except `"0"` or `"false"`), clash becomes a
-/// pass-through — all hooks return immediately without evaluating policy.
-/// This is naturally session-scoped when set in the shell that launches Claude Code.
-pub const CLASH_DISABLE_ENV: &str = "CLASH_DISABLE";
-
-/// The environment variable that enables passthrough mode.
-///
-/// When set, clash defers all permission decisions to Claude Code's native permission
-/// system — hooks return `continue_execution()` ("no opinion") instead of evaluating policy.
-/// Tracing still syncs conversation turns, but there are no policy decisions, audit logs,
-/// or session stats (since clash doesn't know what Claude decided).
-/// If both `CLASH_DISABLE` and `CLASH_PASSTHROUGH` are set, `CLASH_DISABLE` takes priority.
-pub const CLASH_PASSTHROUGH_ENV: &str = "CLASH_PASSTHROUGH";
-
-/// Check whether clash is disabled via the [`CLASH_DISABLE`](CLASH_DISABLE_ENV) environment variable.
-///
-/// Returns `true` when the variable is set to any non-empty value except `"0"` or `"false"`.
-pub fn is_disabled() -> bool {
-    std::env::var(CLASH_DISABLE_ENV)
-        .ok()
-        .is_some_and(|v| is_truthy_disable_value(&v))
-}
-
-/// Check whether clash is in passthrough mode via the [`CLASH_PASSTHROUGH`](CLASH_PASSTHROUGH_ENV)
-/// environment variable.
-///
-/// Returns `true` when the variable is set to any non-empty value except `"0"` or `"false"`.
-pub fn is_passthrough() -> bool {
-    std::env::var(CLASH_PASSTHROUGH_ENV)
-        .ok()
-        .is_some_and(|v| is_truthy_disable_value(&v))
-}
-
-/// Returns `true` when `value` should be interpreted as "disabled".
-///
-/// A non-empty string that is not `"0"` or `"false"` means disabled.
-fn is_truthy_disable_value(value: &str) -> bool {
-    !value.is_empty() && value != "0" && value != "false"
-}
-
-/// Policy level — where a policy file lives in the precedence hierarchy.
-///
-/// Higher-precedence levels override lower ones: Session > Project > User.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
-pub enum PolicyLevel {
-    /// User-level policy: `~/.clash/policy.json` (or `policy.star`)
-    User = 0,
-    /// Project-level policy: `<project_root>/.clash/policy.json` (or `policy.star`)
-    Project = 1,
-    /// Session-level policy: `/tmp/clash-<session_id>/policy.star`
-    /// Temporary rules that last only for the current Claude Code session.
-    Session = 2,
-}
-
-impl PolicyLevel {
-    /// All persistent levels in precedence order (highest first).
-    /// Session is excluded because it requires a session_id to resolve.
-    pub fn all_by_precedence() -> &'static [PolicyLevel] {
-        &[PolicyLevel::Project, PolicyLevel::User]
-    }
-
-    /// Display name for this level.
-    pub fn name(&self) -> &'static str {
-        match self {
-            PolicyLevel::User => "user",
-            PolicyLevel::Project => "project",
-            PolicyLevel::Session => "session",
-        }
-    }
-}
-
-impl std::fmt::Display for PolicyLevel {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.name())
-    }
-}
-
-impl std::str::FromStr for PolicyLevel {
-    type Err = anyhow::Error;
-
-    fn from_str(s: &str) -> Result<Self> {
-        match s {
-            "user" => Ok(PolicyLevel::User),
-            "project" => Ok(PolicyLevel::Project),
-            "session" => Ok(PolicyLevel::Session),
-            _ => anyhow::bail!(
-                "unknown policy level: {s} (expected 'user', 'project', or 'session')"
-            ),
-        }
-    }
-}
-
-/// Default policy source template embedded at compile time.
-/// Contains `{preset}` placeholders for the sandbox preset name.
-pub const DEFAULT_POLICY_TEMPLATE: &str = include_str!("default_policy.star");
-
-/// Available sandbox presets for `clash init`.
-pub const SANDBOX_PRESETS: &[SandboxPreset] = &[
-    SandboxPreset {
-        name: "dev",
-        description: "Build tools, git — read+write project, read home, no network",
-    },
-    SandboxPreset {
-        name: "dev_network",
-        description: "Package managers, gh — read+write project, full network",
-    },
-    SandboxPreset {
-        name: "read_only",
-        description: "Linters, analyzers — read project + home, no writes outside temp",
-    },
-    SandboxPreset {
-        name: "restricted",
-        description: "Untrusted scripts — read-only project, no network",
-    },
-    SandboxPreset {
-        name: "unrestricted",
-        description: "Fully trusted — all filesystem + network access",
-    },
-];
-
-/// A sandbox preset that can be selected during `clash init`.
-pub struct SandboxPreset {
-    pub name: &'static str,
-    pub description: &'static str,
-}
-
-impl crate::dialog::SelectItem for SandboxPreset {
-    fn label(&self) -> &str {
-        self.name
-    }
-    fn description(&self) -> &str {
-        self.description
-    }
-    fn variants() -> &'static [Self] {
-        SANDBOX_PRESETS
-    }
-}
-
-/// Compile the default policy with the given sandbox preset to JSON.
-///
-/// Substitutes `{preset}` in the template with the chosen preset name,
-/// then evaluates the Starlark source and returns pretty-printed JSON.
-pub fn compile_default_policy_to_json_with_preset(preset: &str) -> Result<String> {
-    let source = DEFAULT_POLICY_TEMPLATE.replace("{preset}", preset);
-    let output =
-        clash_starlark::evaluate(&source, "<default_policy>", std::path::Path::new("."))
-            .with_context(|| format!("failed to compile default policy with preset '{preset}'"))?;
-    let value: serde_json::Value =
-        serde_json::from_str(&output.json).context("default policy produced invalid JSON")?;
-    serde_json::to_string_pretty(&value).context("failed to pretty-print default policy JSON")
-}
-
-/// Compile the default policy with the `dev` preset (used for auto-creation).
-pub fn compile_default_policy_to_json() -> Result<String> {
-    compile_default_policy_to_json_with_preset("dev")
-}
-
-/// Session-level context from Claude Code hook input.
-///
-/// Carries runtime values that aren't available as standard environment
-/// variables but are needed to resolve session-specific policy variables.
-#[derive(Debug, Clone, Default)]
-pub struct HookContext {
-    /// Parent directory of the session transcript file. Agent output files
-    /// are stored here and must always be readable.
-    pub transcript_dir: Option<String>,
-}
-
-impl HookContext {
-    /// Build from a transcript_path (as received in hook input).
-    pub fn from_transcript_path(transcript_path: &str) -> Self {
-        let transcript_dir = if transcript_path.is_empty() {
-            None
-        } else {
-            std::path::Path::new(transcript_path)
-                .parent()
-                .map(|p| p.to_string_lossy().to_string())
-                .filter(|s| !s.is_empty())
-        };
-        Self { transcript_dir }
-    }
-}
-
-/// A policy source loaded from a specific level.
-#[derive(Debug, Clone)]
-pub struct LoadedPolicy {
-    /// Which level this policy came from.
-    pub level: PolicyLevel,
-    /// The file path it was loaded from.
-    pub path: PathBuf,
-    /// The raw source text.
-    pub source: String,
-}
-
-#[derive(Debug, Default)]
-pub struct ClashSettings {
-    /// Pre-compiled policy tree for fast evaluation.
-    compiled: Option<CompiledPolicy>,
-
-    /// Policy sources loaded from each level (ordered by precedence, highest first).
-    loaded_policies: Vec<LoadedPolicy>,
-
-    /// Notification and external service configuration, loaded from policy.yaml.
-    pub notifications: NotificationConfig,
-
-    /// Warning message if parsing the notifications config failed or was incomplete.
-    pub notification_warning: Option<String>,
-
-    /// Audit logging configuration, loaded from policy.yaml.
-    pub audit: AuditConfig,
-
-    /// Error message if policy failed to parse or compile.
-    policy_error: Option<String>,
-}
+use super::discovery::{
+    self, find_ancestor_with, parse_audit_config, parse_notification_config,
+    prefer_json_over_star, session_policy_file, settings_dir, tilde_path,
+    compile_default_policy_to_json, PolicyLevel,
+};
+use super::{ClashSettings, HookContext, LoadedPolicy};
 
 impl ClashSettings {
     /// Returns the clash settings directory (`~/.clash/`).
     ///
     /// Respects `CLASH_HOME` env var for override, otherwise defaults to `$HOME/.clash`.
     pub fn settings_dir() -> Result<PathBuf> {
-        if let Ok(p) = std::env::var("CLASH_HOME") {
-            return Ok(PathBuf::from(p));
-        }
-        home_dir()
-            .map(|h| h.join(".clash"))
-            .ok_or_else(|| anyhow::anyhow!("$HOME is not set; cannot determine settings directory"))
+        discovery::settings_dir()
     }
 
     /// Returns the user-level policy file path.
@@ -245,11 +29,7 @@ impl ClashSettings {
     /// Respects `CLASH_POLICY_FILE` env var for override.
     /// Prefers `policy.json` over `policy.star` when both exist.
     pub fn policy_file() -> Result<PathBuf> {
-        if let Ok(p) = std::env::var("CLASH_POLICY_FILE") {
-            return Ok(PathBuf::from(p));
-        }
-        let dir = Self::settings_dir()?;
-        Ok(prefer_json_over_star(&dir))
+        discovery::policy_file()
     }
 
     /// Returns the policy file path for a specific level.
@@ -273,12 +53,12 @@ impl ClashSettings {
 
     // Returns the policy file path for a session, given its ID.
     pub fn session_policy_path(session_id: &str) -> PathBuf {
-        crate::audit::session_dir(session_id).join("policy.star")
+        session_policy_file(session_id)
     }
 
     /// Path to the active-session marker file.
     fn active_session_file() -> Result<PathBuf> {
-        Self::settings_dir().map(|d| d.join("active_session"))
+        settings_dir().map(|d| d.join("active_session"))
     }
 
     /// Read the active session ID from `~/.clash/active_session`.
@@ -506,7 +286,7 @@ impl ClashSettings {
 
     /// Load notification and audit config from a companion policy.yaml if it exists.
     fn load_notification_audit_config(&mut self) {
-        let yaml_path = match Self::settings_dir() {
+        let yaml_path = match settings_dir() {
             Ok(d) => d.join("policy.yaml"),
             Err(_) => return,
         };
@@ -610,162 +390,10 @@ impl ClashSettings {
     }
 }
 
-/// Return `policy.json` if it exists in `dir`, otherwise `policy.star`.
-fn prefer_json_over_star(dir: &std::path::Path) -> PathBuf {
-    let json_path = dir.join("policy.json");
-    if json_path.exists() {
-        json_path
-    } else {
-        dir.join("policy.star")
-    }
-}
-
-/// Shorten a path by replacing the home directory prefix with `~`.
-fn tilde_path(path: &std::path::Path) -> String {
-    if let Some(home) = home_dir()
-        && let Ok(rest) = path.strip_prefix(&home)
-    {
-        return format!("~/{}", rest.display());
-    }
-    path.display().to_string()
-}
-
-/// Extract the `notifications:` section from a YAML string.
-///
-/// Returns the parsed config (falling back to defaults on error) and an
-/// optional warning message if parsing failed.
-pub fn parse_notification_config(yaml_str: &str) -> (NotificationConfig, Option<String>) {
-    #[derive(Deserialize)]
-    struct RawYaml {
-        #[serde(default)]
-        notifications: Option<NotificationConfig>,
-    }
-
-    match serde_yaml::from_str::<RawYaml>(yaml_str) {
-        Ok(raw) => (raw.notifications.unwrap_or_default(), None),
-        Err(e) => {
-            let warning = format!("notifications config parse error: {}", e);
-            warn!(error = %e, "Failed to parse notifications config");
-            (NotificationConfig::default(), Some(warning))
-        }
-    }
-}
-
-/// Extract the `audit:` section from a YAML string.
-///
-/// Returns the parsed config, falling back to defaults on error.
-fn parse_audit_config(yaml_str: &str) -> AuditConfig {
-    #[derive(Deserialize)]
-    struct RawYaml {
-        #[serde(default)]
-        audit: Option<AuditConfig>,
-    }
-
-    match serde_yaml::from_str::<RawYaml>(yaml_str) {
-        Ok(raw) => raw.audit.unwrap_or_default(),
-        Err(_) => AuditConfig::default(),
-    }
-}
-
-/// Evaluate a `.star` policy file and return the compiled JSON source.
-///
-/// Delegates to [`policy_loader::evaluate_star_policy`]. This wrapper is kept
-/// for backward compatibility with callers that import from `settings`.
-pub fn evaluate_star_policy(path: &std::path::Path) -> Result<String> {
-    policy_loader::evaluate_star_policy(path)
-}
-
-/// Evaluate a policy file (`.json` or `.star`) and return the compiled JSON source.
-///
-/// Dispatches based on file extension: `.json` → [`policy_loader::load_json_policy`],
-/// `.star` (or anything else) → [`policy_loader::evaluate_star_policy`].
-pub fn evaluate_policy_file(path: &std::path::Path) -> Result<String> {
-    if path.extension().is_some_and(|ext| ext == "json") {
-        policy_loader::load_json_policy(path)
-    } else {
-        policy_loader::evaluate_star_policy(path)
-    }
-}
-
-/// Find the nearest ancestor directory containing the given name.
-///
-/// If `stop_at` is provided, stops searching before checking that directory.
-/// This prevents `~/.clash/` from being mistaken for a project root.
-fn find_ancestor_with(
-    start: &std::path::Path,
-    name: &str,
-    stop_at: Option<&std::path::Path>,
-) -> Option<PathBuf> {
-    let mut current = start.to_path_buf();
-    loop {
-        if let Some(boundary) = stop_at
-            && current == boundary
-        {
-            return None;
-        }
-        if current.join(name).exists() {
-            return Some(current);
-        }
-        if !current.pop() {
-            return None;
-        }
-    }
-}
-
 #[cfg(test)]
 mod test {
     use super::*;
     use std::io::Write;
-
-    #[allow(dead_code)]
-    struct TestEnv;
-    impl crate::policy::compile::EnvResolver for TestEnv {
-        fn resolve(&self, name: &str) -> anyhow::Result<String> {
-            match name {
-                "PWD" => Ok("/tmp".into()),
-                "HOME" => Ok("/tmp/home".into()),
-                "TMPDIR" => Ok("/tmp".into()),
-                other => anyhow::bail!("unknown env var in test: {other}"),
-            }
-        }
-    }
-
-    #[test]
-    fn default_policy_compiles() -> anyhow::Result<()> {
-        let source = DEFAULT_POLICY_TEMPLATE.replace("{preset}", "dev");
-        let output =
-            clash_starlark::evaluate(&source, "default_policy.star", std::path::Path::new("."))?;
-        let tree = crate::policy::compile::compile_to_tree(&output.json)?;
-        let _ = tree;
-        Ok(())
-    }
-
-    #[test]
-    fn default_policy_compiles_all_presets() -> anyhow::Result<()> {
-        for preset in SANDBOX_PRESETS {
-            compile_default_policy_to_json_with_preset(preset.name)?;
-        }
-        Ok(())
-    }
-
-    #[test]
-    fn default_policy_cwd_sandbox_uses_subpath() -> anyhow::Result<()> {
-        let json_str = compile_default_policy_to_json_with_preset("dev")?;
-        let policy: serde_json::Value = serde_json::from_str(&json_str)?;
-        let cwd_sandbox = &policy["sandboxes"]["cwd"];
-        let rules = cwd_sandbox["rules"].as_array().unwrap();
-        // The $PWD rule should be subpath (from .recurse()), not literal.
-        let pwd_rule = rules
-            .iter()
-            .find(|r| r["path"].as_str() == Some("$PWD"))
-            .expect("should have a $PWD rule");
-        assert_eq!(
-            pwd_rule["path_match"].as_str(),
-            Some("subpath"),
-            "cwd() with .recurse() should produce subpath match, got: {pwd_rule}"
-        );
-        Ok(())
-    }
 
     #[test]
     fn load_missing_file_returns_false() {
@@ -996,30 +624,5 @@ mod test {
         // HOME should always be set in test environments
         let result = resolver.resolve("HOME");
         assert!(result.is_ok(), "HOME should resolve via StdEnvResolver");
-    }
-
-    //
-    // These test `is_truthy_disable_value` directly to avoid env var races.
-    // `env::set_var` is process-wide and Rust runs tests on parallel threads,
-    // so multiple tests mutating the same env var is inherently racy.
-
-    #[test]
-    fn is_truthy_disable_value_not_set() {
-        // Empty string = not disabled (matches env var missing or empty).
-        assert!(!is_truthy_disable_value(""));
-    }
-
-    #[test]
-    fn is_truthy_disable_value_falsy() {
-        assert!(!is_truthy_disable_value("0"));
-        assert!(!is_truthy_disable_value("false"));
-    }
-
-    #[test]
-    fn is_truthy_disable_value_truthy() {
-        assert!(is_truthy_disable_value("1"));
-        assert!(is_truthy_disable_value("true"));
-        assert!(is_truthy_disable_value("yes"));
-        assert!(is_truthy_disable_value("anything"));
     }
 }

--- a/clash/src/settings/mod.rs
+++ b/clash/src/settings/mod.rs
@@ -1,0 +1,88 @@
+//! Loading and resolving clash configuration and policy files.
+//!
+//! This module is the entry point for the settings system. It defines the core
+//! [`ClashSettings`] struct and re-exports public items from submodules:
+//!
+//! - [`env`] — Environment variable checks for clash mode control.
+//! - [`discovery`] — Policy file discovery, preset types, and default policy compilation.
+//! - [`loader`] — Policy loading, compilation, and `ClashSettings` construction.
+
+use std::path::PathBuf;
+
+use crate::audit::AuditConfig;
+use crate::notifications::NotificationConfig;
+use crate::policy::match_tree::CompiledPolicy;
+
+mod env;
+mod discovery;
+mod loader;
+
+// Re-export all public items so existing `crate::settings::*` imports continue to work.
+pub use env::{CLASH_DISABLE_ENV, CLASH_PASSTHROUGH_ENV, is_disabled, is_passthrough};
+pub use discovery::{
+    PolicyLevel,
+    DEFAULT_POLICY_TEMPLATE, SANDBOX_PRESETS, SandboxPreset,
+    compile_default_policy_to_json, compile_default_policy_to_json_with_preset,
+    settings_dir, policy_file, project_policy_file, session_policy_file,
+    evaluate_star_policy, evaluate_policy_file,
+    parse_notification_config,
+};
+
+
+/// Session-level context from Claude Code hook input.
+///
+/// Carries runtime values that aren't available as standard environment
+/// variables but are needed to resolve session-specific policy variables.
+#[derive(Debug, Clone, Default)]
+pub struct HookContext {
+    /// Parent directory of the session transcript file. Agent output files
+    /// are stored here and must always be readable.
+    pub transcript_dir: Option<String>,
+}
+
+impl HookContext {
+    /// Build from a transcript_path (as received in hook input).
+    pub fn from_transcript_path(transcript_path: &str) -> Self {
+        let transcript_dir = if transcript_path.is_empty() {
+            None
+        } else {
+            std::path::Path::new(transcript_path)
+                .parent()
+                .map(|p| p.to_string_lossy().to_string())
+                .filter(|s| !s.is_empty())
+        };
+        Self { transcript_dir }
+    }
+}
+
+/// A policy source loaded from a specific level.
+#[derive(Debug, Clone)]
+pub struct LoadedPolicy {
+    /// Which level this policy came from.
+    pub level: PolicyLevel,
+    /// The file path it was loaded from.
+    pub path: PathBuf,
+    /// The raw source text.
+    pub source: String,
+}
+
+#[derive(Debug, Default)]
+pub struct ClashSettings {
+    /// Pre-compiled policy tree for fast evaluation.
+    compiled: Option<CompiledPolicy>,
+
+    /// Policy sources loaded from each level (ordered by precedence, highest first).
+    loaded_policies: Vec<LoadedPolicy>,
+
+    /// Notification and external service configuration, loaded from policy.yaml.
+    pub notifications: NotificationConfig,
+
+    /// Warning message if parsing the notifications config failed or was incomplete.
+    pub notification_warning: Option<String>,
+
+    /// Audit logging configuration, loaded from policy.yaml.
+    pub audit: AuditConfig,
+
+    /// Error message if policy failed to parse or compile.
+    policy_error: Option<String>,
+}


### PR DESCRIPTION
## Summary
- Split 1025-line `settings.rs` into `settings/` module with 4 focused files:
  - `mod.rs` — `ClashSettings` struct, re-exports
  - `env.rs` — Environment variable checks (`CLASH_DISABLE`, `CLASH_PASSTHROUGH`)
  - `discovery.rs` — Policy file discovery, presets, default policy compilation
  - `loader.rs` — Policy loading, compilation, `ClashSettings` construction
- Pure structural refactor — no behavior changes

## Test plan
- [x] `cargo check -p clash` passes
- [x] All existing tests pass unchanged