### PR TITLE
test(policy): add insta snapshot tests for key outputs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -896,6 +896,7 @@ dependencies = [
  "allocative",
  "anyhow",
  "include_dir",
+ "insta",
  "regex",
  "serde",
  "serde_json",

--- a/clash/Cargo.toml
+++ b/clash/Cargo.toml
@@ -66,7 +66,7 @@ default = []
 tempfile = { workspace = true }
 proptest = { workspace = true }
 mockito = { workspace = true }
-insta = { workspace = true }
+insta = { workspace = true, features = ["json"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 landlock = { workspace = true }

--- a/clash/src/policy/compile.rs
+++ b/clash/src/policy/compile.rs
@@ -219,4 +219,129 @@ mod tests {
             "error should mention the undefined sandbox name, got: {err}"
         );
     }
+
+    #[test]
+    fn snapshot_compiled_exec_rule() {
+        let source = r#"{
+            "schema_version": 5,
+            "default_effect": "deny",
+            "sandboxes": {},
+            "tree": [{
+                "condition": {
+                    "observe": "tool_name",
+                    "pattern": {"literal": {"literal": "Bash"}},
+                    "children": [{
+                        "condition": {
+                            "observe": {"positional_arg": 0},
+                            "pattern": {"literal": {"literal": "git"}},
+                            "children": [{"decision": {"allow": null}}]
+                        }
+                    }]
+                }
+            }]
+        }"#;
+        let policy = compile_to_tree(source).unwrap();
+        insta::assert_json_snapshot!("compiled_exec_rule", policy);
+    }
+
+    #[test]
+    fn snapshot_compiled_fs_rule() {
+        let source = r#"{
+            "schema_version": 5,
+            "default_effect": "deny",
+            "sandboxes": {},
+            "tree": [{
+                "condition": {
+                    "observe": "fs_op",
+                    "pattern": {"literal": {"literal": "read"}},
+                    "children": [{
+                        "condition": {
+                            "observe": "fs_path",
+                            "pattern": {"prefix": {"literal": "/home/user/project"}},
+                            "children": [{"decision": {"allow": null}}]
+                        }
+                    }]
+                }
+            }]
+        }"#;
+        let policy = compile_to_tree(source).unwrap();
+        insta::assert_json_snapshot!("compiled_fs_rule", policy);
+    }
+
+    #[test]
+    fn snapshot_compiled_net_rule() {
+        let source = r#"{
+            "schema_version": 5,
+            "default_effect": "deny",
+            "sandboxes": {},
+            "tree": [{
+                "condition": {
+                    "observe": "net_domain",
+                    "pattern": {"literal": {"literal": "github.com"}},
+                    "children": [{"decision": {"allow": null}}]
+                }
+            }]
+        }"#;
+        let policy = compile_to_tree(source).unwrap();
+        insta::assert_json_snapshot!("compiled_net_rule", policy);
+    }
+
+    #[test]
+    fn snapshot_compiled_sandbox_policy() {
+        let source = r#"{
+            "schema_version": 5,
+            "default_effect": "deny",
+            "sandboxes": {
+                "dev": {
+                    "default": ["read", "execute"],
+                    "network": "deny",
+                    "rules": [
+                        {"effect": "allow", "path": "/home/user/project", "caps": ["read", "write"]}
+                    ]
+                }
+            },
+            "tree": [
+                {
+                    "condition": {
+                        "observe": "tool_name",
+                        "pattern": {"literal": {"literal": "Bash"}},
+                        "children": [{"decision": {"allow": "dev"}}]
+                    }
+                },
+                {
+                    "condition": {
+                        "observe": "tool_name",
+                        "pattern": "wildcard",
+                        "children": [{"decision": {"allow": null}}]
+                    }
+                }
+            ]
+        }"#;
+        let policy = compile_to_tree(source).unwrap();
+        insta::assert_json_snapshot!("compiled_sandbox_policy", policy);
+    }
+
+    #[test]
+    fn snapshot_compile_error_undefined_sandbox() {
+        let source = r#"{
+            "schema_version": 5,
+            "default_effect": "deny",
+            "sandboxes": {},
+            "tree": [{
+                "condition": {
+                    "observe": "tool_name",
+                    "pattern": {"literal": {"literal": "Bash"}},
+                    "children": [{"decision": {"allow": "nonexistent"}}]
+                }
+            }]
+        }"#;
+        let err = compile_to_tree(source).unwrap_err().to_string();
+        insta::assert_snapshot!("compile_error_undefined_sandbox", err);
+    }
+
+    #[test]
+    fn snapshot_compile_error_invalid_json() {
+        let err = compile_to_tree("not valid json").unwrap_err().to_string();
+        insta::assert_snapshot!("compile_error_invalid_json", err);
+    }
 }

