### PR TITLE
chore: centralize workspace version and sync all crates to 0.5.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
+version = "0.5.1"
 edition = "2024"
 rust-version = "1.94"
 license = "Apache-2.0"
@@ -137,16 +138,16 @@ landlock = "0.4"
 seccompiler = "0.4"
 
 # Workspace crates
-clash-brush-builtins = { path = "clash-brush-builtins", version = "0.5.0" }
-clash_notify = { path = "clash_notify", version = "0.5.0" }
-clash_starlark = { path = "clash_starlark", version = "0.5.0" }
-claude_settings = { path = "claude_settings", version = "0.5.0" }
-clash-brush-parser = { path = "clash-brush-parser", version = "0.5.0" }
-clash-brush-core = { path = "clash-brush-core", version = "0.5.0" }
-clash-brush-interactive = { path = "clash-brush-interactive", version = "0.5.0", features = [
+clash-brush-builtins = { path = "clash-brush-builtins", version = "0.5.1" }
+clash_notify = { path = "clash_notify", version = "0.5.1" }
+clash_starlark = { path = "clash_starlark", version = "0.5.1" }
+claude_settings = { path = "claude_settings", version = "0.5.1" }
+clash-brush-parser = { path = "clash-brush-parser", version = "0.5.1" }
+clash-brush-core = { path = "clash-brush-core", version = "0.5.1" }
+clash-brush-interactive = { path = "clash-brush-interactive", version = "0.5.1", features = [
     "basic",
 ] }
 
 # Workspace crate aliases (used by brush crates internally under original brush-* names)
-brush-parser = { path = "clash-brush-parser", version = "0.5.0", package = "clash-brush-parser" }
-brush-core = { path = "clash-brush-core", version = "0.5.0", package = "clash-brush-core" }
+brush-parser = { path = "clash-brush-parser", version = "0.5.1", package = "clash-brush-parser" }
+brush-core = { path = "clash-brush-core", version = "0.5.1", package = "clash-brush-core" }

--- a/clash-brush-builtins/Cargo.toml
+++ b/clash-brush-builtins/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "clash-brush-builtins"
 description = "Builtins for a POSIX/bash shell (used by brush-shell)"
-version = "0.5.0"
+version.workspace = true
 authors = ["reuben olinsky"]
 categories = ["command-line-utilities", "development-tools"]
 edition.workspace = true

--- a/clash-brush-core/Cargo.toml
+++ b/clash-brush-core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "clash-brush-core"
 description = "Reusable core of a POSIX/bash shell (used by brush-shell)"
-version = "0.5.0"
+version.workspace = true
 authors = ["reuben olinsky"]
 categories = ["command-line-utilities", "development-tools"]
 edition.workspace = true

--- a/clash-brush-interactive/Cargo.toml
+++ b/clash-brush-interactive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "clash-brush-interactive"
 description = "Interactive layer of brush-shell"
-version = "0.5.0"
+version.workspace = true
 authors = ["reuben olinsky"]
 categories = ["command-line-utilities", "development-tools"]
 edition.workspace = true

--- a/clash-brush-parser/Cargo.toml
+++ b/clash-brush-parser/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "clash-brush-parser"
 description = "POSIX/bash shell tokenizer and parsers (used by brush-shell)"
-version = "0.5.0"
+version.workspace = true
 authors = ["reuben olinsky"]
 categories = ["command-line-utilities", "development-tools"]
 edition.workspace = true

--- a/clash/Cargo.toml
+++ b/clash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clash"
-version = "0.5.1"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 description = "Command Line Agent Safety Harness — permission policies for coding agents"

--- a/clash_notify/Cargo.toml
+++ b/clash_notify/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clash_notify"
-version = "0.5.0"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 description = "Desktop notification support for clash"

--- a/clash_starlark/Cargo.toml
+++ b/clash_starlark/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clash_starlark"
-version = "0.5.1"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 description = "Starlark policy evaluator for Clash — compiles .star files to JSON policy"

--- a/claude_settings/Cargo.toml
+++ b/claude_settings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claude_settings"
-version = "0.5.0"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 description = "A library for reading and writing Claude Code settings on Unix-like systems"

--- a/clester/Cargo.toml
+++ b/clester/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clester"
-version = "0.5.0"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 publish = false


### PR DESCRIPTION
## Summary
- Add `version = "0.5.1"` to `[workspace.package]` in root `Cargo.toml`
- All 9 crates now use `version.workspace = true` instead of hardcoded versions
- Update workspace dependency version refs from `0.5.0` to `0.5.1`
- Prevents version drift — future releases only need to update one place

## Test plan
- [x] `cargo check` passes for entire workspace
- [x] All crates resolve to version 0.5.1