### PR TITLE
test(clester): add e2e tests for sandbox CLI commands

### DIFF
--- a/clester/tests/scripts/sandbox_cli.yaml
+++ b/clester/tests/scripts/sandbox_cli.yaml
@@ -1,0 +1,72 @@
+meta:
+  name: sandbox CLI — create, list, delete workflow
+  description: Test sandbox create/list/delete commands via the clash CLI
+
+clash:
+  policy_star: |
+    load("@clash//std.star", "exe", "policy", "deny")
+    def main():
+        return policy(default=deny(), rules=[
+            exe("git").allow(),
+        ])
+
+steps:
+  - name: sandbox list shows no sandboxes initially
+    command: sandbox list
+    expect:
+      exit_code: 0
+      stdout_contains: "No sandboxes defined"
+
+  - name: create a sandbox named "ci"
+    command: sandbox create ci --default "read + execute" --network deny --scope user
+    expect:
+      exit_code: 0
+      stdout_contains: "ci"
+
+  - name: sandbox list shows the new sandbox
+    command: sandbox list
+    expect:
+      exit_code: 0
+      stdout_contains: "ci"
+
+  - name: create a second sandbox named "dev"
+    command: sandbox create dev --default "read + write + execute" --network localhost --scope user
+    expect:
+      exit_code: 0
+      stdout_contains: "dev"
+
+  - name: sandbox list shows both sandboxes
+    command: sandbox list
+    expect:
+      exit_code: 0
+      stdout_contains: "ci"
+
+  - name: add a filesystem rule to the ci sandbox
+    command: sandbox add-rule ci --allow "read + write" --path "$HOME/.cache" --scope user
+    expect:
+      exit_code: 0
+      stdout_contains: "Rule added"
+
+  - name: remove the filesystem rule from ci sandbox
+    command: sandbox remove-rule ci --path "$HOME/.cache" --scope user
+    expect:
+      exit_code: 0
+      stdout_contains: "Rule removed"
+
+  - name: delete the ci sandbox
+    command: sandbox delete ci --scope user
+    expect:
+      exit_code: 0
+      stdout_contains: "ci"
+
+  - name: delete the dev sandbox
+    command: sandbox delete dev --scope user
+    expect:
+      exit_code: 0
+      stdout_contains: "dev"
+
+  - name: sandbox list shows no sandboxes after deletion
+    command: sandbox list
+    expect:
+      exit_code: 0
+      stdout_contains: "No sandboxes defined"


### PR DESCRIPTION
## Summary
- Adds `clester/tests/scripts/sandbox_cli.yaml` with 10 end-to-end test steps covering the full sandbox CRUD lifecycle
- Tests `sandbox create`, `sandbox list`, `sandbox add-rule`, `sandbox remove-rule`, and `sandbox delete` commands
- Verifies correct stdout output and exit codes at each step

## Test plan
- [x] `cargo build --bins` succeeds
- [x] `./target/debug/clester run clester/tests/scripts/sandbox_cli.yaml` — all 10 steps pass