--- a/clash/src/policy/error.rs
+++ b/clash/src/policy/error.rs
@@ -168,3 +168,83 @@ pub fn suggest_closest(name: &str, candidates: &[&str]) -> Option<String> {
         .min_by_key(|(_, dist)| *dist)
         .map(|(c, _)| (*c).to_string())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn snapshot_error_invalid_effect() {
+        let err = PolicyParseError::InvalidEffect("yolo".to_string());
+        insta::assert_snapshot!("error_invalid_effect", format!("{err}"));
+    }
+
+    #[test]
+    fn snapshot_error_invalid_effect_hint() {
+        let err = PolicyParseError::InvalidEffect("yolo".to_string());
+        insta::assert_snapshot!("error_invalid_effect_hint", err.help().unwrap());
+    }
+
+    #[test]
+    fn snapshot_error_invalid_rule() {
+        let err = PolicyParseError::InvalidRule {
+            rule: "broken rule".to_string(),
+            message: "expected effect at start".to_string(),
+        };
+        insta::assert_snapshot!("error_invalid_rule", format!("{err}"));
+    }
+
+    #[test]
+    fn snapshot_error_invalid_rule_hint() {
+        let err = PolicyParseError::InvalidRule {
+            rule: "broken rule".to_string(),
+            message: "expected effect at start".to_string(),
+        };
+        insta::assert_snapshot!("error_invalid_rule_hint", err.help().unwrap());
+    }
+
+    #[test]
+    fn snapshot_error_circular_include() {
+        let err = PolicyParseError::CircularInclude {
+            cycle: "base".to_string(),
+            path: Some("base -> strict -> base".to_string()),
+        };
+        insta::assert_snapshot!("error_circular_include", format!("{err}"));
+    }
+
+    #[test]
+    fn snapshot_error_circular_include_hint() {
+        let err = PolicyParseError::CircularInclude {
+            cycle: "base".to_string(),
+            path: Some("base -> strict -> base".to_string()),
+        };
+        insta::assert_snapshot!("error_circular_include_hint", err.help().unwrap());
+    }
+
+    #[test]
+    fn snapshot_error_unknown_include() {
+        let err = PolicyParseError::UnknownInclude {
+            name: "strct".to_string(),
+            suggestion: Some("strict".to_string()),
+        };
+        insta::assert_snapshot!("error_unknown_include_with_suggestion", format!("{err}"));
+    }
+
+    #[test]
+    fn snapshot_error_compile_invalid_glob() {
+        let err = CompileError::InvalidGlob {
+            pattern: "[invalid".to_string(),
+            source: regex::Regex::new("[invalid").unwrap_err(),
+        };
+        insta::assert_snapshot!("error_compile_invalid_glob", format!("{err}"));
+    }
+
+    #[test]
+    fn snapshot_error_compile_invalid_glob_hint() {
+        let err = CompileError::InvalidGlob {
+            pattern: "[invalid".to_string(),
+            source: regex::Regex::new("[invalid").unwrap_err(),
+        };
+        insta::assert_snapshot!("error_compile_invalid_glob_hint", err.help().unwrap());
+    }
+}

--- a/clash/src/policy/format.rs
+++ b/clash/src/policy/format.rs
@@ -199,3 +199,188 @@ pub fn format_pattern(pat: &Pattern) -> String {
         Pattern::Prefix(v) => format!("{}/**", v.resolve()),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::policy::compile::compile_to_tree;
+
+    #[test]
+    fn snapshot_format_rules_exec_policy() {
+        let source = r#"{
+            "schema_version": 5,
+            "default_effect": "deny",
+            "sandboxes": {},
+            "tree": [
+                {
+                    "condition": {
+                        "observe": "tool_name",
+                        "pattern": {"literal": {"literal": "Bash"}},
+                        "children": [{
+                            "condition": {
+                                "observe": {"positional_arg": 0},
+                                "pattern": {"literal": {"literal": "git"}},
+                                "children": [{"decision": {"allow": null}}]
+                            }
+                        }]
+                    }
+                },
+                {
+                    "condition": {
+                        "observe": "tool_name",
+                        "pattern": "wildcard",
+                        "children": [{"decision": {"deny": null}}]
+                    }
+                }
+            ]
+        }"#;
+        let policy = compile_to_tree(source).unwrap();
+        let rules = format_rules(&policy);
+        insta::assert_snapshot!("format_rules_exec", rules.join("\n"));
+    }
+
+    #[test]
+    fn snapshot_format_tree_exec_policy() {
+        let source = r#"{
+            "schema_version": 5,
+            "default_effect": "deny",
+            "sandboxes": {},
+            "tree": [
+                {
+                    "condition": {
+                        "observe": "tool_name",
+                        "pattern": {"literal": {"literal": "Bash"}},
+                        "children": [{
+                            "condition": {
+                                "observe": {"positional_arg": 0},
+                                "pattern": {"literal": {"literal": "git"}},
+                                "children": [{"decision": {"allow": null}}]
+                            }
+                        }]
+                    }
+                },
+                {
+                    "condition": {
+                        "observe": "tool_name",
+                        "pattern": "wildcard",
+                        "children": [{"decision": {"deny": null}}]
+                    }
+                }
+            ]
+        }"#;
+        let policy = compile_to_tree(source).unwrap();
+        let tree_lines = format_tree(&policy);
+        insta::assert_snapshot!("format_tree_exec", tree_lines.join("\n"));
+    }
+
+    #[test]
+    fn snapshot_format_tree_with_sandbox() {
+        let source = r#"{
+            "schema_version": 5,
+            "default_effect": "deny",
+            "sandboxes": {
+                "dev": {
+                    "default": ["read", "execute"],
+                    "network": "deny"
+                }
+            },
+            "tree": [
+                {
+                    "condition": {
+                        "observe": "tool_name",
+                        "pattern": {"literal": {"literal": "Bash"}},
+                        "children": [{"decision": {"allow": "dev"}}]
+                    }
+                },
+                {
+                    "condition": {
+                        "observe": "tool_name",
+                        "pattern": "wildcard",
+                        "children": [{"decision": {"allow": null}}]
+                    }
+                }
+            ]
+        }"#;
+        let policy = compile_to_tree(source).unwrap();
+        let tree_lines = format_tree(&policy);
+        insta::assert_snapshot!("format_tree_with_sandbox", tree_lines.join("\n"));
+    }
+
+    #[test]
+    fn snapshot_format_rules_mixed_capabilities() {
+        let source = r#"{
+            "schema_version": 5,
+            "default_effect": "ask",
+            "sandboxes": {},
+            "tree": [
+                {
+                    "condition": {
+                        "observe": "tool_name",
+                        "pattern": {"literal": {"literal": "Bash"}},
+                        "children": [{
+                            "condition": {
+                                "observe": {"positional_arg": 0},
+                                "pattern": {"literal": {"literal": "git"}},
+                                "children": [{"decision": {"allow": null}}]
+                            }
+                        }]
+                    }
+                },
+                {
+                    "condition": {
+                        "observe": "fs_op",
+                        "pattern": {"literal": {"literal": "read"}},
+                        "children": [{"decision": {"allow": null}}]
+                    }
+                },
+                {
+                    "condition": {
+                        "observe": "net_domain",
+                        "pattern": {"literal": {"literal": "github.com"}},
+                        "children": [{"decision": {"allow": null}}]
+                    }
+                }
+            ]
+        }"#;
+        let policy = compile_to_tree(source).unwrap();
+        let rules = format_rules(&policy);
+        insta::assert_snapshot!("format_rules_mixed_caps", rules.join("\n"));
+    }
+
+    #[test]
+    fn snapshot_format_tree_nested_conditions() {
+        let source = r#"{
+            "schema_version": 5,
+            "default_effect": "deny",
+            "sandboxes": {},
+            "tree": [{
+                "condition": {
+                    "observe": "tool_name",
+                    "pattern": {"literal": {"literal": "Bash"}},
+                    "children": [
+                        {
+                            "condition": {
+                                "observe": {"positional_arg": 0},
+                                "pattern": {"literal": {"literal": "git"}},
+                                "children": [
+                                    {
+                                        "condition": {
+                                            "observe": {"positional_arg": 1},
+                                            "pattern": {"literal": {"literal": "push"}},
+                                            "children": [{"decision": {"deny": null}}]
+                                        }
+                                    },
+                                    {"decision": {"allow": null}}
+                                ]
+                            }
+                        },
+                        {"decision": {"ask": null}}
+                    ]
+                }
+            }]
+        }"#;
+        let policy = compile_to_tree(source).unwrap();
+        let tree_lines = format_tree(&policy);
+        insta::assert_snapshot!("format_tree_nested", tree_lines.join("\n"));
+    }
+}

