### PR TITLE
fix(site): correct tutorial tool references to match configured policy

### DIFF
--- a/site/pages/tutorial.md
+++ b/site/pages/tutorial.md
@@ -61,7 +61,7 @@ Two new concepts:
 Test it:
 
 ```bash
-clash explain read "src/main.rs"
+clash explain glob "src/**/*.rs"
 ```
 
 You should see an <span class="badge badge--allow">allow</span> decision.
@@ -312,9 +312,9 @@ clash status
 Test specific commands against your rules:
 
 ```bash
-clash explain bash "cargo test"
-clash explain bash "git push --force"
-clash explain read "~/.ssh/id_rsa"
+clash explain bash "cargo test"        # → allow (sandbox: dev)
+clash explain bash "git push --force"  # → deny
+clash explain read "~/.ssh/id_rsa"     # → ask (no rule, falls to default)
 ```
 
 Format your policy file:

--- a/site/versions/v0.5.3/pages/tutorial.md
+++ b/site/versions/v0.5.3/pages/tutorial.md
@@ -61,7 +61,7 @@ Two new concepts:
 Test it:
 
 ```bash
-clash explain read "src/main.rs"
+clash explain glob "src/**/*.rs"
 ```
 
 You should see an <span class="badge badge--allow">allow</span> decision.
@@ -312,9 +312,9 @@ clash status
 Test specific commands against your rules:
 
 ```bash
-clash explain bash "cargo test"
-clash explain bash "git push --force"
-clash explain read "~/.ssh/id_rsa"
+clash explain bash "cargo test"        # → allow (sandbox: dev)
+clash explain bash "git push --force"  # → deny
+clash explain read "~/.ssh/id_rsa"     # → ask (no rule, falls to default)
 ```
 
 Format your policy file:


### PR DESCRIPTION
## Summary

Fixes #377 -- the tutorial had incorrect tool references that did not match the policy being taught.

- **Step 2**: Changed `clash explain read "src/main.rs"` to `clash explain glob "src/**/*.rs"` -- the policy configures `tool(["Glob", "Grep"])`, so the test should verify one of those tools, not `Read` (which is only implicitly covered by the `cwd()` rule)
- **Verify section**: Added result annotation comments (`# -> allow`, `# -> deny`, `# -> ask`) matching the style already used in Step 4

Both current (`site/pages/tutorial.md`) and versioned (`site/versions/v0.5.3/pages/tutorial.md`) files updated.

## Test plan

- [ ] Verify `clash explain glob "src/**/*.rs"` returns allow against the Step 2 policy
- [ ] Review the Verify section annotations match the final Step 8 policy behavior
- [ ] Check site renders correctly with `bun run dev` in `site/`