### PR TITLE
feat(justfile): add fast developer feedback commands

### DIFF
--- a/justfile
+++ b/justfile
@@ -101,6 +101,39 @@ release VERSION:
     git push -u origin "$branch"
     gh pr create --title "chore: release ${tag}" --body "Version bump and frozen docs for ${tag}"
 
+# Fast targeted testing for a specific module (default: all clash lib tests)
+quick MODULE="":
+    cargo test -p clash --lib {{MODULE}}
+
+# Run clippy lints only (no tests)
+lint:
+    cargo clippy --workspace --all-targets
+
+# Run unit tests only across the workspace (no e2e)
+test-unit:
+    cargo test --workspace --lib
+
+# Generate test coverage report (requires cargo-llvm-cov)
+coverage:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if ! cargo llvm-cov --version &>/dev/null; then
+        echo "Error: cargo-llvm-cov is not installed."
+        echo "Install it with: cargo install cargo-llvm-cov"
+        echo "Or via rustup: rustup component add llvm-tools-preview && cargo install cargo-llvm-cov"
+        exit 1
+    fi
+    cargo llvm-cov --workspace --html
+    open target/llvm-cov/html/index.html
+
+# Run benchmarks across the workspace
+bench:
+    cargo bench --workspace
+
+# Full CI: alias for `just ci`
+test-all:
+    just ci
+
 fix:
     cargo fix --allow-dirty
 


### PR DESCRIPTION
## Summary
- Add `just quick [MODULE]` for fast targeted testing of specific clash modules
- Add `just lint` for clippy-only checks without running tests
- Add `just test-unit` for workspace-wide unit tests without e2e
- Add `just coverage` for HTML test coverage reports (with install instructions if cargo-llvm-cov is missing)
- Add `just bench` for running benchmarks
- Add `just test-all` as an alias for `just ci`
- Apply `cargo fmt` to fix pre-existing formatting inconsistencies

## Test plan
- [x] Verified `cargo test -p clash --lib policy` runs correctly (quick command)
- [x] Verified `cargo clippy --workspace --all-targets` runs correctly (lint command)
- [x] Verified `cargo test -p clash --lib` runs correctly (quick default)
- [x] Verified `cargo test --workspace --lib` runs correctly (test-unit command)
- [x] Verified `cargo fmt` and `cargo test` and `cargo clippy` all pass