### PR TITLE
feat(starlark): expose OS and ARCH constants for platform-conditional policies

### DIFF
--- a/clash_starlark/src/globals.rs
+++ b/clash_starlark/src/globals.rs
@@ -47,6 +47,10 @@ fn register_globals(builder: &mut GlobalsBuilder) {
     const _DENY: &str = "deny";
     const _ASK: &str = "ask";
 
+    // Platform constants — let Starlark policies branch on OS/architecture
+    const _OS: &str = std::env::consts::OS;
+    const _ARCH: &str = std::env::consts::ARCH;
+
     // -- Minimal Rust primitives (everything else is in @clash//std.star) --
 
     /// Wrap an arbitrary dict/value as a MatchTreeNode.

--- a/clash_starlark/src/lib.rs
+++ b/clash_starlark/src/lib.rs
@@ -1013,4 +1013,96 @@ def main():
             "should have tmpdir rule"
         );
     }
+
+    #[test]
+    fn test_os_and_arch_constants() {
+        let doc = eval_to_doc(
+            r#"
+load("@clash//std.star", "deny", "policy", "tool", "OS", "ARCH")
+
+def main():
+    # OS and ARCH should be non-empty strings
+    if not OS or not ARCH:
+        fail("OS and ARCH must be non-empty")
+    return policy(default = deny(), rules = [tool().allow()])
+"#,
+        );
+        assert_eq!(doc["schema_version"], 5);
+    }
+
+    #[test]
+    fn test_os_matches_rust_const() {
+        // Verify the Starlark OS constant matches the Rust compile-time value.
+        // We do this by evaluating a policy that embeds the OS in a sandbox doc field.
+        let doc = eval_to_doc(
+            r#"
+load("@clash//std.star", "deny", "exe", "policy", "sandbox", "cwd", "OS")
+
+def main():
+    box = sandbox(
+        name = "test",
+        default = deny(),
+        fs = [cwd().allow(read = True)],
+        doc = OS,
+    )
+    return policy(default = deny(), rules = [exe("test").sandbox(box).allow()])
+"#,
+        );
+        let sandbox = &doc["sandboxes"]["test"];
+        assert_eq!(
+            sandbox["doc"].as_str().unwrap(),
+            std::env::consts::OS,
+            "Starlark OS should match std::env::consts::OS"
+        );
+    }
+
+    #[test]
+    fn test_sandbox_auto_inject_platform_home_deny() {
+        // Verify that sandbox() auto-injects a deny rule for the correct
+        // platform-specific user home directory root.
+        let doc = eval_to_doc(
+            r#"
+load("@clash//std.star", "deny", "exe", "policy", "sandbox", "cwd")
+
+def main():
+    box = sandbox(
+        name = "test",
+        default = deny(),
+        fs = [cwd().allow(read = True)],
+    )
+    return policy(default = deny(), rules = [exe("test").sandbox(box).allow()])
+"#,
+        );
+        let sandbox = &doc["sandboxes"]["test"];
+        let rules = sandbox["rules"].as_array().unwrap();
+        let deny_paths: Vec<&str> = rules
+            .iter()
+            .filter(|r| r["effect"].as_str() == Some("deny"))
+            .filter_map(|r| r["path"].as_str())
+            .collect();
+
+        let expected_home = if std::env::consts::OS == "macos" {
+            "/Users"
+        } else {
+            "/home"
+        };
+
+        assert!(
+            deny_paths.iter().any(|p| *p == expected_home),
+            "sandbox should deny {expected_home} on {}, got deny paths: {deny_paths:?}",
+            std::env::consts::OS,
+        );
+
+        // Ensure it does NOT deny the wrong platform's home dir
+        let wrong_home = if std::env::consts::OS == "macos" {
+            "/home"
+        } else {
+            "/Users"
+        };
+        assert!(
+            !deny_paths.iter().any(|p| *p == wrong_home),
+            "sandbox should NOT deny {wrong_home} on {}",
+            std::env::consts::OS,
+        );
+    }
 }

--- a/clash_starlark/stdlib/std.star
+++ b/clash_starlark/stdlib/std.star
@@ -2,7 +2,14 @@
 #
 # Emits v5 match tree nodes using minimal Rust primitives.
 # Rust globals available: _mt_node, _mt_condition, _mt_pattern, _mt_prefix,
-# _mt_literal, _mt_policy, _ALLOW, _DENY, _ASK
+# _mt_literal, _mt_policy, _ALLOW, _DENY, _ASK, _OS, _ARCH
+
+# ---------------------------------------------------------------------------
+# Platform constants — re-export from Rust for use in policy files
+# ---------------------------------------------------------------------------
+
+OS = _OS      # e.g. "macos", "linux"
+ARCH = _ARCH  # e.g. "aarch64", "x86_64"
 
 # ---------------------------------------------------------------------------
 # Effect constructors
@@ -620,7 +627,10 @@ def sandbox(name=None, default="deny", fs=None, net=None, doc=None):
     fs_rules = []
     if fs == None:
         fs = []
-    fs += [path("/").recurse().allow(read=True), path("/Users").recurse().deny()]
+    # Allow reading the root filesystem but deny access to user home directories.
+    # The home directory root differs by platform: /Users on macOS, /home on Linux.
+    _user_homes = "/Users" if OS == "macos" else "/home"
+    fs += [path("/").recurse().allow(read=True), path(_user_homes).recurse().deny()]
     for entry in fs:
         if hasattr(entry, "_is_path"):
             # Path entry — collect sandbox rules from it

--- a/docs/policy-guide.md
+++ b/docs/policy-guide.md
@@ -358,6 +358,20 @@ exe(["cargo", "rustc"])
 exe("git").also(exe("gh"))
 ```
 
+### Platform Constants
+
+```python
+load("@clash//std.star", "OS", "ARCH")
+
+# OS is "macos" or "linux"; ARCH is "aarch64" or "x86_64"
+if OS == "linux":
+    extra_fs = [path("/opt/tools").allow(read = True)]
+else:
+    extra_fs = []
+```
+
+Use `OS` and `ARCH` to write policies that compile differently per platform.
+
 ### Path Helpers
 
 ```python


### PR DESCRIPTION
## Summary

- Adds `OS` and `ARCH` string constants to the Starlark policy environment, sourced from Rust's `std::env::consts::OS` / `std::env::consts::ARCH`
- Fixes the `sandbox()` auto-injected deny rule to use `/Users` on macOS and `/home` on Linux instead of hardcoding `/Users`
- Documents the new constants in the policy guide

Closes #379

## Test plan

- [x] New test `test_os_and_arch_constants` — verifies OS/ARCH are loadable and non-empty
- [x] New test `test_os_matches_rust_const` — verifies Starlark OS value matches `std::env::consts::OS`
- [x] New test `test_sandbox_auto_inject_platform_home_deny` — verifies sandbox denies the correct platform home dir and does NOT deny the other platform's home dir
- [x] All 38 existing tests pass with no regressions
- [x] Full workspace `cargo check` passes