--- a/clash/src/policy/match_tree.rs
+++ b/clash/src/policy/match_tree.rs
@@ -1990,4 +1990,142 @@ mod tests {
         };
         assert!(policy.platform_warnings().is_empty());
     }
+
+    // -----------------------------------------------------------------------
+    // Snapshot tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn snapshot_eval_trace_match() {
+        let source = r#"{
+            "schema_version": 5,
+            "default_effect": "deny",
+            "sandboxes": {},
+            "tree": [{
+                "condition": {
+                    "observe": "tool_name",
+                    "pattern": {"literal": {"literal": "Bash"}},
+                    "children": [{
+                        "condition": {
+                            "observe": {"positional_arg": 0},
+                            "pattern": {"literal": {"literal": "git"}},
+                            "children": [{"decision": {"allow": null}}]
+                        }
+                    }]
+                }
+            }]
+        }"#;
+        let policy: CompiledPolicy = serde_json::from_str(source).unwrap();
+        let decision = policy.evaluate("Bash", &serde_json::json!({"command": "git status"}));
+        insta::assert_snapshot!("eval_trace_match", decision.explanation().join("\n"));
+    }
+
+    #[test]
+    fn snapshot_eval_trace_no_match() {
+        let source = r#"{
+            "schema_version": 5,
+            "default_effect": "deny",
+            "sandboxes": {},
+            "tree": [{
+                "condition": {
+                    "observe": "tool_name",
+                    "pattern": {"literal": {"literal": "Bash"}},
+                    "children": [{
+                        "condition": {
+                            "observe": {"positional_arg": 0},
+                            "pattern": {"literal": {"literal": "git"}},
+                            "children": [{"decision": {"allow": null}}]
+                        }
+                    }]
+                }
+            }]
+        }"#;
+        let policy: CompiledPolicy = serde_json::from_str(source).unwrap();
+        let decision = policy.evaluate("Read", &serde_json::json!({"file_path": "/etc/passwd"}));
+        insta::assert_snapshot!("eval_trace_no_match", decision.explanation().join("\n"));
+    }
+
+    #[test]
+    fn snapshot_eval_human_explanation_match() {
+        let source = r#"{
+            "schema_version": 5,
+            "default_effect": "deny",
+            "sandboxes": {},
+            "tree": [{
+                "condition": {
+                    "observe": "tool_name",
+                    "pattern": {"literal": {"literal": "Bash"}},
+                    "children": [{
+                        "condition": {
+                            "observe": {"positional_arg": 0},
+                            "pattern": {"literal": {"literal": "git"}},
+                            "children": [{"decision": {"allow": null}}]
+                        }
+                    }]
+                }
+            }]
+        }"#;
+        let policy: CompiledPolicy = serde_json::from_str(source).unwrap();
+        let decision = policy.evaluate("Bash", &serde_json::json!({"command": "git push"}));
+        insta::assert_snapshot!(
+            "eval_human_explanation_match",
+            decision.human_explanation().join("\n")
+        );
+    }
+
+    #[test]
+    fn snapshot_eval_human_explanation_default() {
+        let source = r#"{
+            "schema_version": 5,
+            "default_effect": "ask",
+            "sandboxes": {},
+            "tree": [{
+                "condition": {
+                    "observe": "tool_name",
+                    "pattern": {"literal": {"literal": "Bash"}},
+                    "children": [{"decision": {"allow": null}}]
+                }
+            }]
+        }"#;
+        let policy: CompiledPolicy = serde_json::from_str(source).unwrap();
+        let decision = policy.evaluate("Read", &serde_json::json!({"file_path": "/etc/hosts"}));
+        insta::assert_snapshot!(
+            "eval_human_explanation_default",
+            decision.human_explanation().join("\n")
+        );
+    }
+
+    #[test]
+    fn snapshot_eval_decision_debug() {
+        let source = r#"{
+            "schema_version": 5,
+            "default_effect": "deny",
+            "sandboxes": {},
+            "tree": [
+                {
+                    "condition": {
+                        "observe": "tool_name",
+                        "pattern": {"literal": {"literal": "Bash"}},
+                        "children": [{
+                            "condition": {
+                                "observe": {"positional_arg": 0},
+                                "pattern": {"literal": {"literal": "git"}},
+                                "children": [{"decision": {"deny": null}}]
+                            }
+                        }]
+                    }
+                },
+                {
+                    "condition": {
+                        "observe": "tool_name",
+                        "pattern": "wildcard",
+                        "children": [{"decision": {"allow": null}}]
+                    }
+                }
+            ]
+        }"#;
+        let policy: CompiledPolicy = serde_json::from_str(source).unwrap();
+        let decision = policy.evaluate("Bash", &serde_json::json!({"command": "git push"}));
+        insta::assert_debug_snapshot!("eval_decision_debug", decision.trace);
+    }
 }

