### PR TITLE
docs: add curated policy examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,16 @@ Even if a command is allowed by policy, the sandbox ensures it can only access t
 
 For the full rule syntax, see the [Policy Writing Guide](docs/policy-guide.md).
 
+### Examples
+
+See the [`examples/`](examples/) directory for ready-to-use policies:
+
+- **[rust-dev.star](examples/rust-dev.star)** — Rust development with cargo sandboxing
+- **[node-dev.star](examples/node-dev.star)** — Node.js development with npm/bun
+- **[python-dev.star](examples/python-dev.star)** — Python development with pip/uv
+- **[paranoid.star](examples/paranoid.star)** — Maximum security, read-only access
+- **[permissive.star](examples/permissive.star)** — Minimal friction, common tools allowed
+
 ---
 
 ## Useful Commands

--- a/examples/node-dev.star
+++ b/examples/node-dev.star
@@ -1,0 +1,28 @@
+# Node.js Development Policy
+# Allows npm/bun/node with sandboxed filesystem access.
+load("@clash//std.star", "exe", "tool", "policy", "sandbox", "cwd", "tempdir", "allow", "deny", "ask")
+
+def main():
+    node_sandbox = sandbox(
+        name = "node",
+        default = deny(),
+        fs = [
+            cwd(follow_worktrees = True).allow(read = True, write = True),
+            tempdir().allow(),
+        ],
+        net = allow(),
+    )
+    return policy(
+        default = ask(),
+        rules = [
+            exe("npm").sandbox(node_sandbox).allow(),
+            exe("npx").sandbox(node_sandbox).allow(),
+            exe("node").sandbox(node_sandbox).allow(),
+            exe("bun").sandbox(node_sandbox).allow(),
+            exe("git").allow(),
+            exe("git", args = ["push", "--force"]).deny(),
+            tool("Read").allow(),
+            tool("Glob").allow(),
+            tool("Grep").allow(),
+        ],
+    )

--- a/examples/paranoid.star
+++ b/examples/paranoid.star
@@ -1,0 +1,17 @@
+# Maximum Security Policy
+# Deny-all default. Only read-only git and file reading tools allowed.
+# Use this when security is more important than convenience.
+load("@clash//std.star", "exe", "tool", "policy", "deny")
+
+def main():
+    return policy(
+        default = deny(),
+        rules = [
+            exe("git", args = ["status"]).allow(),
+            exe("git", args = ["diff"]).allow(),
+            exe("git", args = ["log"]).allow(),
+            tool("Read").allow(),
+            tool("Glob").allow(),
+            tool("Grep").allow(),
+        ],
+    )

--- a/examples/permissive.star
+++ b/examples/permissive.star
@@ -1,0 +1,28 @@
+# Permissive Policy
+# Ask-all default with common dev tools auto-allowed.
+# Denies only truly dangerous operations.
+load("@clash//std.star", "exe", "tool", "policy", "allow", "deny", "ask")
+
+def main():
+    return policy(
+        default = ask(),
+        rules = [
+            exe("git").allow(),
+            exe("git", args = ["push", "--force"]).deny(),
+            exe("cargo").allow(),
+            exe("npm").allow(),
+            exe("npx").allow(),
+            exe("node").allow(),
+            exe("bun").allow(),
+            exe("python").allow(),
+            exe("pip").allow(),
+            exe("uv").allow(),
+            exe("make").allow(),
+            exe("just").allow(),
+            tool("Read").allow(),
+            tool("Write").allow(),
+            tool("Edit").allow(),
+            tool("Glob").allow(),
+            tool("Grep").allow(),
+        ],
+    )

--- a/examples/python-dev.star
+++ b/examples/python-dev.star
@@ -1,0 +1,29 @@
+# Python Development Policy
+# Allows python/pip/uv/pytest with sandboxed filesystem access.
+load("@clash//std.star", "exe", "tool", "policy", "sandbox", "cwd", "tempdir", "allow", "deny", "ask")
+
+def main():
+    py_sandbox = sandbox(
+        name = "python",
+        default = deny(),
+        fs = [
+            cwd(follow_worktrees = True).allow(read = True, write = True),
+            tempdir().allow(),
+        ],
+        net = allow(),
+    )
+    return policy(
+        default = ask(),
+        rules = [
+            exe("python").sandbox(py_sandbox).allow(),
+            exe("python3").sandbox(py_sandbox).allow(),
+            exe("pip").sandbox(py_sandbox).allow(),
+            exe("uv").sandbox(py_sandbox).allow(),
+            exe("pytest").sandbox(py_sandbox).allow(),
+            exe("git").allow(),
+            exe("git", args = ["push", "--force"]).deny(),
+            tool("Read").allow(),
+            tool("Glob").allow(),
+            tool("Grep").allow(),
+        ],
+    )

--- a/examples/rust-dev.star
+++ b/examples/rust-dev.star
@@ -1,0 +1,31 @@
+# Rust Development Policy
+# Allows common Rust toolchain commands with filesystem sandboxing.
+# Default: ask for anything not explicitly allowed.
+load("@clash//std.star", "exe", "tool", "policy", "sandbox", "cwd", "tempdir", "home", "allow", "deny", "ask")
+
+def main():
+    rust_sandbox = sandbox(
+        name = "rust",
+        default = deny(),
+        fs = [
+            cwd(follow_worktrees = True).allow(read = True, write = True),
+            tempdir().allow(),
+            home().child(".cargo").allow(read = True, write = True),
+            home().child(".rustup").allow(read = True),
+        ],
+        net = allow(),
+    )
+    return policy(
+        default = ask(),
+        rules = [
+            exe("cargo").sandbox(rust_sandbox).allow(),
+            exe("rustc").sandbox(rust_sandbox).allow(),
+            exe("rustup").allow(),
+            exe("rustfmt").sandbox(rust_sandbox).allow(),
+            exe("git").allow(),
+            exe("git", args = ["push", "--force"]).deny(),
+            tool("Read").allow(),
+            tool("Glob").allow(),
+            tool("Grep").allow(),
+        ],
+    )


### PR DESCRIPTION
## Summary

- Adds five ready-to-use policy examples in `examples/` covering common development workflows:
  - **rust-dev.star** — Rust toolchain (cargo, rustc, rustfmt) with filesystem sandboxing
  - **node-dev.star** — Node.js (npm, npx, node, bun) with sandboxed filesystem access
  - **python-dev.star** — Python (python, pip, uv, pytest) with sandboxed filesystem access
  - **paranoid.star** — Maximum security deny-all policy with only read-only git and file tools
  - **permissive.star** — Minimal friction ask-all default with common dev tools auto-allowed
- Adds an "Examples" subsection to the README linking to each policy file

## Test plan

- [x] All five `.star` files validated with `clash policy validate --file`
- [ ] Verify links in README render correctly on GitHub