### PR TITLE
feat(tui): unify playground and policy editor with test console

### DIFF
--- a/clash/src/cli.rs
+++ b/clash/src/cli.rs
@@ -65,6 +65,9 @@ pub enum PolicyCmd {
         /// Open in $EDITOR instead of the interactive TUI
         #[arg(long)]
         raw: bool,
+        /// Open with the test console panel visible
+        #[arg(long)]
+        test: bool,
     },
     /// Add an allow rule for a tool or binary
     ///

--- a/clash/src/cmd/playground.rs
+++ b/clash/src/cmd/playground.rs
@@ -11,7 +11,6 @@ use reedline::{
 };
 use tracing::{Level, instrument};
 
-use crate::debug::replay;
 use crate::display;
 use crate::policy::compile;
 use crate::policy::match_tree::CompiledPolicy;
@@ -923,17 +922,16 @@ fn handle_test(input: &str, state: &PlaygroundState) -> String {
         None => return "No policy loaded. Use 'add rule' first.".to_string(),
     };
 
-    let (tool_name, tool_input) = match parse_test_input(input) {
-        Ok(pair) => pair,
-        Err(e) => return format!("Failed to parse test input: {e}"),
-    };
-
-    let decision = tree.evaluate(&tool_name, &tool_input);
-
-    let mut lines = display::format_tool_header("Input:", &tool_name, &tool_input);
-    lines.push(String::new());
-    lines.extend(display::format_decision(&decision));
-    lines.join("\n")
+    match crate::policy::test_eval::evaluate_test(input, tree) {
+        Ok(result) => {
+            let mut lines =
+                display::format_tool_header("Input:", &result.tool_name, &result.tool_input);
+            lines.push(String::new());
+            lines.extend(display::format_decision(&result.decision));
+            lines.join("\n")
+        }
+        Err(e) => format!("Failed to parse test input: {e}"),
+    }
 }
 
 fn handle_show(state: &PlaygroundState) -> String {
@@ -978,34 +976,6 @@ fn handle_show(state: &PlaygroundState) -> String {
     }
 
     lines.join("\n")
-}
-
-// ---------------------------------------------------------------------------
-// Test input parsing
-// ---------------------------------------------------------------------------
-
-/// Parse `ToolName { json }` or `tool_shorthand "args"` formats.
-///
-/// Supports:
-///   - `Bash { "command": "git status" }`
-///   - `bash "git status"` (shorthand resolved via replay::resolve_tool_input)
-fn parse_test_input(input: &str) -> Result<(String, serde_json::Value)> {
-    // Try "ToolName { json }" format first
-    if let Some(brace_pos) = input.find('{') {
-        let tool_name = input[..brace_pos].trim().to_string();
-        let json_str = input[brace_pos..].trim();
-        if !tool_name.is_empty() {
-            let tool_input: serde_json::Value =
-                serde_json::from_str(json_str).context("invalid JSON in tool input")?;
-            return Ok((tool_name, tool_input));
-        }
-    }
-
-    // Fall back to the same resolution used by `clash explain`
-    let parts: Vec<&str> = input.splitn(2, ' ').collect();
-    let tool = parts[0];
-    let args = parts.get(1).copied();
-    replay::resolve_tool_input(tool, args)
 }
 
 // ---------------------------------------------------------------------------