--- a/clash/src/policy/snapshots/clash__policy__compile__tests__compile_error_invalid_json.snap
+++ b/clash/src/policy/snapshots/clash__policy__compile__tests__compile_error_invalid_json.snap
@@ -1,0 +1,5 @@
+---
+source: clash/src/policy/compile.rs
+expression: err
+---
+invalid match tree policy JSON: expected ident at line 1 column 2

--- a/clash/src/policy/snapshots/clash__policy__compile__tests__compile_error_undefined_sandbox.snap
+++ b/clash/src/policy/snapshots/clash__policy__compile__tests__compile_error_undefined_sandbox.snap
@@ -1,0 +1,5 @@
+---
+source: clash/src/policy/compile.rs
+expression: err
+---
+match tree validation errors: sandbox reference 'nonexistent' not found in sandboxes map

--- a/clash/src/policy/snapshots/clash__policy__compile__tests__compiled_exec_rule.snap
+++ b/clash/src/policy/snapshots/clash__policy__compile__tests__compiled_exec_rule.snap
@@ -1,0 +1,41 @@
+---
+source: clash/src/policy/compile.rs
+expression: policy
+---
+{
+  "sandboxes": {},
+  "tree": [
+    {
+      "condition": {
+        "observe": "tool_name",
+        "pattern": {
+          "literal": {
+            "literal": "Bash"
+          }
+        },
+        "children": [
+          {
+            "condition": {
+              "observe": {
+                "positional_arg": 0
+              },
+              "pattern": {
+                "literal": {
+                  "literal": "git"
+                }
+              },
+              "children": [
+                {
+                  "decision": {
+                    "allow": null
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ],
+  "default_effect": "deny"
+}

--- a/clash/src/policy/snapshots/clash__policy__compile__tests__compiled_fs_rule.snap
+++ b/clash/src/policy/snapshots/clash__policy__compile__tests__compiled_fs_rule.snap
@@ -1,0 +1,39 @@
+---
+source: clash/src/policy/compile.rs
+expression: policy
+---
+{
+  "sandboxes": {},
+  "tree": [
+    {
+      "condition": {
+        "observe": "fs_op",
+        "pattern": {
+          "literal": {
+            "literal": "read"
+          }
+        },
+        "children": [
+          {
+            "condition": {
+              "observe": "fs_path",
+              "pattern": {
+                "prefix": {
+                  "literal": "/home/user/project"
+                }
+              },
+              "children": [
+                {
+                  "decision": {
+                    "allow": null
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ],
+  "default_effect": "deny"
+}

--- a/clash/src/policy/snapshots/clash__policy__compile__tests__compiled_net_rule.snap
+++ b/clash/src/policy/snapshots/clash__policy__compile__tests__compiled_net_rule.snap
@@ -1,0 +1,27 @@
+---
+source: clash/src/policy/compile.rs
+expression: policy
+---
+{
+  "sandboxes": {},
+  "tree": [
+    {
+      "condition": {
+        "observe": "net_domain",
+        "pattern": {
+          "literal": {
+            "literal": "github.com"
+          }
+        },
+        "children": [
+          {
+            "decision": {
+              "allow": null
+            }
+          }
+        ]
+      }
+    }
+  ],
+  "default_effect": "deny"
+}

--- a/clash/src/policy/snapshots/clash__policy__compile__tests__compiled_sandbox_policy.snap
+++ b/clash/src/policy/snapshots/clash__policy__compile__tests__compiled_sandbox_policy.snap
@@ -1,0 +1,59 @@
+---
+source: clash/src/policy/compile.rs
+expression: policy
+---
+{
+  "sandboxes": {
+    "dev": {
+      "default": [
+        "read",
+        "execute"
+      ],
+      "rules": [
+        {
+          "effect": "allow",
+          "caps": [
+            "read",
+            "write"
+          ],
+          "path": "/home/user/project",
+          "path_match": "subpath"
+        }
+      ],
+      "network": "deny"
+    }
+  },
+  "tree": [
+    {
+      "condition": {
+        "observe": "tool_name",
+        "pattern": {
+          "literal": {
+            "literal": "Bash"
+          }
+        },
+        "children": [
+          {
+            "decision": {
+              "allow": "dev"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "condition": {
+        "observe": "tool_name",
+        "pattern": "wildcard",
+        "children": [
+          {
+            "decision": {
+              "allow": null
+            }
+          }
+        ]
+      }
+    }
+  ],
+  "default_effect": "deny"
+}

--- a/clash/src/policy/snapshots/clash__policy__error__tests__error_circular_include.snap
+++ b/clash/src/policy/snapshots/clash__policy__error__tests__error_circular_include.snap
@@ -1,0 +1,5 @@
+---
+source: clash/src/policy/error.rs
+expression: "format!(\"{err}\")"
+---
+circular profile include: base

--- a/clash/src/policy/snapshots/clash__policy__error__tests__error_circular_include_hint.snap
+++ b/clash/src/policy/snapshots/clash__policy__error__tests__error_circular_include_hint.snap
@@ -1,0 +1,5 @@
+---
+source: clash/src/policy/error.rs
+expression: err.help().unwrap()
+---
+include cycle: base -> strict -> base

--- a/clash/src/policy/snapshots/clash__policy__error__tests__error_compile_invalid_glob.snap
+++ b/clash/src/policy/snapshots/clash__policy__error__tests__error_compile_invalid_glob.snap
@@ -1,0 +1,8 @@
+---
+source: clash/src/policy/error.rs
+expression: "format!(\"{err}\")"
+---
+invalid glob pattern '[invalid': regex parse error:
+    [invalid
+    ^
+error: unclosed character class

--- a/clash/src/policy/snapshots/clash__policy__error__tests__error_compile_invalid_glob_hint.snap
+++ b/clash/src/policy/snapshots/clash__policy__error__tests__error_compile_invalid_glob_hint.snap
@@ -1,0 +1,5 @@
+---
+source: clash/src/policy/error.rs
+expression: err.help().unwrap()
+---
+check glob pattern '[invalid': use * for single segment, ** for recursive, ? for single char

--- a/clash/src/policy/snapshots/clash__policy__error__tests__error_invalid_effect.snap
+++ b/clash/src/policy/snapshots/clash__policy__error__tests__error_invalid_effect.snap
@@ -1,0 +1,5 @@
+---
+source: clash/src/policy/error.rs
+expression: "format!(\"{err}\")"
+---
+invalid effect 'yolo'

--- a/clash/src/policy/snapshots/clash__policy__error__tests__error_invalid_effect_hint.snap
+++ b/clash/src/policy/snapshots/clash__policy__error__tests__error_invalid_effect_hint.snap
@@ -1,0 +1,5 @@
+---
+source: clash/src/policy/error.rs
+expression: err.help().unwrap()
+---
+valid effects are: allow, deny, ask (got 'yolo')

--- a/clash/src/policy/snapshots/clash__policy__error__tests__error_invalid_rule.snap
+++ b/clash/src/policy/snapshots/clash__policy__error__tests__error_invalid_rule.snap
@@ -1,0 +1,5 @@
+---
+source: clash/src/policy/error.rs
+expression: "format!(\"{err}\")"
+---
+invalid rule 'broken rule': expected effect at start

--- a/clash/src/policy/snapshots/clash__policy__error__tests__error_invalid_rule_hint.snap
+++ b/clash/src/policy/snapshots/clash__policy__error__tests__error_invalid_rule_hint.snap
@@ -1,0 +1,5 @@
+---
+source: clash/src/policy/error.rs
+expression: err.help().unwrap()
+---
+expected format: 'effect entity tool pattern [: constraint]' (got 'broken rule')

--- a/clash/src/policy/snapshots/clash__policy__error__tests__error_unknown_include_with_suggestion.snap
+++ b/clash/src/policy/snapshots/clash__policy__error__tests__error_unknown_include_with_suggestion.snap
@@ -1,0 +1,5 @@
+---
+source: clash/src/policy/error.rs
+expression: "format!(\"{err}\")"
+---
+unknown profile 'strct' in include; did you mean 'strict'?

--- a/clash/src/policy/snapshots/clash__policy__format__tests__format_rules_exec.snap
+++ b/clash/src/policy/snapshots/clash__policy__format__tests__format_rules_exec.snap
@@ -1,0 +1,6 @@
+---
+source: clash/src/policy/format.rs
+expression: "rules.join(\"\\n\")"
+---
+allow tool="Bash" → arg[0]="git"
+deny tool=*

--- a/clash/src/policy/snapshots/clash__policy__format__tests__format_rules_mixed_caps.snap
+++ b/clash/src/policy/snapshots/clash__policy__format__tests__format_rules_mixed_caps.snap
@@ -1,0 +1,7 @@
+---
+source: clash/src/policy/format.rs
+expression: "rules.join(\"\\n\")"
+---
+allow net_domain="github.com"
+allow tool="Bash" → arg[0]="git"
+allow fs_op="read"

--- a/clash/src/policy/snapshots/clash__policy__format__tests__format_tree_exec.snap
+++ b/clash/src/policy/snapshots/clash__policy__format__tests__format_tree_exec.snap
@@ -1,0 +1,7 @@
+---
+source: clash/src/policy/format.rs
+expression: "tree_lines.join(\"\\n\")"
+---
+tool="Bash"
+└── arg[0]="git" → allow
+tool=* → deny

--- a/clash/src/policy/snapshots/clash__policy__format__tests__format_tree_nested.snap
+++ b/clash/src/policy/snapshots/clash__policy__format__tests__format_tree_nested.snap
@@ -1,0 +1,9 @@
+---
+source: clash/src/policy/format.rs
+expression: "tree_lines.join(\"\\n\")"
+---
+tool="Bash"
+├── arg[0]="git"
+│   ├── arg[1]="push" → deny
+│   └── allow
+└── ask

--- a/clash/src/policy/snapshots/clash__policy__format__tests__format_tree_with_sandbox.snap
+++ b/clash/src/policy/snapshots/clash__policy__format__tests__format_tree_with_sandbox.snap
@@ -1,0 +1,6 @@
+---
+source: clash/src/policy/format.rs
+expression: "tree_lines.join(\"\\n\")"
+---
+tool="Bash" → allow [sandbox: dev]
+tool=* → allow

--- a/clash/src/policy/snapshots/clash__policy__match_tree__tests__eval_decision_debug.snap
+++ b/clash/src/policy/snapshots/clash__policy__match_tree__tests__eval_decision_debug.snap
@@ -1,0 +1,24 @@
+---
+source: clash/src/policy/match_tree.rs
+expression: decision.trace
+---
+DecisionTrace {
+    matched_rules: [
+        RuleMatch {
+            rule_index: 0,
+            description: "PositionalArg(0)=git",
+            effect: Allow,
+            has_active_constraints: true,
+            node_id: None,
+        },
+        RuleMatch {
+            rule_index: 1,
+            description: "ToolName=Bash",
+            effect: Allow,
+            has_active_constraints: true,
+            node_id: None,
+        },
+    ],
+    skipped_rules: [],
+    final_resolution: "result: deny",
+}

--- a/clash/src/policy/snapshots/clash__policy__match_tree__tests__eval_human_explanation_default.snap
+++ b/clash/src/policy/snapshots/clash__policy__match_tree__tests__eval_human_explanation_default.snap
@@ -1,0 +1,6 @@
+---
+source: clash/src/policy/match_tree.rs
+expression: "decision.human_explanation().join(\"\\n\")"
+---
+Rule 'ToolName: Literal(Literal("Bash"))' was skipped: pattern does not match this request
+No rules matched. Defaulting to ask.

--- a/clash/src/policy/snapshots/clash__policy__match_tree__tests__eval_human_explanation_match.snap
+++ b/clash/src/policy/snapshots/clash__policy__match_tree__tests__eval_human_explanation_match.snap
@@ -1,0 +1,7 @@
+---
+source: clash/src/policy/match_tree.rs
+expression: "decision.human_explanation().join(\"\\n\")"
+---
+Rule 'PositionalArg(0)=git' matched — action allowed
+Rule 'ToolName=Bash' matched — action allowed
+Final decision: allow

--- a/clash/src/policy/snapshots/clash__policy__match_tree__tests__eval_trace_match.snap
+++ b/clash/src/policy/snapshots/clash__policy__match_tree__tests__eval_trace_match.snap
@@ -1,0 +1,7 @@
+---
+source: clash/src/policy/match_tree.rs
+expression: "decision.explanation().join(\"\\n\")"
+---
+matched: PositionalArg(0)=git
+matched: ToolName=Bash
+result: allow

--- a/clash/src/policy/snapshots/clash__policy__match_tree__tests__eval_trace_no_match.snap
+++ b/clash/src/policy/snapshots/clash__policy__match_tree__tests__eval_trace_no_match.snap
@@ -1,0 +1,6 @@
+---
+source: clash/src/policy/match_tree.rs
+expression: "decision.explanation().join(\"\\n\")"
+---
+skipped: ToolName: Literal(Literal("Bash")) (pattern mismatch (value: Read))
+no rules matched, default: deny

--- a/clash_starlark/Cargo.toml
+++ b/clash_starlark/Cargo.toml
@@ -20,3 +20,5 @@ include_dir = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }
+insta = { workspace = true, features = ["json"] }
+serde_json = { workspace = true }

--- a/clash_starlark/src/lib.rs
+++ b/clash_starlark/src/lib.rs
@@ -1013,4 +1013,102 @@ def main():
             "should have tmpdir rule"
         );
     }
+
+    // -----------------------------------------------------------------------
+    // Snapshot tests — Starlark to JSON IR
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn snapshot_starlark_simple_policy() {
+        let doc = eval_to_doc(
+            r#"
+load("@clash//std.star", "tool", "policy")
+
+def main():
+    return policy(default = deny, rules = [tool().allow()])
+"#,
+        );
+        insta::assert_json_snapshot!("starlark_simple_policy", doc);
+    }
+
+    #[test]
+    fn snapshot_starlark_exec_rules() {
+        let doc = eval_to_doc(
+            r#"
+load("@clash//std.star", "exe", "tool", "policy")
+
+def main():
+    return policy(default = deny, rules = [
+        exe("git").allow(),
+        exe("cargo").allow(),
+        tool("Read").allow(),
+        tool().deny(),
+    ])
+"#,
+        );
+        insta::assert_json_snapshot!("starlark_exec_rules", doc);
+    }
+
+    #[test]
+    fn snapshot_starlark_exe_with_args() {
+        let doc = eval_to_doc(
+            r#"
+load("@clash//std.star", "exe", "tool", "policy")
+
+def main():
+    return policy(default = deny, rules = [
+        exe("git", args = ["push"]).deny(),
+        exe("git").allow(),
+        tool().allow(),
+    ])
+"#,
+        );
+        insta::assert_json_snapshot!("starlark_exe_with_args", doc);
+    }
+
+    #[test]
+    fn snapshot_starlark_regex_pattern() {
+        let doc = eval_to_doc(
+            r#"
+load("@clash//std.star", "exe", "regex", "policy")
+
+def main():
+    return policy(default = deny, rules = [
+        exe(regex("cargo.*")).allow(),
+    ])
+"#,
+        );
+        insta::assert_json_snapshot!("starlark_regex_pattern", doc);
+    }
+
+    #[test]
+    fn snapshot_starlark_fs_rules() {
+        let doc = eval_to_doc(
+            r#"
+load("@clash//std.star", "tool", "policy", "cwd")
+
+def main():
+    return policy(default = deny, rules = [
+        cwd().file(".env").deny(write = True),
+        cwd().allow(read = True, write = True),
+        tool().allow(),
+    ])
+"#,
+        );
+        insta::assert_json_snapshot!("starlark_fs_rules", doc);
+    }
+
+    #[test]
+    fn snapshot_starlark_error_no_main() {
+        let result = evaluate("x = 1", "test.star", &PathBuf::from("."));
+        let err = result.unwrap_err().to_string();
+        insta::assert_snapshot!("starlark_error_no_main", err);
+    }
+
+    #[test]
+    fn snapshot_starlark_error_syntax() {
+        let result = evaluate("def main(\n  broken", "test.star", &PathBuf::from("."));
+        let err = result.unwrap_err().to_string();
+        insta::assert_snapshot!("starlark_error_syntax", err);
+    }
 }

--- a/clash_starlark/src/snapshots/clash_starlark__tests__starlark_error_no_main.snap
+++ b/clash_starlark/src/snapshots/clash_starlark__tests__starlark_error_no_main.snap
@@ -1,0 +1,5 @@
+---
+source: clash_starlark/src/lib.rs
+expression: err
+---
+policy.star must define a main() function

--- a/clash_starlark/src/snapshots/clash_starlark__tests__starlark_error_syntax.snap
+++ b/clash_starlark/src/snapshots/clash_starlark__tests__starlark_error_syntax.snap
@@ -1,0 +1,10 @@
+---
+source: clash_starlark/src/lib.rs
+expression: err
+---
+error: Parse error: unexpected new line here, expected one of "(", ")", ",", ":" or "="
+ --> test.star:2:9
+  |
+2 |   broken
+  |         
+  |

--- a/clash_starlark/src/snapshots/clash_starlark__tests__starlark_exe_with_args.snap
+++ b/clash_starlark/src/snapshots/clash_starlark__tests__starlark_exe_with_args.snap
@@ -1,0 +1,104 @@
+---
+source: clash_starlark/src/lib.rs
+expression: doc
+---
+{
+  "default_effect": "deny",
+  "sandboxes": {},
+  "schema_version": 5,
+  "tree": [
+    {
+      "condition": {
+        "children": [
+          {
+            "condition": {
+              "children": [
+                {
+                  "condition": {
+                    "children": [
+                      {
+                        "decision": "deny"
+                      }
+                    ],
+                    "observe": {
+                      "positional_arg": 1
+                    },
+                    "pattern": {
+                      "literal": {
+                        "literal": "push"
+                      }
+                    },
+                    "source": "test.star:6:9-36"
+                  }
+                }
+              ],
+              "observe": {
+                "positional_arg": 0
+              },
+              "pattern": {
+                "literal": {
+                  "literal": "git"
+                }
+              },
+              "source": "test.star:6:9-36"
+            }
+          }
+        ],
+        "observe": "tool_name",
+        "pattern": {
+          "literal": {
+            "literal": "Bash"
+          }
+        },
+        "source": "test.star:6:9-36"
+      }
+    },
+    {
+      "condition": {
+        "children": [
+          {
+            "condition": {
+              "children": [
+                {
+                  "decision": {
+                    "allow": null
+                  }
+                }
+              ],
+              "observe": {
+                "positional_arg": 0
+              },
+              "pattern": {
+                "literal": {
+                  "literal": "git"
+                }
+              },
+              "source": "test.star:7:9-19"
+            }
+          }
+        ],
+        "observe": "tool_name",
+        "pattern": {
+          "literal": {
+            "literal": "Bash"
+          }
+        },
+        "source": "test.star:7:9-19"
+      }
+    },
+    {
+      "condition": {
+        "children": [
+          {
+            "decision": {
+              "allow": null
+            }
+          }
+        ],
+        "observe": "tool_name",
+        "pattern": "wildcard",
+        "source": "test.star:8:9-15"
+      }
+    }
+  ]
+}

--- a/clash_starlark/src/snapshots/clash_starlark__tests__starlark_exec_rules.snap
+++ b/clash_starlark/src/snapshots/clash_starlark__tests__starlark_exec_rules.snap
@@ -1,0 +1,107 @@
+---
+source: clash_starlark/src/lib.rs
+expression: doc
+---
+{
+  "default_effect": "deny",
+  "sandboxes": {},
+  "schema_version": 5,
+  "tree": [
+    {
+      "condition": {
+        "children": [
+          {
+            "condition": {
+              "children": [
+                {
+                  "decision": {
+                    "allow": null
+                  }
+                }
+              ],
+              "observe": {
+                "positional_arg": 0
+              },
+              "pattern": {
+                "literal": {
+                  "literal": "git"
+                }
+              },
+              "source": "test.star:6:9-19"
+            }
+          }
+        ],
+        "observe": "tool_name",
+        "pattern": {
+          "literal": {
+            "literal": "Bash"
+          }
+        },
+        "source": "test.star:6:9-19"
+      }
+    },
+    {
+      "condition": {
+        "children": [
+          {
+            "condition": {
+              "children": [
+                {
+                  "decision": {
+                    "allow": null
+                  }
+                }
+              ],
+              "observe": {
+                "positional_arg": 0
+              },
+              "pattern": {
+                "literal": {
+                  "literal": "cargo"
+                }
+              },
+              "source": "test.star:7:9-21"
+            }
+          }
+        ],
+        "observe": "tool_name",
+        "pattern": {
+          "literal": {
+            "literal": "Bash"
+          }
+        },
+        "source": "test.star:7:9-21"
+      }
+    },
+    {
+      "condition": {
+        "children": [
+          {
+            "decision": {
+              "allow": null
+            }
+          }
+        ],
+        "observe": "tool_name",
+        "pattern": {
+          "literal": {
+            "literal": "Read"
+          }
+        },
+        "source": "test.star:8:9-21"
+      }
+    },
+    {
+      "condition": {
+        "children": [
+          {
+            "decision": "deny"
+          }
+        ],
+        "observe": "tool_name",
+        "pattern": "wildcard",
+        "source": "test.star:9:9-15"
+      }
+    }
+  ]
+}

--- a/clash_starlark/src/snapshots/clash_starlark__tests__starlark_fs_rules.snap
+++ b/clash_starlark/src/snapshots/clash_starlark__tests__starlark_fs_rules.snap
@@ -1,0 +1,123 @@
+---
+source: clash_starlark/src/lib.rs
+expression: doc
+---
+{
+  "default_effect": "deny",
+  "sandboxes": {},
+  "schema_version": 5,
+  "tree": [
+    {
+      "condition": {
+        "children": [
+          {
+            "condition": {
+              "children": [
+                {
+                  "decision": "deny"
+                }
+              ],
+              "observe": "fs_path",
+              "pattern": {
+                "literal": {
+                  "path": [
+                    {
+                      "env": "PWD"
+                    },
+                    {
+                      "literal": ".env"
+                    }
+                  ]
+                }
+              },
+              "source": "test.star:6:9-46"
+            }
+          }
+        ],
+        "observe": "fs_op",
+        "pattern": {
+          "literal": {
+            "literal": "write"
+          }
+        },
+        "source": "test.star:6:9-46"
+      }
+    },
+    {
+      "condition": {
+        "children": [
+          {
+            "condition": {
+              "children": [
+                {
+                  "decision": {
+                    "allow": null
+                  }
+                }
+              ],
+              "observe": "fs_path",
+              "pattern": {
+                "literal": {
+                  "env": "PWD"
+                }
+              },
+              "source": "test.star:7:9-47"
+            }
+          }
+        ],
+        "observe": "fs_op",
+        "pattern": {
+          "literal": {
+            "literal": "read"
+          }
+        },
+        "source": "test.star:7:9-47"
+      }
+    },
+    {
+      "condition": {
+        "children": [
+          {
+            "condition": {
+              "children": [
+                {
+                  "decision": {
+                    "allow": null
+                  }
+                }
+              ],
+              "observe": "fs_path",
+              "pattern": {
+                "literal": {
+                  "env": "PWD"
+                }
+              },
+              "source": "test.star:7:9-47"
+            }
+          }
+        ],
+        "observe": "fs_op",
+        "pattern": {
+          "literal": {
+            "literal": "write"
+          }
+        },
+        "source": "test.star:7:9-47"
+      }
+    },
+    {
+      "condition": {
+        "children": [
+          {
+            "decision": {
+              "allow": null
+            }
+          }
+        ],
+        "observe": "tool_name",
+        "pattern": "wildcard",
+        "source": "test.star:8:9-15"
+      }
+    }
+  ]
+}

--- a/clash_starlark/src/snapshots/clash_starlark__tests__starlark_regex_pattern.snap
+++ b/clash_starlark/src/snapshots/clash_starlark__tests__starlark_regex_pattern.snap
@@ -1,0 +1,42 @@
+---
+source: clash_starlark/src/lib.rs
+expression: doc
+---
+{
+  "default_effect": "deny",
+  "sandboxes": {},
+  "schema_version": 5,
+  "tree": [
+    {
+      "condition": {
+        "children": [
+          {
+            "condition": {
+              "children": [
+                {
+                  "decision": {
+                    "allow": null
+                  }
+                }
+              ],
+              "observe": {
+                "positional_arg": 0
+              },
+              "pattern": {
+                "regex": "cargo.*"
+              },
+              "source": "test.star:6:9-30"
+            }
+          }
+        ],
+        "observe": "tool_name",
+        "pattern": {
+          "literal": {
+            "literal": "Bash"
+          }
+        },
+        "source": "test.star:6:9-30"
+      }
+    }
+  ]
+}

--- a/clash_starlark/src/snapshots/clash_starlark__tests__starlark_simple_policy.snap
+++ b/clash_starlark/src/snapshots/clash_starlark__tests__starlark_simple_policy.snap
@@ -1,0 +1,25 @@
+---
+source: clash_starlark/src/lib.rs
+expression: doc
+---
+{
+  "default_effect": "deny",
+  "sandboxes": {},
+  "schema_version": 5,
+  "tree": [
+    {
+      "condition": {
+        "children": [
+          {
+            "decision": {
+              "allow": null
+            }
+          }
+        ],
+        "observe": "tool_name",
+        "pattern": "wildcard",
+        "source": "test.star:5:44-50"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Add 32 insta snapshot tests across the policy subsystem to catch accidental regressions in output formatting
- Cover policy compilation (exec/fs/net/sandbox), policy tree and rule formatting, error messages with hints, decision trace explanations, and Starlark-to-JSON IR compilation
- Enable the `json` feature on `insta` for `assert_json_snapshot!` in both `clash` and `clash_starlark` crates

## Test plan
- [x] `just check` passes cleanly (all unit tests, lints, and end-to-end tests)
- [x] All 32 snapshot files generated and reviewed via `cargo insta test --accept`
- [x] No `.snap.new` pending files remain