### PR TITLE
fix(policy): auto-migrate legacy string-style caps in policy.json

### DIFF
--- a/clash/src/cmd/init.rs
+++ b/clash/src/cmd/init.rs
@@ -103,8 +103,8 @@ fn run_init_user(no_bypass: Option<bool>) -> Result<()> {
 
 /// Quick-init: skip the wizard and write a sensible default policy directly.
 fn run_init_quick(no_bypass: Option<bool>) -> Result<()> {
-    let settings_dir = ClashSettings::settings_dir()
-        .context("could not determine clash settings directory")?;
+    let settings_dir =
+        ClashSettings::settings_dir().context("could not determine clash settings directory")?;
 
     std::fs::create_dir_all(&settings_dir)
         .with_context(|| format!("failed to create {}", settings_dir.display()))?;
@@ -222,11 +222,22 @@ fn run_init_project() -> Result<()> {
     println!();
     println!("{}", style::bold("Setup complete!"));
     println!();
-    ui::success(&format!("Project policy created at {}", policy_path.display()));
+    ui::success(&format!(
+        "Project policy created at {}",
+        policy_path.display()
+    ));
     println!();
     println!("{}:", style::bold("Next steps"));
-    println!("  {}  {}", style::dim("clash policy show"), style::dim("# view the compiled policy"));
-    println!("  {}  {}", style::dim("clash policy validate"), style::dim("# check for errors"));
+    println!(
+        "  {}  {}",
+        style::dim("clash policy show"),
+        style::dim("# view the compiled policy")
+    );
+    println!(
+        "  {}  {}",
+        style::dim("clash policy validate"),
+        style::dim("# check for errors")
+    );
 
     Ok(())
 }
@@ -242,12 +253,19 @@ pub fn set_bypass_permissions() -> Result<()> {
 }
 
 fn print_user_summary(actions: &InitActions) {
-    let any_action = actions.policy_created || actions.plugin_installed
-        || actions.bypass_set || actions.statusline_installed;
-    if !any_action { return; }
+    let any_action = actions.policy_created
+        || actions.plugin_installed
+        || actions.bypass_set
+        || actions.statusline_installed;
+    if !any_action {
+        return;
+    }
 
     println!();
-    println!("{}", style::bold("Setup complete! Here's what was configured:"));
+    println!(
+        "{}",
+        style::bold("Setup complete! Here's what was configured:")
+    );
     println!();
 
     if actions.policy_created {
@@ -265,19 +283,43 @@ fn print_user_summary(actions: &InitActions) {
 
     println!();
     println!("{}:", style::bold("To undo"));
-    println!("  {}  {}", style::dim("clash uninstall"), style::dim("# remove everything"));
+    println!(
+        "  {}  {}",
+        style::dim("clash uninstall"),
+        style::dim("# remove everything")
+    );
     if actions.policy_created {
-        println!("  {}  {}", style::dim("clash policy edit"), style::dim("# modify your policy"));
+        println!(
+            "  {}  {}",
+            style::dim("clash policy edit"),
+            style::dim("# modify your policy")
+        );
     }
     if actions.bypass_set {
-        println!("  {}  {}", style::dim("clash init --no-bypass"), style::dim("# re-run without bypassPermissions"));
+        println!(
+            "  {}  {}",
+            style::dim("clash init --no-bypass"),
+            style::dim("# re-run without bypassPermissions")
+        );
     }
 
     println!();
     println!("{}:", style::bold("Next steps"));
-    println!("  {}  {}", style::dim("claude"), style::dim("# start a session with clash active"));
-    println!("  {}  {}", style::dim("/clash:status"), style::dim("# check policy status inside a session"));
-    println!("  {}  {}", style::dim("/clash:edit"), style::dim("# interactively edit your policy"));
+    println!(
+        "  {}  {}",
+        style::dim("claude"),
+        style::dim("# start a session with clash active")
+    );
+    println!(
+        "  {}  {}",
+        style::dim("/clash:status"),
+        style::dim("# check policy status inside a session")
+    );
+    println!(
+        "  {}  {}",
+        style::dim("/clash:edit"),
+        style::dim("# interactively edit your policy")
+    );
 }
 
 /// Install the clash plugin into Claude Code from the GitHub marketplace.

--- a/clash/src/cmd/policy.rs
+++ b/clash/src/cmd/policy.rs
@@ -19,9 +19,7 @@ pub fn run(cmd: PolicyCmd) -> Result<()> {
             trace,
             tool,
             args,
-        } => {
-            super::explain::run(json, trace, tool.unwrap_or_default(), args.join(" "))
-        }
+        } => super::explain::run(json, trace, tool.unwrap_or_default(), args.join(" ")),
         PolicyCmd::List { json } => handle_list(json),
         PolicyCmd::Validate { file, json } => handle_validate(file, json),
         PolicyCmd::Show { json } => handle_show(json),

--- a/clash/src/policy_loader.rs
+++ b/clash/src/policy_loader.rs
@@ -47,11 +47,96 @@ pub fn evaluate_star_policy(path: &Path) -> Result<String> {
     Ok(output.json)
 }
 
+/// Migrate legacy string-style capability values in a policy JSON to the
+/// current array format.
+///
+/// Old format: `"caps": "read + write"`, `"default": "all - delete"`
+/// New format: `"caps": ["read", "write"]`, `"default": ["read", "write", "create", "execute"]`
+///
+/// If any values are migrated, the fixed JSON is written back to disk so
+/// the migration is transparent and one-time.
+fn migrate_legacy_caps(path: &Path, raw: String) -> Result<String> {
+    let mut value: serde_json::Value = serde_json::from_str(&raw)
+        .with_context(|| format!("failed to parse {}", path.display()))?;
+
+    let mut changed = false;
+
+    if let Some(sandboxes) = value.get_mut("sandboxes").and_then(|v| v.as_object_mut()) {
+        for (_name, sandbox) in sandboxes.iter_mut() {
+            let Some(sandbox_obj) = sandbox.as_object_mut() else {
+                continue;
+            };
+
+            // Migrate "default" field
+            if let Some(default_val) = sandbox_obj.get("default") {
+                if let Some(migrated) = migrate_cap_value(default_val) {
+                    sandbox_obj.insert("default".into(), migrated);
+                    changed = true;
+                }
+            }
+
+            // Migrate "caps" in each rule
+            if let Some(rules) = sandbox_obj.get_mut("rules").and_then(|v| v.as_array_mut()) {
+                for rule in rules.iter_mut() {
+                    if let Some(rule_obj) = rule.as_object_mut() {
+                        if let Some(caps_val) = rule_obj.get("caps") {
+                            if let Some(migrated) = migrate_cap_value(caps_val) {
+                                rule_obj.insert("caps".into(), migrated);
+                                changed = true;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    if !changed {
+        return Ok(raw);
+    }
+
+    let fixed =
+        serde_json::to_string_pretty(&value).context("failed to serialize migrated policy")?;
+
+    // Write the migrated policy back so this is a one-time fixup.
+    if let Err(e) = std::fs::write(path, &fixed) {
+        warn!(path = %path.display(), error = %e, "Failed to write migrated policy back to disk");
+    } else {
+        warn!(
+            path = %path.display(),
+            "Migrated legacy string-style caps to array format"
+        );
+    }
+
+    Ok(fixed)
+}
+
+/// If a JSON value is a string that looks like a legacy cap expression
+/// (e.g. "read + write"), parse it and return the equivalent array value.
+/// Returns `None` if the value is already an array or not a valid cap string.
+fn migrate_cap_value(value: &serde_json::Value) -> Option<serde_json::Value> {
+    use crate::policy::sandbox_types::Cap;
+
+    let s = value.as_str()?;
+    let cap = Cap::parse(s).ok()?;
+    let names: Vec<serde_json::Value> = cap
+        .to_list()
+        .into_iter()
+        .map(|n| serde_json::Value::String(n.into()))
+        .collect();
+    Some(serde_json::Value::Array(names))
+}
+
 /// Load a `policy.json` manifest: parse the JSON, resolve includes, and return
 /// a merged JSON source string suitable for [`compile::compile_to_tree`].
 pub fn load_json_policy(path: &Path) -> Result<String> {
     let raw = std::fs::read_to_string(path)
         .with_context(|| format!("failed to read {}", path.display()))?;
+
+    // Migrate legacy string-style caps (e.g. "read + write") to array format
+    // (e.g. ["read", "write"]) before parsing. Writes the fixed file back if changed.
+    let raw = migrate_legacy_caps(path, raw)?;
+
     let manifest: PolicyManifest = serde_json::from_str(&raw)
         .with_context(|| format!("failed to parse {}", path.display()))?;
 
@@ -523,5 +608,80 @@ def main():
         let loaded = read_manifest(&json_path).unwrap();
         assert_eq!(loaded.includes.len(), 1);
         assert_eq!(loaded.includes[0].path, "@clash//builtin.star");
+    }
+
+    #[test]
+    fn migrate_legacy_string_caps_to_array() {
+        let dir = tempfile::tempdir().unwrap();
+        let json_path = dir.path().join("policy.json");
+        std::fs::write(
+            &json_path,
+            r#"{
+                "default_effect": "deny",
+                "sandboxes": {
+                    "dev": {
+                        "default": "read + execute",
+                        "rules": [
+                            {
+                                "effect": "allow",
+                                "caps": "all - delete",
+                                "path": "/tmp",
+                                "path_match": "subpath"
+                            }
+                        ]
+                    }
+                },
+                "tree": []
+            }"#,
+        )
+        .unwrap();
+
+        let source = load_json_policy(&json_path).unwrap();
+        let policy: CompiledPolicy = serde_json::from_str(&source).unwrap();
+
+        // The sandbox should have parsed successfully after migration.
+        let dev = policy.sandboxes.get("dev").expect("dev sandbox");
+        assert_eq!(
+            dev.default,
+            crate::policy::sandbox_types::Cap::READ | crate::policy::sandbox_types::Cap::EXECUTE
+        );
+        assert_eq!(
+            dev.rules[0].caps,
+            crate::policy::sandbox_types::Cap::READ
+                | crate::policy::sandbox_types::Cap::WRITE
+                | crate::policy::sandbox_types::Cap::CREATE
+                | crate::policy::sandbox_types::Cap::EXECUTE
+        );
+
+        // The file on disk should have been rewritten with array format.
+        let on_disk: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&json_path).unwrap()).unwrap();
+        let dev_default = &on_disk["sandboxes"]["dev"]["default"];
+        assert!(dev_default.is_array(), "default should be an array on disk");
+        let rule_caps = &on_disk["sandboxes"]["dev"]["rules"][0]["caps"];
+        assert!(rule_caps.is_array(), "caps should be an array on disk");
+    }
+
+    #[test]
+    fn no_migration_when_already_array_format() {
+        let dir = tempfile::tempdir().unwrap();
+        let json_path = dir.path().join("policy.json");
+        let original = r#"{
+                "default_effect": "deny",
+                "sandboxes": {
+                    "dev": {
+                        "default": ["read", "execute"],
+                        "rules": []
+                    }
+                },
+                "tree": []
+            }"#;
+        std::fs::write(&json_path, original).unwrap();
+
+        let _source = load_json_policy(&json_path).unwrap();
+
+        // File should not have been rewritten (content preserved exactly).
+        let on_disk = std::fs::read_to_string(&json_path).unwrap();
+        assert_eq!(on_disk, original);
     }
 }

--- a/clash/src/settings/loader.rs
+++ b/clash/src/settings/loader.rs
@@ -190,8 +190,9 @@ impl ClashSettings {
     /// Returns `Ok(Some(path))` if a new file was created, `Ok(None)` if one already existed.
     /// The created file uses the embedded `DEFAULT_POLICY` (deny-all with read access to CWD).
     pub fn ensure_user_policy_exists() -> Result<Option<PathBuf>> {
-        let path = Self::policy_file()
-            .context("resolving user policy file path (~/.clash/policy.json or CLASH_POLICY_FILE)")?;
+        let path = Self::policy_file().context(
+            "resolving user policy file path (~/.clash/policy.json or CLASH_POLICY_FILE)",
+        )?;
         Self::ensure_policy_at(path)
     }
 
@@ -220,8 +221,8 @@ impl ClashSettings {
             }
         }
 
-        let json =
-            compile_default_policy_to_json().context("compiling embedded default policy (std.star) to JSON")?;
+        let json = compile_default_policy_to_json()
+            .context("compiling embedded default policy (std.star) to JSON")?;
         std::fs::write(&json_path, &json).with_context(|| {
             format!("failed to write default policy to {}", json_path.display())
         })?;

--- a/clash/src/trace_display.rs
+++ b/clash/src/trace_display.rs
@@ -4,11 +4,11 @@
 //! rendering showing every rule considered, why each condition matched or
 //! was skipped, and which rule ultimately won.
 
+use crate::policy::Effect;
 use crate::policy::format::format_condition;
 use crate::policy::match_tree::{
     CompiledPolicy, Decision, Node, Observable, Pattern, QueryContext,
 };
-use crate::policy::Effect;
 use crate::style;
 
 /// A single condition step in the trace for a rule branch.
@@ -347,11 +347,7 @@ pub fn render_trace(trace: &PolicyTrace) -> Vec<String> {
                     .unwrap_or_else(|| " (absent)".to_string());
                 (
                     style::red("\u{2717}"),
-                    format!(
-                        "{} does not match{}",
-                        style::red(&cond.label),
-                        value_str
-                    ),
+                    format!("{} does not match{}", style::red(&cond.label), value_str),
                 )
             };
             lines.push(format!("  {pipe}    {symbol} {detail}"));


### PR DESCRIPTION
## Summary

- When loading a `policy.json`, automatically detect old-style string capability values (e.g. `"read + write"`) and convert them to the current array format (e.g. `["read", "write"]`)
- The fixed file is written back to disk so the migration is one-time and transparent to the user
- Ensures policies authored before the Cap deserialization refactor (ba05a82) continue to load without errors

## Test plan

- [x] Unit test: legacy string caps (`"read + execute"`, `"all - delete"`) are migrated to arrays and file is rewritten
- [x] Unit test: already-correct array format files are left untouched
- [x] `just check` passes (all 55 e2e steps pass)