@@ -1086,32 +1056,7 @@ pub fn run() -> Result<()> {
 mod tests {
     use super::*;
 
-    #[test]
-    fn test_parse_test_input_json_format() {
-        let (name, input) = parse_test_input(r#"Bash { "command": "git status" }"#).unwrap();
-        assert_eq!(name, "Bash");
-        assert_eq!(input["command"], "git status");
-    }
-
-    #[test]
-    fn test_parse_test_input_shorthand() {
-        let (name, input) = parse_test_input("bash \"git push\"").unwrap();
-        assert_eq!(name, "Bash");
-        assert_eq!(input["command"], "\"git push\"");
-    }
-
-    #[test]
-    fn test_parse_test_input_read() {
-        let (name, input) = parse_test_input(r#"Read { "file_path": "/etc/passwd" }"#).unwrap();
-        assert_eq!(name, "Read");
-        assert_eq!(input["file_path"], "/etc/passwd");
-    }
-
-    #[test]
-    fn test_parse_test_input_invalid_json() {
-        let result = parse_test_input("Bash { invalid }");
-        assert!(result.is_err());
-    }
+    // parse_test_input tests have moved to policy::test_eval::tests
 
     #[test]
     fn test_dispatch_help() {

--- a/clash/src/cmd/policy.rs
+++ b/clash/src/cmd/policy.rs
@@ -23,7 +23,7 @@ pub fn run(cmd: PolicyCmd) -> Result<()> {
         PolicyCmd::List { json } => handle_list(json),
         PolicyCmd::Validate { file, json } => handle_validate(file, json),
         PolicyCmd::Show { json } => handle_show(json),
-        PolicyCmd::Edit { scope, raw } => handle_edit(scope, raw),
+        PolicyCmd::Edit { scope, raw, test } => handle_edit(scope, raw, test),
         PolicyCmd::Allow {
             command,
             tool,
@@ -373,7 +373,7 @@ pub fn open_in_editor(path: &Path) -> Result<()> {
 }
 
 /// Handle `clash policy edit`.
-fn handle_edit(scope: Option<String>, raw: bool) -> Result<()> {
+fn handle_edit(scope: Option<String>, raw: bool, test: bool) -> Result<()> {
     if raw {
         // --raw: open in $EDITOR
         let level = match scope.as_deref() {
@@ -397,7 +397,7 @@ fn handle_edit(scope: Option<String>, raw: bool) -> Result<()> {
 
     // Interactive TUI editor
     let path = resolve_manifest_path(scope)?;
-    crate::tui::run(&path)
+    crate::tui::run_with_options(&path, test)
 }
 
 // ---------------------------------------------------------------------------

--- a/clash/src/main.rs
+++ b/clash/src/main.rs
@@ -48,7 +48,11 @@ fn main() -> Result<()> {
                 args,
             } => clash::shell_cmd::run_shell(command, args, cwd, sandbox, debug),
             Commands::Sandbox(sandbox_cmd) => run_sandbox(sandbox_cmd),
-            Commands::Playground => cmd::playground::run(),
+            Commands::Playground => {
+                eprintln!("Note: `clash playground` is now `clash policy edit --test`");
+                eprintln!("      The playground REPL has been unified into the policy editor.\n");
+                cmd::playground::run()
+            }
             Commands::Doctor { onboard } => cmd::doctor::run(onboard),
             Commands::Debug(cmd) => cmd::debug::run(cmd),
             Commands::Trace(cmd) => cmd::trace::run(cmd),

--- a/clash/src/policy/mod.rs
+++ b/clash/src/policy/mod.rs
@@ -12,6 +12,7 @@ pub mod match_tree;
 pub mod path;
 pub mod sandbox_edit;
 pub mod sandbox_types;
+pub mod test_eval;
 
 #[cfg(test)]
 mod proptests;

--- a/clash/src/policy/test_eval.rs
+++ b/clash/src/policy/test_eval.rs
@@ -1,0 +1,175 @@
+//! Shared test parsing and evaluation for policy testing.
+//!
+//! Used by both the TUI test panel and the playground REPL to parse
+//! shorthand tool invocations and evaluate them against a compiled policy.
+
+use anyhow::{Context, Result};
+
+use crate::policy::ir::PolicyDecision;
+use crate::policy::match_tree::CompiledPolicy;
+use crate::policy::Effect;
+
+/// The result of testing a tool invocation against a policy.
+#[derive(Debug, Clone)]
+pub struct TestResult {
+    /// The resolved tool name (e.g. "Bash", "Read").
+    pub tool_name: String,
+    /// The resolved tool input JSON.
+    pub tool_input: serde_json::Value,
+    /// The policy decision.
+    pub decision: PolicyDecision,
+}
+
+impl TestResult {
+    /// The effect of this test result.
+    pub fn effect(&self) -> Effect {
+        self.decision.effect
+    }
+
+    /// Short human-readable summary of the decision.
+    pub fn summary(&self) -> String {
+        let effect = match self.decision.effect {
+            Effect::Allow => "allow",
+            Effect::Deny => "deny",
+            Effect::Ask => "ask",
+        };
+        match &self.decision.reason {
+            Some(reason) => format!("{effect} ({reason})"),
+            None => effect.to_string(),
+        }
+    }
+}
+
+/// Parse a test input string and evaluate it against a compiled policy.
+///
+/// Accepts both JSON format (`Bash { "command": "git push" }`) and
+/// shorthand (`bash "git push"`).
+pub fn evaluate_test(input: &str, policy: &CompiledPolicy) -> Result<TestResult> {
+    let (tool_name, tool_input) = parse_test_input(input)?;
+    let decision = policy.evaluate(&tool_name, &tool_input);
+    Ok(TestResult {
+        tool_name,
+        tool_input,
+        decision,
+    })
+}
+
+/// Parse `ToolName { json }` or `tool_shorthand "args"` formats.
+///
+/// Supports:
+///   - `Bash { "command": "git status" }`
+///   - `bash "git status"` (shorthand resolved via resolve_tool_input)
+pub fn parse_test_input(input: &str) -> Result<(String, serde_json::Value)> {
+    // Try "ToolName { json }" format first
+    if let Some(brace_pos) = input.find('{') {
+        let tool_name = input[..brace_pos].trim().to_string();
+        let json_str = input[brace_pos..].trim();
+        if !tool_name.is_empty() {
+            let tool_input: serde_json::Value =
+                serde_json::from_str(json_str).context("invalid JSON in tool input")?;
+            return Ok((tool_name, tool_input));
+        }
+    }
+
+    // Fall back to shorthand resolution
+    let parts: Vec<&str> = input.splitn(2, ' ').collect();
+    let tool = parts[0];
+    let args = parts.get(1).copied();
+    resolve_tool_input(tool, args)
+}
+
+/// Resolve a shorthand tool name and optional argument into a canonical
+/// (tool_name, tool_input) pair.
+///
+/// Maps lowercase names to their canonical forms (`bash` → `Bash`) and
+/// builds the appropriate JSON input shape for each tool type.
+pub fn resolve_tool_input(
+    tool: &str,
+    input: Option<&str>,
+) -> Result<(String, serde_json::Value)> {
+    let noun = input.unwrap_or_default();
+
+    if tool.to_lowercase() == "tool" {
+        return Ok((noun.to_string(), serde_json::json!({})));
+    }
+
+    let tool_name = match tool.to_lowercase().as_str() {
+        "bash" => "Bash",
+        "read" => "Read",
+        "write" => "Write",
+        "edit" => "Edit",
+        _ => tool,
+    };
+
+    let tool_input = serde_json::from_str::<serde_json::Value>(noun)
+        .ok()
+        .filter(|v| v.is_object())
+        .unwrap_or_else(|| build_tool_input(tool_name, noun));
+
+    Ok((tool_name.to_string(), tool_input))
+}
+
+fn build_tool_input(tool_name: &str, noun: &str) -> serde_json::Value {
+    let field = match tool_name {
+        "Bash" => "command",
+        "Read" | "Write" | "Edit" | "NotebookEdit" => "file_path",
+        "Glob" | "Grep" => "pattern",
+        "WebFetch" => "url",
+        "WebSearch" => "query",
+        _ => "command",
+    };
+    serde_json::json!({ field: noun })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_json_format() {
+        let (name, input) = parse_test_input(r#"Bash { "command": "git status" }"#).unwrap();
+        assert_eq!(name, "Bash");
+        assert_eq!(input["command"], "git status");
+    }
+
+    #[test]
+    fn test_parse_shorthand() {
+        let (name, input) = parse_test_input("bash \"git push\"").unwrap();
+        assert_eq!(name, "Bash");
+        assert_eq!(input["command"], "\"git push\"");
+    }
+
+    #[test]
+    fn test_parse_read() {
+        let (name, input) = parse_test_input(r#"Read { "file_path": "/etc/passwd" }"#).unwrap();
+        assert_eq!(name, "Read");
+        assert_eq!(input["file_path"], "/etc/passwd");
+    }
+
+    #[test]
+    fn test_parse_invalid_json() {
+        let result = parse_test_input("Bash { invalid }");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_resolve_bash() {
+        let (name, input) = resolve_tool_input("bash", Some("ls -la")).unwrap();
+        assert_eq!(name, "Bash");
+        assert_eq!(input["command"], "ls -la");
+    }
+
+    #[test]
+    fn test_resolve_read() {
+        let (name, input) = resolve_tool_input("read", Some("/tmp/foo")).unwrap();
+        assert_eq!(name, "Read");
+        assert_eq!(input["file_path"], "/tmp/foo");
+    }
+
+    #[test]
+    fn test_resolve_tool() {
+        let (name, input) = resolve_tool_input("tool", Some("Agent")).unwrap();
+        assert_eq!(name, "Agent");
+        assert!(input.is_object());
+    }
+}

--- a/clash/src/tui/app.rs
+++ b/clash/src/tui/app.rs
@@ -22,6 +22,7 @@ use super::inline_form::{FormEvent, FormState};
 use super::sandbox_view::SandboxView;
 use super::settings_view::SettingsView;
 use super::tea::{Action, Component};
+use super::test_panel::{self, TestPanel, TestPanelAction};
 use super::tree_view::TreeView;
 use super::widgets::{self, DiffLine};
 
@@ -62,6 +63,8 @@ pub enum Msg {
     Save,
     Quit,
     ToggleHelp,
+    ToggleTestPanel,
+    ToggleTestFocus,
     ConfirmYes,
     ConfirmNo,
     DiffScrollDown,
@@ -70,6 +73,7 @@ pub enum Msg {
     SandboxMsg(<SandboxView as Component>::Msg),
     IncludesMsg(<IncludesView as Component>::Msg),
     SettingsMsg(<SettingsView as Component>::Msg),
+    TestPanelMsg(test_panel::Msg),
 }
 
 pub struct App {
@@ -83,6 +87,9 @@ pub struct App {
     sandbox_view: SandboxView,
     includes_view: IncludesView,
     settings_view: SettingsView,
+    test_panel: TestPanel,
+    /// Whether the test panel currently has keyboard focus.
+    test_focused: bool,
     mode: Mode,
     dirty: bool,
     flash: Option<(String, Instant)>,
@@ -133,10 +140,19 @@ impl App {
             sandbox_view,
             includes_view,
             settings_view,
+            test_panel: TestPanel::new(),
+            test_focused: false,
             mode: Mode::Normal,
             dirty: false,
             flash,
         })
+    }
+
+    /// Show the test panel and focus it (called by --test flag).
+    pub fn show_test_panel(&mut self) {
+        self.test_panel.visible = true;
+        self.test_panel.input_active = true;
+        self.test_focused = true;
     }
 
     /// Run the main event loop.
@@ -155,6 +171,38 @@ impl App {
                 if matches!(self.mode, Mode::Form(_)) {
                     let FormHandled::Continue = self.handle_form_key(key);
                     continue;
+                }
+
+                // Test panel focused: route keys to the test panel.
+                // Esc returns focus to the left pane. Tab toggles input/history.
+                if self.test_panel.visible
+                    && self.test_focused
+                    && matches!(self.mode, Mode::Normal)
+                {
+                    match key.code {
+                        KeyCode::Esc => {
+                            // Return focus to the left pane
+                            self.test_focused = false;
+                            continue;
+                        }
+                        KeyCode::Tab => {
+                            // Toggle between input and history within test panel
+                            self.test_panel.toggle_input_focus();
+                            continue;
+                        }
+                        _ => {
+                            if let Some(msg) = self.test_panel.handle_key(key) {
+                                let compiled = self.current_compiled_policy();
+                                match self.test_panel.update(msg, compiled.as_ref()) {
+                                    TestPanelAction::Flash(s) => {
+                                        self.flash = Some((s, Instant::now()));
+                                    }
+                                    TestPanelAction::None => {}
+                                }
+                            }
+                            continue;
+                        }
+                    }
                 }
 
                 if let Some(msg) = self.handle_key(key) {
@@ -276,6 +324,7 @@ impl App {
         match key.code {
             KeyCode::Char('q') => return Some(Msg::Quit),
             KeyCode::Char('s') => return Some(Msg::Save),
+            KeyCode::Char('t') => return Some(Msg::ToggleTestPanel),
             KeyCode::Char('?') => return Some(Msg::ToggleHelp),
             KeyCode::Char('1') => return Some(Msg::SwitchTab(Tab::Tree)),
             KeyCode::Char('2') => return Some(Msg::SwitchTab(Tab::Sandboxes)),
@@ -406,11 +455,46 @@ impl App {
                 }
                 Action::None
             }
+            Msg::ToggleTestPanel => {
+                if self.test_panel.visible {
+                    // Panel visible: toggle focus to test panel
+                    self.test_focused = true;
+                    self.test_panel.input_active = true;
+                } else {
+                    // Panel hidden: show it and focus it
+                    self.test_panel.visible = true;
+                    self.test_focused = true;
+                    self.test_panel.input_active = true;
+                }
+                Action::None
+            }
+            Msg::ToggleTestFocus => {
+                self.test_panel.toggle_input_focus();
+                Action::None
+            }
             Msg::TreeMsg(m) => self.tree_view.update(m, &mut self.manifest),
             Msg::SandboxMsg(m) => self.sandbox_view.update(m, &mut self.manifest),
             Msg::IncludesMsg(m) => self.includes_view.update(m, &mut self.manifest),
             Msg::SettingsMsg(m) => self.settings_view.update(m, &mut self.manifest),
+            Msg::TestPanelMsg(m) => {
+                let compiled = self.current_compiled_policy();
+                match self.test_panel.update(m, compiled.as_ref()) {
+                    TestPanelAction::Flash(s) => Action::Flash(s),
+                    TestPanelAction::None => Action::None,
+                }
+            }
         }
+    }
+
+    /// Build a merged compiled policy (inline + included) for test evaluation.
+    fn current_compiled_policy(&self) -> Option<CompiledPolicy> {
+        let mut merged = self.manifest.policy.clone();
+        // Append included rules so tests see the full picture
+        merged.tree.extend(self.included.tree.clone());
+        for (k, v) in &self.included.sandboxes {
+            merged.sandboxes.entry(k.clone()).or_insert_with(|| v.clone());
+        }
+        Some(merged)
     }
 
     fn rebuild_views(&mut self) {
@@ -418,6 +502,13 @@ impl App {
             .rebuild_with_included(&self.manifest, &self.included);
         self.sandbox_view
             .rebuild_with_included(&self.manifest, &self.included);
+
+        // Re-evaluate test cases against updated policy
+        if self.test_panel.visible {
+            if let Some(compiled) = self.current_compiled_policy() {
+                self.test_panel.re_evaluate(&compiled);
+            }
+        }
     }
 
     fn view(&self, frame: &mut Frame, area: Rect, manifest: &PolicyManifest) {
@@ -454,12 +545,29 @@ impl App {
             self.dirty,
         );
 
-        // Content area — delegate to active tab
+        // Content area — split horizontally if test panel is visible
+        let (content_area, test_area) = if self.test_panel.visible {
+            let split = Layout::horizontal([
+                Constraint::Percentage(68),
+                Constraint::Percentage(32),
+            ])
+            .split(chunks[1]);
+            (split[0], Some(split[1]))
+        } else {
+            (chunks[1], None)
+        };
+
+        // Active tab content
         match self.active_tab {
-            Tab::Tree => self.tree_view.view(frame, chunks[1], manifest),
-            Tab::Sandboxes => self.sandbox_view.view(frame, chunks[1], manifest),
-            Tab::Includes => self.includes_view.view(frame, chunks[1], manifest),
-            Tab::Settings => self.settings_view.view(frame, chunks[1], manifest),
+            Tab::Tree => self.tree_view.view(frame, content_area, manifest),
+            Tab::Sandboxes => self.sandbox_view.view(frame, content_area, manifest),
+            Tab::Includes => self.includes_view.view(frame, content_area, manifest),
+            Tab::Settings => self.settings_view.view(frame, content_area, manifest),
+        }
+
+        // Test panel (side panel)
+        if let Some(area) = test_area {
+            self.test_panel.view_with_focus(frame, area, self.test_focused);
         }
 
         // Status bar
@@ -471,6 +579,12 @@ impl App {
             }
         });
 
+        let test_hint = if self.test_focused {
+            ("Esc", "back to editor")
+        } else {
+            ("t", "test console")
+        };
+
         let hints: &[(&str, &str)] = match self.active_tab {
             Tab::Tree => &[
                 ("j/k", "move"),
@@ -479,6 +593,7 @@ impl App {
                 ("a", "add"),
                 ("d", "delete"),
                 ("c", "copy to inline"),
+                test_hint,
                 ("s", "save"),
             ],
             Tab::Sandboxes => &[
@@ -488,6 +603,7 @@ impl App {
                 ("e", "edit"),
                 ("d", "delete"),
                 ("c", "copy to inline"),
+                test_hint,
                 ("s", "save"),
             ],
             Tab::Includes => &[
@@ -495,9 +611,10 @@ impl App {
                 ("J/K", "reorder"),
                 ("a", "add"),
                 ("d", "delete"),
+                test_hint,
                 ("s", "save"),
             ],
-            Tab::Settings => &[("j/k", "move"), ("Enter", "cycle"), ("s", "save")],
+            Tab::Settings => &[("j/k", "move"), ("Enter", "cycle"), test_hint, ("s", "save")],
         };
 
         widgets::render_status_bar(frame, chunks[2], hints, flash_msg);

--- a/clash/src/tui/inline_form.rs
+++ b/clash/src/tui/inline_form.rs
@@ -21,6 +21,9 @@ use crate::tui::tool_registry;
 
 use super::tea::FormRequest;
 
+/// Starlark load preamble used when compiling user-entered expressions.
+const STARLARK_LOAD: &str = r#"load("@clash//std.star", "exe", "tool", "cmd", "tools", "policy", "sandbox", "cwd", "home", "tempdir", "path", "regex", "domains", "domain", "allow", "deny", "ask")"#;
+
 // ---------------------------------------------------------------------------
 // Field types
 // ---------------------------------------------------------------------------
@@ -164,11 +167,16 @@ impl FormState {
         let fields = vec![
             FormField::Select {
                 label: "Rule type".into(),
-                options: vec!["Tool rule".into(), "Shell command".into()],
+                options: vec![
+                    "Tool rule".into(),
+                    "Shell command".into(),
+                    "Starlark expression".into(),
+                ],
                 selected: 0,
                 hints: vec![
                     "Match a Claude tool like Read, Write, Bash, Edit",
                     "Match a shell command like git, npm, curl",
+                    "Write a raw Starlark policy expression",
                 ],
             },
             FormField::Text {
@@ -207,6 +215,14 @@ impl FormState {
                 options: sandbox_opts,
                 selected: sb_default,
                 hints: vec![],
+            },
+            // Field 6: Starlark expression (only visible when rule_type == 2)
+            FormField::Text {
+                label: "Expression".into(),
+                value: String::new(),
+                cursor: 0,
+                placeholder: r#"e.g. exe("git").allow(), tool("Read").deny()"#.into(),
+                hint: Some("Starlark DSL expression — compiled and added to the policy tree"),
             },
         ];
 
@@ -911,6 +927,13 @@ impl FormState {
                     _ => 0,
                 };
 
+                // Starlark expression mode — only show type selector + expression field
+                if rule_type == 2 {
+                    self.tool_context = None;
+                    self.visible = vec![0, 6];
+                    return;
+                }
+
                 // Update tool context from typed tool name
                 if rule_type == 0 {
                     let name = self.text_value(1);
@@ -1040,6 +1063,12 @@ impl FormState {
             self.fields[self.active_field_index()],
             FormField::Select { .. }
         )
+    }
+
+    /// Whether field at index `fi` should render all options inline.
+    fn is_inline_select(&self, fi: usize) -> bool {
+        // The "Rule type" selector in AddRule shows all options at once
+        matches!((&self.kind, fi), (FormKind::AddRule, 0))
     }
 }
 
@@ -1245,6 +1274,12 @@ impl FormState {
 
     fn apply_add_rule(&self, manifest: &mut PolicyManifest) -> Result<bool, String> {
         let rule_type = self.select_value(0);
+
+        // Starlark expression mode
+        if rule_type == 2 {
+            return self.apply_add_starlark_rule(manifest);
+        }
+
         let effect_idx = tool_registry::filtered_effect_to_canonical(
             self.tool_context.as_deref(),
             self.select_value(4),
@@ -1294,6 +1329,43 @@ impl FormState {
         };
 
         manifest_edit::upsert_rule(manifest, node);
+        Ok(true)
+    }
+
+    fn apply_add_starlark_rule(&self, manifest: &mut PolicyManifest) -> Result<bool, String> {
+        let expr = self.text_value(6);
+        if expr.is_empty() {
+            return Err("Starlark expression is required".into());
+        }
+
+        // Build a minimal Starlark program wrapping the expression
+        let starlark_source = format!(
+            "{STARLARK_LOAD}\n\ndef main():\n    return policy(default = deny(), rules = [\n        {expr},\n    ])\n"
+        );
+
+        let json = clash_starlark::evaluate(
+            &starlark_source,
+            "tui_expression.star",
+            &std::path::PathBuf::from("."),
+        )
+        .map_err(|e| format!("Starlark error: {e:#}"))?;
+
+        let compiled = crate::policy::compile::compile_to_tree(&json.json)
+            .map_err(|e| format!("Compile error: {e:#}"))?;
+
+        if compiled.tree.is_empty() {
+            return Err("Expression produced no rules".into());
+        }
+
+        // Append compiled nodes to the manifest tree
+        for node in compiled.tree {
+            manifest.policy.tree.push(node);
+        }
+        // Merge any sandboxes defined in the expression
+        for (name, sb) in compiled.sandboxes {
+            manifest.policy.sandboxes.entry(name).or_insert(sb);
+        }
+
         Ok(true)
     }
 
@@ -1632,7 +1704,14 @@ impl FormState {
     }
 
     pub fn view(&self, frame: &mut Frame, area: Rect) {
-        let height = (self.visible.len() as u16 * 3) + 6; // fields + hint + spacing + title + footer
+        // Use max possible field count for forms that change visibility dynamically,
+        // so the popup stays in a fixed position when cycling options.
+        let field_count = match &self.kind {
+            FormKind::AddRule => self.fields.len().max(5), // stable at max visible fields
+            FormKind::AddChild { .. } => self.fields.len().max(5),
+            _ => self.visible.len(),
+        };
+        let height = (field_count as u16 * 3) + 6; // fields + hint + spacing + title + footer
         let height_pct = ((height as f32 / area.height as f32) * 100.0)
             .ceil()
             .clamp(30.0, 80.0) as u16;
@@ -1730,40 +1809,76 @@ impl FormState {
                     } else {
                         Style::default().fg(Color::Gray)
                     };
-                    let option = &options[*selected];
-                    let arrows = if is_active {
-                        ("< ", " >")
-                    } else {
-                        ("  ", "  ")
-                    };
-                    let value_style = if is_active {
-                        Style::default()
-                            .fg(Color::Cyan)
-                            .add_modifier(Modifier::BOLD)
-                    } else {
-                        Style::default().fg(Color::Cyan)
-                    };
 
-                    lines.push(Line::from(vec![
-                        Span::styled(format!("  {label}: "), label_style),
-                        Span::styled(
-                            arrows.0,
-                            Style::default().fg(if is_active {
-                                Color::Yellow
+                    if self.is_inline_select(fi) {
+                        // Inline mode: show all options, highlight selected
+                        let mut spans = vec![Span::styled(
+                            format!("  {label}: "),
+                            label_style,
+                        )];
+                        for (i, opt) in options.iter().enumerate() {
+                            if i > 0 {
+                                spans.push(Span::styled(
+                                    "  ",
+                                    Style::default().fg(Color::DarkGray),
+                                ));
+                            }
+                            let style = if i == *selected {
+                                Style::default()
+                                    .fg(Color::Cyan)
+                                    .add_modifier(Modifier::BOLD)
+                                    .add_modifier(Modifier::UNDERLINED)
+                            } else if is_active {
+                                Style::default().fg(Color::DarkGray)
                             } else {
-                                Color::DarkGray
-                            }),
-                        ),
-                        Span::styled(option.as_str(), value_style),
-                        Span::styled(
-                            arrows.1,
-                            Style::default().fg(if is_active {
-                                Color::Yellow
-                            } else {
-                                Color::DarkGray
-                            }),
-                        ),
-                    ]));
+                                Style::default().fg(Color::DarkGray)
+                            };
+                            spans.push(Span::styled(opt.as_str(), style));
+                        }
+                        if is_active {
+                            spans.push(Span::styled(
+                                "  ←/→",
+                                Style::default().fg(Color::DarkGray),
+                            ));
+                        }
+                        lines.push(Line::from(spans));
+                    } else {
+                        // Default mode: show < selected >
+                        let option = &options[*selected];
+                        let arrows = if is_active {
+                            ("< ", " >")
+                        } else {
+                            ("  ", "  ")
+                        };
+                        let value_style = if is_active {
+                            Style::default()
+                                .fg(Color::Cyan)
+                                .add_modifier(Modifier::BOLD)
+                        } else {
+                            Style::default().fg(Color::Cyan)
+                        };
+
+                        lines.push(Line::from(vec![
+                            Span::styled(format!("  {label}: "), label_style),
+                            Span::styled(
+                                arrows.0,
+                                Style::default().fg(if is_active {
+                                    Color::Yellow
+                                } else {
+                                    Color::DarkGray
+                                }),
+                            ),
+                            Span::styled(option.as_str(), value_style),
+                            Span::styled(
+                                arrows.1,
+                                Style::default().fg(if is_active {
+                                    Color::Yellow
+                                } else {
+                                    Color::DarkGray
+                                }),
+                            ),
+                        ]));
+                    }
                 }
                 FormField::MultiSelect {
                     label,

--- a/clash/src/tui/mod.rs
+++ b/clash/src/tui/mod.rs
@@ -9,6 +9,7 @@ pub mod inline_form;
 pub mod sandbox_view;
 pub mod settings_view;
 pub mod tea;
+pub mod test_panel;
 pub mod tool_registry;
 pub mod tree_view;
 pub mod widgets;
@@ -28,10 +29,18 @@ use crate::policy_loader;
 
 /// Launch the interactive policy editor TUI.
 pub fn run(path: &Path) -> Result<()> {
+    run_with_options(path, false)
+}
+
+/// Launch the TUI with options.
+pub fn run_with_options(path: &Path, show_test_panel: bool) -> Result<()> {
     let manifest = policy_loader::read_manifest(path)
         .with_context(|| format!("failed to read {}", path.display()))?;
 
     let mut app = app::App::new(path.to_path_buf(), manifest)?;
+    if show_test_panel {
+        app.show_test_panel();
+    }
 
     // Setup terminal
     enable_raw_mode()?;

--- a/clash/src/tui/test_panel.rs
+++ b/clash/src/tui/test_panel.rs
@@ -1,0 +1,668 @@
+//! Test console panel — a persistent side panel for testing tool invocations
+//! against the current policy in real-time.
+//!
+//! The panel maintains a history of test cases. When the policy is modified,
+//! all cases are re-evaluated and changed results are flagged.
+
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use ratatui::Frame;
+use ratatui::layout::{Constraint, Layout, Rect};
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, Paragraph};
+
+use crate::policy::match_tree::CompiledPolicy;
+use crate::policy::test_eval;
+use crate::policy::Effect;
+
+/// A single test case in the console history.
+#[derive(Debug, Clone)]
+pub struct TestCase {
+    /// The raw input string the user typed.
+    pub input: String,
+    /// The resolved tool name.
+    pub tool_name: String,
+    /// The resolved tool input JSON.
+    pub tool_input: serde_json::Value,
+    /// The most recent evaluation result.
+    pub effect: Effect,
+    /// Short summary of the decision.
+    pub summary: String,
+    /// Whether this test case is pinned (always visible).
+    pub pinned: bool,
+    /// Whether the result changed on the last re-evaluation.
+    pub changed: bool,
+    /// The previous effect before re-evaluation (for change detection).
+    prev_effect: Option<Effect>,
+}
+
+/// Messages for the TestPanel component.
+#[derive(Debug)]
+pub enum Msg {
+    ScrollUp,
+    ScrollDown,
+    JumpTop,
+    JumpBottom,
+    TogglePin,
+    DeleteCase,
+    ClearHistory,
+    /// A character typed into the input line.
+    InputChar(char),
+    InputBackspace,
+    InputDelete,
+    InputLeft,
+    InputRight,
+    InputHome,
+    InputEnd,
+    InputSubmit,
+    InputClear,
+}
+
+pub struct TestPanel {
+    /// Test case history (newest last).
+    cases: Vec<TestCase>,
+    /// Currently selected case in the history.
+    selected: usize,
+    /// Scroll offset for the history view.
+    scroll_offset: usize,
+    /// Whether the input line is focused (vs history navigation).
+    pub input_active: bool,
+    /// The current input line text.
+    input_line: String,
+    /// Cursor position in the input line.
+    input_cursor: usize,
+    /// Whether the panel is visible.
+    pub visible: bool,
+    /// Flash message (error from last submit).
+    flash: Option<String>,
+}
+
+impl Default for TestPanel {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl TestPanel {
+    pub fn new() -> Self {
+        TestPanel {
+            cases: Vec::new(),
+            selected: 0,
+            scroll_offset: 0,
+            input_active: true,
+            input_line: String::new(),
+            input_cursor: 0,
+            visible: true,
+            flash: None,
+        }
+    }
+
+    /// Toggle panel visibility.
+    pub fn toggle(&mut self) {
+        self.visible = !self.visible;
+        if self.visible {
+            self.input_active = true;
+        }
+    }
+
+    /// Handle a key event, returning a message if applicable.
+    pub fn handle_key(&self, key: KeyEvent) -> Option<Msg> {
+        if self.input_active {
+            // Input mode keys
+            match key.code {
+                KeyCode::Enter => Some(Msg::InputSubmit),
+                KeyCode::Backspace => Some(Msg::InputBackspace),
+                KeyCode::Delete => Some(Msg::InputDelete),
+                KeyCode::Left => Some(Msg::InputLeft),
+                KeyCode::Right => Some(Msg::InputRight),
+                KeyCode::Home => Some(Msg::InputHome),
+                KeyCode::End => Some(Msg::InputEnd),
+                KeyCode::Esc => Some(Msg::InputClear),
+                KeyCode::Char('u') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                    Some(Msg::InputClear)
+                }
+                KeyCode::Char(c) => Some(Msg::InputChar(c)),
+                _ => None,
+            }
+        } else {
+            // History navigation mode
+            match key.code {
+                KeyCode::Char('k') | KeyCode::Up => Some(Msg::ScrollUp),
+                KeyCode::Char('j') | KeyCode::Down => Some(Msg::ScrollDown),
+                KeyCode::Char('g') => Some(Msg::JumpTop),
+                KeyCode::Char('G') => Some(Msg::JumpBottom),
+                KeyCode::Char('p') => Some(Msg::TogglePin),
+                KeyCode::Char('d') => Some(Msg::DeleteCase),
+                KeyCode::Char('x') => Some(Msg::ClearHistory),
+                KeyCode::Char('i') | KeyCode::Enter => {
+                    // Switch to input mode — handled by returning None and letting
+                    // the caller set input_active
+                    None
+                }
+                _ => None,
+            }
+        }
+    }
+
+    /// Process a message and update state. Returns true if a flash should be shown.
+    pub fn update(&mut self, msg: Msg, policy: Option<&CompiledPolicy>) -> TestPanelAction {
+        match msg {
+            Msg::ScrollUp => {
+                self.selected = self.selected.saturating_sub(1);
+                TestPanelAction::None
+            }
+            Msg::ScrollDown => {
+                if !self.cases.is_empty() {
+                    self.selected = (self.selected + 1).min(self.cases.len() - 1);
+                }
+                TestPanelAction::None
+            }
+            Msg::JumpTop => {
+                self.selected = 0;
+                TestPanelAction::None
+            }
+            Msg::JumpBottom => {
+                if !self.cases.is_empty() {
+                    self.selected = self.cases.len() - 1;
+                }
+                TestPanelAction::None
+            }
+            Msg::TogglePin => {
+                if let Some(case) = self.cases.get_mut(self.selected) {
+                    case.pinned = !case.pinned;
+                }
+                TestPanelAction::None
+            }
+            Msg::DeleteCase => {
+                if self.selected < self.cases.len() {
+                    self.cases.remove(self.selected);
+                    if self.selected >= self.cases.len() && !self.cases.is_empty() {
+                        self.selected = self.cases.len() - 1;
+                    }
+                }
+                TestPanelAction::None
+            }
+            Msg::ClearHistory => {
+                // Keep pinned cases
+                self.cases.retain(|c| c.pinned);
+                self.selected = 0;
+                TestPanelAction::None
+            }
+            Msg::InputChar(c) => {
+                self.flash = None;
+                self.input_line.insert(self.input_cursor, c);
+                self.input_cursor += c.len_utf8();
+                TestPanelAction::None
+            }
+            Msg::InputBackspace => {
+                if self.input_cursor > 0 {
+                    let prev = self.input_line[..self.input_cursor]
+                        .chars()
+                        .last()
+                        .map(|c| c.len_utf8())
+                        .unwrap_or(0);
+                    self.input_cursor -= prev;
+                    self.input_line.remove(self.input_cursor);
+                }
+                TestPanelAction::None
+            }
+            Msg::InputDelete => {
+                if self.input_cursor < self.input_line.len() {
+                    self.input_line.remove(self.input_cursor);
+                }
+                TestPanelAction::None
+            }
+            Msg::InputLeft => {
+                if self.input_cursor > 0 {
+                    let prev = self.input_line[..self.input_cursor]
+                        .chars()
+                        .last()
+                        .map(|c| c.len_utf8())
+                        .unwrap_or(0);
+                    self.input_cursor -= prev;
+                }
+                TestPanelAction::None
+            }
+            Msg::InputRight => {
+                if self.input_cursor < self.input_line.len() {
+                    let next = self.input_line[self.input_cursor..]
+                        .chars()
+                        .next()
+                        .map(|c| c.len_utf8())
+                        .unwrap_or(0);
+                    self.input_cursor += next;
+                }
+                TestPanelAction::None
+            }
+            Msg::InputHome => {
+                self.input_cursor = 0;
+                TestPanelAction::None
+            }
+            Msg::InputEnd => {
+                self.input_cursor = self.input_line.len();
+                TestPanelAction::None
+            }
+            Msg::InputSubmit => {
+                let input = self.input_line.trim().to_string();
+                if input.is_empty() {
+                    return TestPanelAction::None;
+                }
+
+                let Some(policy) = policy else {
+                    self.flash = Some("No policy loaded".into());
+                    return TestPanelAction::Flash("No policy loaded".into());
+                };
+
+                match test_eval::evaluate_test(&input, policy) {
+                    Ok(result) => {
+                        let effect = result.effect();
+                        let summary = result.summary();
+                        let case = TestCase {
+                            input: input.clone(),
+                            tool_name: result.tool_name,
+                            tool_input: result.tool_input,
+                            effect,
+                            summary,
+                            pinned: false,
+                            changed: false,
+                            prev_effect: None,
+                        };
+                        self.cases.push(case);
+                        self.selected = self.cases.len() - 1;
+                        self.input_line.clear();
+                        self.input_cursor = 0;
+                        self.flash = None;
+                        TestPanelAction::None
+                    }
+                    Err(e) => {
+                        let msg = format!("Parse error: {e:#}");
+                        self.flash = Some(msg.clone());
+                        TestPanelAction::Flash(msg)
+                    }
+                }
+            }
+            Msg::InputClear => {
+                self.input_line.clear();
+                self.input_cursor = 0;
+                self.flash = None;
+                TestPanelAction::None
+            }
+        }
+    }
+
+    /// Re-evaluate all test cases against a new policy.
+    /// Called whenever the policy is modified.
+    pub fn re_evaluate(&mut self, policy: &CompiledPolicy) {
+        for case in &mut self.cases {
+            let new_decision = policy.evaluate(&case.tool_name, &case.tool_input);
+            let new_effect = new_decision.effect;
+            let new_summary = match &new_decision.reason {
+                Some(reason) => format!("{} ({reason})", effect_str(new_effect)),
+                None => effect_str(new_effect).to_string(),
+            };
+
+            // Detect changes: compare new effect against current effect
+            let old_effect = case.effect;
+            case.changed = new_effect != old_effect;
+            case.prev_effect = Some(old_effect);
+            case.effect = new_effect;
+            case.summary = new_summary;
+        }
+    }
+
+    /// Switch focus between input and history.
+    pub fn toggle_input_focus(&mut self) {
+        self.input_active = !self.input_active;
+    }
+
+    /// Render the test panel into the given area.
+    pub fn view(&self, frame: &mut Frame, area: Rect) {
+        self.view_with_focus(frame, area, true)
+    }
+
+    /// Render the test panel, with focus indicator.
+    pub fn view_with_focus(&self, frame: &mut Frame, area: Rect, focused: bool) {
+        let border_color = if focused { Color::Blue } else { Color::DarkGray };
+        let block = Block::default()
+            .borders(Borders::ALL)
+            .border_style(Style::default().fg(border_color))
+            .title(" Test Console ");
+
+        let inner = block.inner(area);
+        frame.render_widget(block, area);
+
+        if inner.height < 3 {
+            return;
+        }
+
+        // Split: history area + input line (2 rows: prompt + hint)
+        let chunks = Layout::vertical([
+            Constraint::Min(1),    // history
+            Constraint::Length(2), // input + hint
+        ])
+        .split(inner);
+
+        self.render_history(frame, chunks[0]);
+        self.render_input(frame, chunks[1]);
+    }
+
+    fn render_history(&self, frame: &mut Frame, area: Rect) {
+        if self.cases.is_empty() {
+            let empty = Paragraph::new(Line::from(Span::styled(
+                " Type a test below...",
+                Style::default().fg(Color::DarkGray),
+            )));
+            frame.render_widget(empty, area);
+            return;
+        }
+
+        let visible_height = area.height as usize;
+
+        // Adjust scroll to keep selected visible
+        let scroll = if self.selected < self.scroll_offset {
+            self.selected
+        } else if self.selected >= self.scroll_offset + visible_height {
+            self.selected.saturating_sub(visible_height - 1)
+        } else {
+            self.scroll_offset
+        };
+
+        // Separate pinned from unpinned for rendering
+        let mut lines: Vec<Line> = Vec::new();
+
+        // Render unpinned cases first, then pinned section
+        let has_pinned = self.cases.iter().any(|c| c.pinned);
+
+        for (i, case) in self.cases.iter().enumerate().skip(scroll).take(visible_height) {
+            if case.pinned && has_pinned {
+                continue; // Render pinned separately below
+            }
+            lines.push(self.render_case(i, case));
+        }
+
+        // Pinned divider + pinned cases
+        if has_pinned {
+            let pinned_cases: Vec<(usize, &TestCase)> = self
+                .cases
+                .iter()
+                .enumerate()
+                .filter(|(_, c)| c.pinned)
+                .collect();
+
+            if !pinned_cases.is_empty() && lines.len() + 1 < visible_height {
+                lines.push(Line::from(Span::styled(
+                    " ┄┄ pinned ┄┄",
+                    Style::default().fg(Color::DarkGray),
+                )));
+                for (i, case) in pinned_cases {
+                    if lines.len() >= visible_height {
+                        break;
+                    }
+                    lines.push(self.render_case(i, case));
+                }
+            }
+        }
+
+        let para = Paragraph::new(lines);
+        frame.render_widget(para, area);
+    }
+
+    fn render_case(&self, index: usize, case: &TestCase) -> Line<'static> {
+        let is_selected = index == self.selected && !self.input_active;
+        let pin_marker = if case.pinned { "* " } else { "  " };
+        let changed_badge = if case.changed { " [CHG]" } else { "" };
+
+        let effect_icon = match case.effect {
+            Effect::Allow => "✓",
+            Effect::Deny => "✗",
+            Effect::Ask => "?",
+        };
+
+        let effect_color = match case.effect {
+            Effect::Allow => Color::Green,
+            Effect::Deny => Color::Red,
+            Effect::Ask => Color::Yellow,
+        };
+
+        let style = if is_selected {
+            Style::default()
+                .bg(Color::DarkGray)
+                .fg(Color::White)
+                .add_modifier(Modifier::BOLD)
+        } else {
+            Style::default()
+        };
+
+        let mut spans = vec![
+            Span::styled(pin_marker.to_string(), style),
+            Span::styled(
+                format!("{effect_icon} "),
+                if is_selected {
+                    style
+                } else {
+                    Style::default().fg(effect_color)
+                },
+            ),
+            Span::styled(truncate_input(&case.input, 20), style.fg(Color::White)),
+            Span::styled(
+                format!(" {}", case.summary),
+                if is_selected {
+                    style
+                } else {
+                    Style::default().fg(effect_color)
+                },
+            ),
+        ];
+
+        if !changed_badge.is_empty() {
+            spans.push(Span::styled(
+                changed_badge.to_string(),
+                Style::default()
+                    .fg(Color::Magenta)
+                    .add_modifier(Modifier::BOLD),
+            ));
+        }
+
+        Line::from(spans)
+    }
+
+    fn render_input(&self, frame: &mut Frame, area: Rect) {
+        if area.height < 1 {
+            return;
+        }
+
+        // Input line
+        let prompt_style = if self.input_active {
+            Style::default().fg(Color::Cyan)
+        } else {
+            Style::default().fg(Color::DarkGray)
+        };
+
+        let input_display = if self.input_line.is_empty() && self.input_active {
+            "bash \"cmd\", Read { ... }".to_string()
+        } else {
+            self.input_line.clone()
+        };
+
+        let input_style = if self.input_line.is_empty() && self.input_active {
+            Style::default().fg(Color::DarkGray)
+        } else if self.input_active {
+            Style::default().fg(Color::White)
+        } else {
+            Style::default().fg(Color::DarkGray)
+        };
+
+        let input_line = Line::from(vec![
+            Span::styled(" > ", prompt_style),
+            Span::styled(input_display, input_style),
+        ]);
+
+        let mut lines = vec![input_line];
+
+        // Flash/error message or hint
+        if area.height >= 2 {
+            if let Some(ref flash) = self.flash {
+                lines.push(Line::from(Span::styled(
+                    format!("   {flash}"),
+                    Style::default().fg(Color::Red),
+                )));
+            } else {
+                lines.push(Line::from(Span::styled(
+                    "   Tab: focus history  p: pin",
+                    Style::default().fg(Color::DarkGray),
+                )));
+            }
+        }
+
+        let para = Paragraph::new(lines);
+        frame.render_widget(para, area);
+
+        // Show cursor in input when active
+        if self.input_active {
+            let cursor_x = area.x + 3 + self.input_cursor as u16;
+            let cursor_y = area.y;
+            if cursor_x < area.x + area.width {
+                frame.set_cursor_position((cursor_x, cursor_y));
+            }
+        }
+    }
+}
+
+/// Action returned from TestPanel::update.
+pub enum TestPanelAction {
+    None,
+    Flash(String),
+}
+
+fn effect_str(effect: Effect) -> &'static str {
+    match effect {
+        Effect::Allow => "allow",
+        Effect::Deny => "deny",
+        Effect::Ask => "ask",
+    }
+}
+
+fn truncate_input(input: &str, max: usize) -> String {
+    if input.len() <= max {
+        input.to_string()
+    } else {
+        format!("{}…", &input[..max - 1])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::policy::match_tree::*;
+    use crate::policy::manifest_edit;
+    use std::collections::HashMap;
+
+    fn empty_policy() -> CompiledPolicy {
+        CompiledPolicy {
+            sandboxes: HashMap::new(),
+            tree: vec![],
+            default_effect: Effect::Deny,
+            default_sandbox: None,
+        }
+    }
+
+    fn policy_allowing_read() -> CompiledPolicy {
+        let mut manifest = PolicyManifest {
+            includes: vec![],
+            policy: empty_policy(),
+        };
+        manifest_edit::upsert_rule(
+            &mut manifest,
+            manifest_edit::build_tool_rule("Read", Decision::Allow(None)),
+        );
+        manifest.policy
+    }
+
+    #[test]
+    fn test_submit_and_evaluate() {
+        let mut panel = TestPanel::new();
+        let policy = policy_allowing_read();
+
+        // Type "Read /tmp/foo"
+        for c in "Read /tmp/foo".chars() {
+            panel.update(Msg::InputChar(c), Some(&policy));
+        }
+        panel.update(Msg::InputSubmit, Some(&policy));
+
+        assert_eq!(panel.cases.len(), 1);
+        assert_eq!(panel.cases[0].effect, Effect::Allow);
+        assert!(panel.input_line.is_empty());
+    }
+
+    #[test]
+    fn test_re_evaluate_detects_changes() {
+        let mut panel = TestPanel::new();
+        let policy = policy_allowing_read();
+
+        // Submit a test
+        panel.input_line = r#"Read { "file_path": "/tmp/foo" }"#.to_string();
+        panel.input_cursor = panel.input_line.len();
+        panel.update(Msg::InputSubmit, Some(&policy));
+
+        assert_eq!(panel.cases[0].effect, Effect::Allow);
+
+        // Re-evaluate against a deny-all policy
+        let deny_policy = empty_policy();
+        panel.re_evaluate(&deny_policy);
+
+        assert_eq!(panel.cases[0].effect, Effect::Deny);
+        assert!(panel.cases[0].changed);
+    }
+
+    #[test]
+    fn test_pin_toggle() {
+        let mut panel = TestPanel::new();
+        let policy = empty_policy();
+
+        panel.input_line = "bash ls".to_string();
+        panel.input_cursor = panel.input_line.len();
+        panel.update(Msg::InputSubmit, Some(&policy));
+
+        assert!(!panel.cases[0].pinned);
+
+        panel.input_active = false;
+        panel.update(Msg::TogglePin, None);
+        assert!(panel.cases[0].pinned);
+
+        // Clear should keep pinned
+        panel.update(Msg::ClearHistory, None);
+        assert_eq!(panel.cases.len(), 1);
+    }
+
+    #[test]
+    fn test_delete_case() {
+        let mut panel = TestPanel::new();
+        let policy = empty_policy();
+
+        panel.input_line = "bash ls".to_string();
+        panel.input_cursor = panel.input_line.len();
+        panel.update(Msg::InputSubmit, Some(&policy));
+
+        panel.input_line = "bash pwd".to_string();
+        panel.input_cursor = panel.input_line.len();
+        panel.update(Msg::InputSubmit, Some(&policy));
+
+        assert_eq!(panel.cases.len(), 2);
+
+        panel.input_active = false;
+        panel.selected = 0;
+        panel.update(Msg::DeleteCase, None);
+        assert_eq!(panel.cases.len(), 1);
+    }
+
+    #[test]
+    fn test_no_policy_flash() {
+        let mut panel = TestPanel::new();
+        panel.input_line = "bash ls".to_string();
+        panel.input_cursor = panel.input_line.len();
+
+        let action = panel.update(Msg::InputSubmit, None);
+        assert!(matches!(action, TestPanelAction::Flash(_)));
+        assert!(panel.cases.is_empty());
+    }
+}

--- a/clash/src/tui/widgets.rs
+++ b/clash/src/tui/widgets.rs
@@ -142,6 +142,10 @@ pub fn render_help_overlay(frame: &mut Frame, area: Rect) {
             Span::raw("Move item up/down (includes)"),
         ]),
         Line::from(vec![
+            Span::styled("t      ", Style::default().fg(Color::Yellow)),
+            Span::raw("Toggle test console panel"),
+        ]),
+        Line::from(vec![
             Span::styled("s      ", Style::default().fg(Color::Yellow)),
             Span::raw("Save (review diff first)"),
         ]),


### PR DESCRIPTION
## Summary

- Adds a persistent **test console side panel** to the policy editor TUI, eliminating the need for a separate `clash playground` REPL
- Users can test tool invocations against their policy in real-time as they edit rules — results update live with `[CHG]` badges when the policy changes
- Adds a **Starlark expression** option to the AddRule form so power users can write raw DSL (`exe("git").allow()`) directly in the structured editor

## Changes

### New files
| File | Purpose |
|---|---|
| `clash/src/policy/test_eval.rs` | Shared test parsing + evaluation (extracted from playground) |
| `clash/src/tui/test_panel.rs` | TestPanel component: history, input, pin, re-evaluate, change badges |

### Modified files
- **`tui/app.rs`** — TestPanel integration: split layout, focus toggle, live re-evaluation on modify
- **`tui/inline_form.rs`** — Third "Starlark expression" option in AddRule form; inline selector for rule types
- **`tui/mod.rs`** — Export test_panel, add `run_with_options(path, show_test_panel)`
- **`tui/widgets.rs`** — Help overlay: added `t` keybinding
- **`cli.rs`** — Added `--test` flag to `policy edit`
- **`cmd/policy.rs`** — Pass `--test` flag through to TUI
- **`cmd/playground.rs`** — Uses shared `test_eval`, removed duplicated parsing
- **`main.rs`** — Deprecation notice on `clash playground`

## UX

- Test console is **visible by default** (right side, 32% width)
- `t` focuses the test console from the editor; `Esc` returns to editor
- `Tab` toggles between test input and history within the console
- `p` pins a test case; `x` clears unpinned history
- `clash policy edit --test` opens with test console focused
- `clash playground` still works with a deprecation notice

## Test plan

- [x] 545 lib tests pass (including 5 new TestPanel tests, 7 new test_eval tests)
- [ ] Manual: open `clash policy edit`, verify test console renders on right
- [ ] Manual: type `bash "git push"` in test input, verify result appears
- [ ] Manual: edit a rule, verify test results update with [CHG] badge
- [ ] Manual: press `a`, select "Starlark expression", type `exe("curl").deny()`, verify it compiles
- [ ] Manual: press `Esc` to return to tree, `t` to refocus test console