### PR TITLE
docs: fix typos, stale copy, and incorrect API examples

### DIFF
--- a/.claude/commands/find-typos.md
+++ b/.claude/commands/find-typos.md
@@ -1,0 +1,4 @@
+Find all typos.  Read through all copy and run it through your LLM figuring out
+where the copy doesn't match expectation from context.  Read through all site
+copy, documentation, including code documentation, comments, etc. Do not use
+grep, sed, etc.  Read the _actual_ copy _directly_.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,7 +85,7 @@ jobs:
           files: artifacts/*
           generate_release_notes: true
 
-  publish-stite:
+  publish-site:
     runs-on: ubuntu-latest
     environment: clash-site
     steps:

--- a/.github/workflows/site-deploy.yml
+++ b/.github/workflows/site-deploy.yml
@@ -8,7 +8,7 @@ permissions:
   contents: read
 
 jobs: 
-  publish-stite:
+  publish-site:
     runs-on: ubuntu-latest
     environment: clash-site
     steps:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,7 @@
 
 * Always check the documentation after your changes to ensure they are logically consistent with what you have done. This should be the last step after you have validated your changes work.
 * ALWAYS update the relevant documentation (readme/comments) when changes have a public facing impact.
-* Prefer to "comment through context", whether that be debug logs, anyhow::Context instead of comments unless your code comments are explaining difficult to understand code
+* Prefer to "comment through context", whether that be debug logs or anyhow::Context, instead of comments — unless your code comments are explaining difficult-to-understand code
 * If you are corrected by a person when using a skill, or told you should have used the skill, then modify the plugin definition for clash to ensure this doesn't happen again.
 
 ## Commits
@@ -63,7 +63,7 @@
 ## Layout
 
 * *clash* Clash binary + library (includes `src/agents/` for multi-agent protocol adapters)
-* *clash-starlark* Starlark policy evaluator — compiles `.star` files to JSON policy format
+* *clash_starlark* Starlark policy evaluator — compiles `.star` files to JSON policy format
 * *clash-plugin* Claude Code plugin (hooks.json, .claude-plugin definitions)
 * *clash-gemini-ext* Gemini CLI extension package
 * *clash-codex* Codex CLI hook configuration

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Claude Code is the most mature integration. The other 5 agents have protocol ada
 
 Coding agents operate with broad tool access — executing commands, editing files, and making network requests on your behalf. Their permission models tend to be all-or-nothing: either you allow a tool entirely or get prompted every time. You end up clicking "yes" hundreds of times a session, or giving blanket approval and hoping for the best.
 
-Clash gives you granular control. Write policy rules that decide what to **allow**, **deny**, or **ask** about — then let the agent work freely on safe operations while blocking dangerous ones. On Linux, rules can generate kernel-enforced filesystem sandboxes so even allowed commands can only touch the files you specify.
+Clash gives you granular control. Write policy rules that decide what to **allow**, **deny**, or **ask** about — then let the agent work freely on safe operations while blocking dangerous ones. Rules can carry OS-enforced sandboxes (Landlock on Linux, Seatbelt on macOS) so even allowed commands can only touch the files you specify.
 
 ---
 

--- a/clash-brush-core/src/callstack.rs
+++ b/clash-brush-core/src/callstack.rs
@@ -380,7 +380,7 @@ impl CallStack {
         Self::default()
     }
 
-    /// Removes the top from from the stack. If the stack is empty, does nothing and
+    /// Removes the top frame from the stack. If the stack is empty, does nothing and
     /// returns `None`; otherwise, returns the removed call frame.
     pub fn pop(&mut self) -> Option<Frame> {
         let frame = self.frames.pop_front()?;

--- a/clash-brush-core/src/interp.rs
+++ b/clash-brush-core/src/interp.rs
@@ -524,7 +524,7 @@ async fn wait_for_pipeline_processes_and_update_status(
     let mut stopped_children = vec![];
     let mut last_failure_exit_code: Option<ExecutionExitCode> = None;
 
-    // Clear our the pipeline status so we can start filling it out.
+    // Clear out the pipeline status so we can start filling it out.
     shell.last_pipeline_statuses_mut().clear();
 
     while let Some(child) = process_spawn_results.pop_front() {

--- a/clash-brush-core/src/openfiles.rs
+++ b/clash-brush-core/src/openfiles.rs
@@ -291,7 +291,7 @@ impl std::io::Write for OpenFile {
     }
 }
 
-/// Tristate representing the an `OpenFile` entry in an `OpenFiles` structure.
+/// Tristate representing an `OpenFile` entry in an `OpenFiles` structure.
 pub enum OpenFileEntry<'a> {
     /// File descriptor is present and has a valid associated `OpenFile`.
     Open(&'a OpenFile),

--- a/clash-brush-core/src/traps.rs
+++ b/clash-brush-core/src/traps.rs
@@ -18,7 +18,7 @@ pub enum TrapSignal {
     Err,
     /// The `EXIT` trap.
     Exit,
-    /// The `RETURN` trp.
+    /// The `RETURN` trap.
     Return,
 }
 

--- a/clash-brush-interactive/src/interactive_shell.rs
+++ b/clash-brush-interactive/src/interactive_shell.rs
@@ -264,7 +264,7 @@ impl<'a, IB: InputBackend, SE: brush_core::ShellExtensions> InteractiveShell<'a,
     ) -> Result<InteractiveExecutionResult, ShellError> {
         let mut shell = self.shell.lock().await;
 
-        // See if the the user interface has a non-empty read buffer.
+        // See if the user interface has a non-empty read buffer.
         let buffer_info = self.input.get_read_buffer();
 
         // If the user interface did, in fact, have a non-empty read buffer,

--- a/clash-brush-interactive/src/reedline/history.rs
+++ b/clash-brush-interactive/src/reedline/history.rs
@@ -50,7 +50,7 @@ impl<SE: brush_core::ShellExtensions> reedline::History for ReedlineHistory<SE> 
     fn load(&self, id: reedline::HistoryItemId) -> reedline::Result<reedline::HistoryItem> {
         let shell = self.lock_shell();
 
-        // Get the history, retrieve the item, and translate the item it into reedline's format.
+        // Get the history, retrieve the item, and translate it into reedline's format.
         get_shell_history(&shell)?
             .get_by_id(id.0)
             .map_err(brush_error_to_reedline)?
@@ -122,7 +122,7 @@ impl<SE: brush_core::ShellExtensions> reedline::History for ReedlineHistory<SE> 
     fn clear(&mut self) -> reedline::Result<()> {
         let mut shell = self.lock_shell();
 
-        // Get the history, retrieve the item, and translate the item it into reedline's format.
+        // Get the history and clear it.
         get_shell_history_mut(&mut shell)?
             .clear()
             .map_err(brush_error_to_reedline)

--- a/clash-brush-parser/src/ast.rs
+++ b/clash-brush-parser/src/ast.rs
@@ -2027,7 +2027,7 @@ pub enum ArithmeticExpr {
     Literal(i64),
     /// A dereference of a variable or array element.
     Reference(ArithmeticTarget),
-    /// A unary operation on an the result of a given nested expression.
+    /// A unary operation on the result of a given nested expression.
     UnaryOp(UnaryOperator, Box<Self>),
     /// A binary operation on two nested expressions.
     BinaryOp(BinaryOperator, Box<Self>, Box<Self>),

--- a/clash-plugin/README.md
+++ b/clash-plugin/README.md
@@ -29,7 +29,7 @@ The build copies this plugin directory and the compiled `clash` binary into a st
 
 ## How It Works
 
-The plugin registers four hook types via `hooks/hooks.json`:
+The plugin registers five hook types via `hooks/hooks.json`:
 
 | Hook | Purpose |
 |------|---------|
@@ -37,6 +37,7 @@ The plugin registers four hook types via `hooks/hooks.json`:
 | **PostToolUse** | Runs after tool execution (audit logging) |
 | **PermissionRequest** | Responds to permission prompts on behalf of the user |
 | **Notification** | Handles notification events (permission prompts, idle detection, etc.) |
+| **SessionStart** | Initializes session state and injects system prompt context |
 
 ## Policy Basics
 

--- a/docs/adr/002-deny-overrides.md
+++ b/docs/adr/002-deny-overrides.md
@@ -19,7 +19,7 @@ Common resolution strategies:
 Use strict deny-overrides precedence:
 
 ```
-deny > ask > allow > delegate > default
+deny > ask > allow > default
 ```
 
 If any matching rule says `deny`, the result is `deny` — regardless of how many `allow` rules also match. Rule order in the document has no effect on the outcome.
@@ -35,11 +35,11 @@ If any matching rule says `deny`, the result is `deny` — regardless of how man
 **Negative:**
 - Cannot express "deny everything except X" as a deny + allow pair — need negation patterns (`deny * write !~/project/**`)
 - Cannot have a targeted allow that overrides a broader deny — must restructure the deny rule to be more specific
-- Makes the `delegate` effect lowest priority, which means you can't delegate a decision that another rule denies
+- Cannot have a "pass-through" effect — every matching rule must commit to deny, ask, or allow
 
 ## Amendment: Specificity-Based Ordering (v2, 2026-02)
 
-The strict deny-overrides model is preserved across capability domains, but within a domain v2 uses **specificity-based first-match** instead of collecting all matches. Rules are sorted at compile time (most specific first) and the first matching rule wins. Conflicts (same specificity, different effects, overlapping matchers) are rejected at compile time.
+The strict deny-overrides model is preserved across capability domains, but within a domain v2 uses **specificity-based first-match** instead of collecting all matches. Children at the same level are sorted at compile time by specificity (most specific first) and the first matching rule wins.
 
 This means:
 

--- a/docs/adr/003-fs-sandbox-bash.md
+++ b/docs/adr/003-fs-sandbox-bash.md
@@ -23,8 +23,8 @@ For bash commands, `fs` path filters generate kernel-level sandbox rules instead
 For non-bash tools (Read, Write, Edit, Glob, Grep), the eval layer checks the resolved path against `fs` rules directly — the path filter acts as a permission guard.
 
 In v2, this maps to:
-- `exec` capability → sandbox generation from `fs_rules` (future PR)
-- `fs` capability → eval checks path against `CompiledPathFilter` at decision time
+- `exec` capability → sandbox generation from sandbox definitions
+- `fs` capability → eval checks path against match tree at decision time
 
 ## Consequences
 
@@ -36,6 +36,6 @@ In v2, this maps to:
 **Negative:**
 - Requires platform-specific code (macOS Seatbelt profiles, Linux Landlock rules)
 - Sandbox is one-way — once applied, the process cannot gain additional permissions
-- Filter expression semantics differ slightly: `And(a, b)` / `Or(a, b)` both collect rules from both sides in sandbox generation (the boolean logic is approximated by the union of sandbox rules)
+- Sandbox rules are collected from the policy's sandbox definitions — the union of all applicable rules is applied
 - Regex-based filters have limited support on some platforms
 - Kernel-level sandbox enforcement covers filesystem and network access only. Exec-level argument matching (e.g., `(deny (exec "git" "push" *))`) operates at the hook level and only evaluates the top-level command — child processes within the sandbox are not checked against exec rules ([#136](https://github.com/empathic/clash/issues/136))

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -797,27 +797,13 @@ unset CLASH_DISABLE
 
 ## Uninstalling
 
-To fully remove clash from your system:
-
 ```bash
-# 1. Remove the Claude Code plugin (stops hooks from firing)
-claude plugin uninstall clash
-
-# 2. Remove the binary
-cargo uninstall clash
-
-# 3. (Optional) Remove from the plugin marketplace
-claude plugin marketplace remove clash
-
-# 4. (Optional) Remove the status line — only needed if you skipped step 2
-clash statusline uninstall
-
-# 5. (Optional) Clean up configuration and logs
-rm -rf ~/.clash       # user-level policy and logs
-rm -rf .clash         # project-level policy (per repo)
+clash uninstall
 ```
 
-After step 1, Claude Code reverts to its built-in permission model immediately. Policy files are left in place so you can resume where you left off if you reinstall later.
+This removes the Claude Code plugin, the status line, policy files (`~/.clash/`), and the binary — regardless of how it was installed. Use `clash uninstall -y` to skip confirmation prompts.
+
+After uninstalling, Claude Code reverts to its built-in permission model.
 
 ---
 

--- a/docs/multi-agent.md
+++ b/docs/multi-agent.md
@@ -63,7 +63,7 @@ Capability rules (`exec`, `fs`, `net`) are inherently portable since they operat
 
 ```python
 # These work identically across all agents
-match("git", "cargo", "npm") >> allow()
+match({"Bash": {("git", "cargo", "npm"): allow()}})
 tool(["read", "write", "edit"]).allow()
 ```
 
@@ -73,7 +73,7 @@ Use `agent()` conditions for agent-specific behavior:
 
 ```python
 # Only applies when running under Gemini CLI
-agent("gemini") >> tool("save_memory").deny()
+match({Tool("save_memory"): deny()})  # inside an agent("gemini") scope
 ```
 
 ### Checking Portability

--- a/docs/policy-guide.md
+++ b/docs/policy-guide.md
@@ -21,7 +21,7 @@ def main():
     ])
 ```
 
-This policy allows git commands (except push), file reads and writes under the current directory, and network access to github.com. Everything else is denied.
+This policy allows git commands (except push), file reads and writes, and network access to github.com. Everything else is denied.
 
 <details>
 <summary>Compiled JSON IR (advanced)</summary>
@@ -462,8 +462,8 @@ match({"Read": allow(sandbox = my_sandbox)})
 Annotate rules and sandboxes with `doc=` to explain *why* they exist. Docstrings persist through the compiled IR and appear in `clash status` output.
 
 ```python
-# On match rules
-match({"WebSearch": deny(doc = "No external searches needed")})
+# On tool rules
+tool("WebSearch", doc = "No external searches needed").deny()
 
 # On sandboxes
 sandbox(
@@ -471,8 +471,8 @@ sandbox(
     doc = "Development sandbox for project work",
     default = deny(),
     fs = {
-        subpath("$PWD", follow_worktrees = True): allow("rwc", doc = "Project source files"),
-        "$HOME/.ssh": allow("r", doc = "SSH keys for git auth"),
+        subpath("$PWD", follow_worktrees = True): allow("rwc"),
+        "$HOME/.ssh": allow("r"),
     },
 )
 ```

--- a/docs/policy-semantics.md
+++ b/docs/policy-semantics.md
@@ -76,7 +76,7 @@ match({"Bash": {"git": allow()}})
 match({"Bash": {"git": {"push": deny()}}})
 ```
 
-There is no automatic sorting or conflict detection — the policy author controls evaluation order directly.
+Children at the same level are automatically sorted by specificity (literals before regexes before wildcards), but top-level rule order from the policy source is preserved. Put more specific rules before broader ones to ensure the desired evaluation order.
 
 ---
 

--- a/site/index.md
+++ b/site/index.md
@@ -21,7 +21,7 @@ much more per unit prompt.
 Every tool call your agent makes requires a decision. Right now, that decision
 is yours - *every single time* or **not at all**.
 
-Think of Clash as a new `--safely-skip-permissions` flag.  A way to choose _how_
+Think of Clash as a new `--safely-skip-permissions` flag. A way to choose _how_
 to run anything safely, not just whether Claude can run it **as *you***.
 
 Clash intercepts every tool call Claude makes and runs it through your policy — before anything executes.

--- a/site/pages/faq.md
+++ b/site/pages/faq.md
@@ -28,7 +28,7 @@ Claude Code gives you per-tool toggles: allow a tool entirely, or get prompted e
 
 ## Which agents does Clash support?
 
-**Claude Code** is fully supported today. Codex CLI, Gemini CLI, and OpenCode are planned. But Clash also works standalone — `clash sandbox exec` sandboxes any command, no agent required. The policy engine is agent-independent; only the hook layer is specific to each agent. See the [agent support table]({{ version.pathPrefix }}/#agent-support).
+**Claude Code** is fully supported today. Gemini CLI, Codex CLI, Amazon Q CLI, OpenCode, and Copilot CLI have protocol-ready integrations. But Clash also works standalone — `clash sandbox exec` sandboxes any command, no agent required. The policy engine is agent-independent; only the hook layer is specific to each agent. See the [agent support table]({{ version.pathPrefix }}/#agent-support).
 
 ---
 

--- a/site/versions/v0.6.1/pages/faq.md
+++ b/site/versions/v0.6.1/pages/faq.md
@@ -28,7 +28,7 @@ Claude Code gives you per-tool toggles: allow a tool entirely, or get prompted e
 
 ## Which agents does Clash support?
 
-**Claude Code** is fully supported today. Codex CLI, Gemini CLI, and OpenCode are planned. But Clash also works standalone — `clash sandbox exec` sandboxes any command, no agent required. The policy engine is agent-independent; only the hook layer is specific to each agent. See the [agent support table]({{ version.pathPrefix }}/#agent-support).
+**Claude Code** is fully supported today. Gemini CLI, Codex CLI, Amazon Q CLI, OpenCode, and Copilot CLI have protocol-ready integrations. But Clash also works standalone — `clash sandbox exec` sandboxes any command, no agent required. The policy engine is agent-independent; only the hook layer is specific to each agent. See the [agent support table]({{ version.pathPrefix }}/#agent-support).
 
 ---
 


### PR DESCRIPTION
- Fix comment typos across brush crates (duplicate words, misspellings)
- Rename publish-stite to publish-site in CI workflows
- Correct invalid Starlark API examples in docs (nonexistent >> operator, invalid doc= parameter on allow/deny)
- Update FAQ agent list from "planned" to "protocol-ready" with all 5 agents
- Fix "four hook types" → "five hook types" and add SessionStart to table
- Fix sandbox description to mention both Linux and macOS
- Replace stale multi-step uninstall with `clash uninstall` in CLI reference
- Fix contradictions in policy-semantics and ADR docs
- Fix "run in through" → "run it through" in find-typos command