### PR TITLE
refactor: improve error context messages in handlers and settings loader

### DIFF
--- a/clash/src/cmd/hooks.rs
+++ b/clash/src/cmd/hooks.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use anyhow::{Context, Result};
 use tracing::{Level, info, instrument};
 
 use crate::cli::HooksCmd;
@@ -32,7 +32,9 @@ impl HooksCmd {
                 HookOutput::continue_execution()
             }
         };
-        output.write_stdout()?;
+        output
+            .write_stdout()
+            .context("serializing disabled-mode hook response to stdout")?;
         Ok(())
     }
 
@@ -46,7 +48,8 @@ impl HooksCmd {
 
         let output = match self {
             Self::PreToolUse => {
-                let input = ToolUseHookInput::from_reader(std::io::stdin().lock())?;
+                let input = ToolUseHookInput::from_reader(std::io::stdin().lock())
+                    .context("parsing PreToolUse hook input from stdin — expected JSON with tool_name and tool_input fields")?;
 
                 if passthrough {
                     info!(
@@ -117,7 +120,8 @@ impl HooksCmd {
                 }
             }
             Self::PostToolUse => {
-                let input = ToolUseHookInput::from_reader(std::io::stdin().lock())?;
+                let input = ToolUseHookInput::from_reader(std::io::stdin().lock())
+                    .context("parsing PostToolUse hook input from stdin")?;
 
                 // Check if this tool use was previously "ask"ed and the user
                 // accepted. If so, return advisory context suggesting a session
@@ -174,7 +178,8 @@ impl HooksCmd {
                 HookOutput::post_tool_use(context)
             }
             Self::PermissionRequest => {
-                let input = ToolUseHookInput::from_reader(std::io::stdin().lock())?;
+                let input = ToolUseHookInput::from_reader(std::io::stdin().lock())
+                    .context("parsing PermissionRequest hook input from stdin")?;
                 if passthrough {
                     info!(
                         tool = %input.tool_name,
@@ -192,12 +197,14 @@ impl HooksCmd {
             }
             Self::SessionStart => {
                 let input =
-                    crate::hooks::SessionStartHookInput::from_reader(std::io::stdin().lock())?;
+                    crate::hooks::SessionStartHookInput::from_reader(std::io::stdin().lock())
+                        .context("parsing SessionStart hook input from stdin")?;
                 crate::handlers::handle_session_start(&input)?
             }
             Self::Stop => {
                 // Read stdin to avoid broken pipe, extract session_id.
-                let input = crate::hooks::StopHookInput::from_reader(std::io::stdin().lock())?;
+                let input = crate::hooks::StopHookInput::from_reader(std::io::stdin().lock())
+                    .context("parsing Stop hook input from stdin")?;
 
                 // Final catch-up sync for non-tool conversation turns.
                 if let Err(e) = trace::sync_trace(&input.session_id, None) {
@@ -208,7 +215,9 @@ impl HooksCmd {
             }
         };
 
-        output.write_stdout()?;
+        output
+            .write_stdout()
+            .context("serializing hook response to stdout")?;
         Ok(())
     }
 }

--- a/clash/src/settings/loader.rs
+++ b/clash/src/settings/loader.rs
@@ -187,7 +187,8 @@ impl ClashSettings {
     /// Returns `Ok(Some(path))` if a new file was created, `Ok(None)` if one already existed.
     /// The created file uses the embedded `DEFAULT_POLICY` (deny-all with read access to CWD).
     pub fn ensure_user_policy_exists() -> Result<Option<PathBuf>> {
-        let path = Self::policy_file().context("failed to determine user policy file path")?;
+        let path = Self::policy_file()
+            .context("resolving user policy file path (~/.clash/policy.json or CLASH_POLICY_FILE)")?;
         Self::ensure_policy_at(path)
     }
 
@@ -217,7 +218,7 @@ impl ClashSettings {
         }
 
         let json =
-            compile_default_policy_to_json().context("failed to compile default policy to JSON")?;
+            compile_default_policy_to_json().context("compiling embedded default policy (std.star) to JSON")?;
         std::fs::write(&json_path, &json).with_context(|| {
             format!("failed to write default policy to {}", json_path.display())
         })?;


### PR DESCRIPTION
## Summary

- Replace generic `.context("failed to ...")` messages with specific, actionable descriptions that tell the user *what* was being done and *where*
- Add `anyhow::Context` to hook input parsing (`from_reader`) calls in `cmd/hooks.rs` so parse failures name the specific hook event (PreToolUse, PostToolUse, etc.)
- Add context to `write_stdout()` calls so serialization errors are clearly attributed

## Changes

**`clash/src/cmd/hooks.rs`**
- Import `anyhow::Context`
- Add `.context()` to all 5 `from_reader` calls (PreToolUse, PostToolUse, PermissionRequest, SessionStart, Stop)
- Add `.context()` to both `write_stdout()` calls

**`clash/src/settings/loader.rs`**
- `"failed to determine user policy file path"` -> `"resolving user policy file path (~/.clash/policy.json or CLASH_POLICY_FILE)"`
- `"failed to compile default policy to JSON"` -> `"compiling embedded default policy (std.star) to JSON"`

## Test plan

- [x] `cargo test -p clash` — all 489 tests pass
- [x] `cargo clippy -p clash` — no warnings