### PR TITLE
test(clester): add e2e tests for policy layer precedence

### DIFF
--- a/clester/tests/scripts/star_default_override.yaml
+++ b/clester/tests/scripts/star_default_override.yaml
@@ -1,0 +1,39 @@
+meta:
+  name: starlark policy — project default overrides user default
+  description: Project-level default effect takes precedence over user-level default
+
+clash:
+  policy_star: |
+    load("@clash//std.star", "exe", "policy", "allow")
+    def main():
+        return policy(default=allow(), rules=[])
+  project_policy_star: |
+    load("@clash//std.star", "exe", "policy", "deny")
+    def main():
+        return policy(default=deny(), rules=[])
+
+steps:
+  - name: unknown command denied by project default (overrides user allow)
+    hook: pre-tool-use
+    tool_name: Bash
+    tool_input:
+      command: some-unknown-command --flag
+    expect:
+      decision: deny
+
+  - name: read denied by project default
+    hook: pre-tool-use
+    tool_name: Read
+    tool_input:
+      file_path: /tmp/somefile.txt
+    expect:
+      decision: deny
+
+  - name: write denied by project default
+    hook: pre-tool-use
+    tool_name: Write
+    tool_input:
+      file_path: /tmp/output.txt
+      content: hello
+    expect:
+      decision: deny

--- a/clester/tests/scripts/star_layer_precedence.yaml
+++ b/clester/tests/scripts/star_layer_precedence.yaml
@@ -1,0 +1,43 @@
+meta:
+  name: starlark policy — project layer overrides user rules
+  description: Project-level policy can add deny rules that override user-level allows
+
+clash:
+  policy_star: |
+    load("@clash//std.star", "exe", "policy", "ask", "allow")
+    def main():
+        return policy(default=ask(), rules=[
+            exe("git").allow(),
+            exe("cargo").allow(),
+        ])
+  project_policy_star: |
+    load("@clash//std.star", "exe", "policy", "deny")
+    def main():
+        return policy(default=deny(), rules=[
+            exe("git", args=["push"]).deny(),
+        ])
+
+steps:
+  - name: git status allowed by user rule (not overridden by project)
+    hook: pre-tool-use
+    tool_name: Bash
+    tool_input:
+      command: git status
+    expect:
+      decision: allow
+
+  - name: git push denied by project deny rule
+    hook: pre-tool-use
+    tool_name: Bash
+    tool_input:
+      command: git push origin main
+    expect:
+      decision: deny
+
+  - name: cargo build allowed by user rule
+    hook: pre-tool-use
+    tool_name: Bash
+    tool_input:
+      command: cargo build
+    expect:
+      decision: allow


### PR DESCRIPTION
## Summary
- Add `star_layer_precedence.yaml`: verifies that project-level deny rules override user-level allows (user allows git+cargo, project denies git push; git status passes, git push is denied, cargo passes)
- Add `star_default_override.yaml`: verifies that project-level default effect overrides user-level default (user default=allow, project default=deny; unknown commands are denied)

## Test plan
- [x] `clester run clester/tests/scripts/star_layer_precedence.yaml` — all 3 steps pass
- [x] `clester run clester/tests/scripts/star_default_override.yaml` — all 3 steps pass