### PR TITLE
fix: replace critical unwrap() calls with proper error handling

### DIFF
--- a/clash/src/cmd/wizard.rs
+++ b/clash/src/cmd/wizard.rs
@@ -414,8 +414,9 @@ fn condition_terminal(
         "children": children
     });
     if terminal {
+        // Safety: `cond` is constructed via `json!({...})` above, always an object.
         cond.as_object_mut()
-            .unwrap()
+            .expect("json!({}) always produces an object")
             .insert("terminal".into(), json!(true));
     }
     json!({ "condition": cond })
@@ -504,7 +505,9 @@ pub fn wiz() -> Result<()> {
         Start::Manual => {
             let policy_path = ClashSettings::policy_file()?;
             let policy_path = policy_path.with_extension("json");
-            let dir = policy_path.parent().unwrap();
+            let dir = policy_path
+                .parent()
+                .context("policy file path has no parent directory")?;
             std::fs::create_dir_all(dir)
                 .with_context(|| format!("failed to create {}", dir.display()))?;
 
@@ -602,7 +605,9 @@ fn guided() -> Result<()> {
 
     let policy_path = ClashSettings::policy_file()?;
     let policy_path = policy_path.with_extension("json");
-    let dir = policy_path.parent().unwrap();
+    let dir = policy_path
+        .parent()
+        .context("policy file path has no parent directory")?;
     std::fs::create_dir_all(dir).with_context(|| format!("failed to create {}", dir.display()))?;
 
     let tree: Vec<serde_json::Value> = rules.into_iter().map(|r| r.node).collect();

--- a/clash/src/debug/log.rs
+++ b/clash/src/debug/log.rs
@@ -133,7 +133,8 @@ pub fn find_by_hash(hash: &str) -> Result<AuditLogEntry> {
         .collect();
     match matches.len() {
         0 => anyhow::bail!("no audit log entry matching '{hash}'"),
-        1 => Ok(matches.into_iter().next().unwrap()),
+        // Safety: the match arm guarantees exactly one element.
+        1 => Ok(matches.into_iter().next().expect("len == 1")),
         n => anyhow::bail!("ambiguous hash '{hash}' matches {n} entries — use more characters"),
     }
 }

--- a/clash/src/sandbox/proxy.rs
+++ b/clash/src/sandbox/proxy.rs
@@ -43,12 +43,14 @@ fn full_body(msg: impl Into<Bytes>) -> BoxBody {
 
 fn error_response(status: u16, reason: &str) -> Response<BoxBody> {
     let body_text = format!("{status} {reason}\r\n");
+    // The builder only fails if the status code is invalid; we control all
+    // call sites and always pass valid HTTP status codes.
     Response::builder()
         .status(status)
         .header("Content-Type", "text/plain")
         .header("Connection", "close")
         .body(full_body(body_text))
-        .unwrap()
+        .expect("constructing error response with valid status code")
 }
 
 // ---------------------------------------------------------------------------

--- a/clash/src/settings/loader.rs
+++ b/clash/src/settings/loader.rs
@@ -83,7 +83,10 @@ impl ClashSettings {
     /// Write the active session ID to `~/.clash/active_session`.
     pub fn set_active_session(session_id: &str) -> Result<()> {
         let path = Self::active_session_file()?;
-        std::fs::create_dir_all(path.parent().unwrap())?;
+        let parent = path
+            .parent()
+            .context("active session file path has no parent directory")?;
+        std::fs::create_dir_all(parent)?;
         std::fs::write(&path, session_id)?;
         Ok(())
     }

--- a/clash/src/trace.rs
+++ b/clash/src/trace.rs
@@ -347,7 +347,9 @@ fn load_meta(session_id: &str) -> anyhow::Result<TraceMeta> {
 fn save_meta(session_id: &str, meta: &TraceMeta) -> anyhow::Result<()> {
     let json = serde_json::to_string_pretty(meta).context("serializing trace metadata")?;
     let out = trace_meta_path(session_id);
-    let dir = out.parent().unwrap();
+    let dir = out
+        .parent()
+        .context("trace meta path has no parent directory")?;
     let tmp = dir.join(".trace.json.tmp");
     std::fs::write(&tmp, &json).context("writing trace meta tmp file")?;
     std::fs::rename(&tmp, &out).context("renaming trace tmp to trace.json")?;

--- a/clash/src/tui/tree_view.rs
+++ b/clash/src/tui/tree_view.rs
@@ -224,7 +224,8 @@ impl TreeView {
             return;
         }
         let parent_path = &path[..path.len() - 1];
-        let child_idx = *path.last().unwrap();
+        // Safety: path.len() >= 2 since the len()==1 case returned above.
+        let child_idx = *path.last().expect("path is non-empty");
         if let Some(parent) = Self::get_node_at_path_mut(tree, parent_path)
             && let Node::Condition { children, .. } = parent
             && child_idx < children.len()
@@ -397,7 +398,8 @@ impl Component for TreeView {
                 } else if path.len() >= 2 {
                     // Child node — remove from parent's children
                     let parent_path = &path[..path.len() - 1];
-                    let child_idx = *path.last().unwrap();
+                    // Safety: path.len() >= 2 guarantees non-empty.
+                    let child_idx = *path.last().expect("path is non-empty");
                     if let Some(parent) =
                         Self::get_node_at_path_mut(&mut manifest.policy.tree, parent_path)
                         && let Node::Condition { children, .. } = parent

--- a/claude_settings/src/merge.rs
+++ b/claude_settings/src/merge.rs
@@ -173,7 +173,8 @@ pub fn merge_all(settings: &[(SettingsLevel, Settings)]) -> Settings {
 
     // Start with the lowest precedence and merge up
     let mut iter = settings.iter().rev();
-    let (_, first) = iter.next().unwrap();
+    // Safety: the early return above guarantees at least one element.
+    let (_, first) = iter.next().expect("settings is non-empty");
     let mut result = first.clone();
 
     for (_, higher) in iter {


### PR DESCRIPTION
## Summary

- Replace `unwrap()` calls in production (non-test) code paths with `anyhow::Context` error propagation or safety-documenting `expect()` messages
- For a security tool, panics mean policy is not enforced -- each unwrap in the hook/permission/policy path is a potential security gap
- Focused on the ~10 production-code unwraps (all test-code unwraps are left as-is per Rust convention)

### Replaced with `anyhow::Context` (panic -> recoverable error):
- `trace.rs`: `save_meta()` parent directory lookup
- `settings/loader.rs`: `set_active_session()` parent directory lookup
- `cmd/wizard.rs`: two `policy_path.parent()` calls in `wiz()` and guided flow

### Documented with safety comments + `expect()`:
- `sandbox/proxy.rs`: `error_response()` HTTP builder (infallible with valid status codes)
- `cmd/wizard.rs`: `json!({}).as_object_mut()` (always produces an object)
- `debug/log.rs`: `iterator.next()` after length check (`len == 1`)
- `tui/tree_view.rs`: `path.last()` after length guard (`len >= 2`)
- `claude_settings/merge.rs`: `iterator.next()` after emptiness guard

Also includes `cargo fmt` reformatting of touched and adjacent files.

## Test plan
- [x] `cargo fmt` passes
- [x] `cargo test` passes (all tests green)
- [x] `cargo clippy` passes (no warnings)