### PR TITLE
feat: unify multi-agent init, fix OpenCode plugin, add clash install

### DIFF
--- a/clash-opencode/plugin.ts
+++ b/clash-opencode/plugin.ts
@@ -1,71 +1,95 @@
 /**
  * Clash plugin for OpenCode.
  *
- * Bridges OpenCode's JS plugin API to Clash's CLI hook interface.
- * Place this file in .opencode/plugins/ or ~/.config/opencode/plugins/
+ * Bridges OpenCode's plugin API to Clash's CLI hook interface.
+ * Place this file in ~/.opencode/plugins/
  */
 
 import type { Plugin } from "@opencode-ai/plugin"
 import { execSync } from "child_process"
 
-export const ClashPlugin: Plugin = async ({ directory }) => {
+const ClashPlugin: Plugin = async ({ directory }) => {
+  // Use a stable session ID derived from OpenCode's own session.
+  // Falls back to a random ID if sessionID isn't available yet.
+  let sessionId = ""
+
+  // Fire session-start so clash initializes session state (audit log, traces).
+  try {
+    execSync("clash hook --agent opencode session-start", {
+      input: JSON.stringify({
+        session_id: sessionId,
+        cwd: directory,
+        hook_event_name: "session.start",
+      }),
+      encoding: "utf-8",
+      timeout: 10000,
+    })
+  } catch {
+    // Non-fatal: clash may not be on PATH yet
+  }
+
   return {
-    tool: {
-      execute: {
-        before: async (input, output) => {
-          const hookInput = JSON.stringify({
-            tool: input.tool,
-            args: output.args,
-            directory,
-            hook_event_name: "tool.execute.before",
-          })
+    "tool.execute.before": async (input, output) => {
+      // Use OpenCode's session ID once available.
+      if (!sessionId && input.sessionID) {
+        sessionId = `opencode-${input.sessionID}`
+      }
 
-          try {
-            const result = execSync(
-              "clash hook --agent opencode pre-tool-use",
-              {
-                input: hookInput,
-                encoding: "utf-8",
-                timeout: 10000,
-              }
-            )
+      const hookInput = JSON.stringify({
+        tool: input.tool,
+        args: output.args,
+        session_id: sessionId,
+        directory,
+        hook_event_name: "tool.execute.before",
+      })
 
-            const decision = JSON.parse(result)
-            if (decision.action === "deny") {
-              throw new Error(
-                `Clash policy denied: ${decision.reason || "blocked by policy"}`
-              )
-            }
-            if (decision.args) {
-              Object.assign(output.args, decision.args)
-            }
-          } catch (e: any) {
-            if (e.message?.startsWith("Clash policy denied:")) {
-              throw e
-            }
-            // Non-fatal: let the tool execute if clash fails
-            console.error(`[clash] hook error: ${e.message}`)
+      try {
+        const result = execSync(
+          "clash hook --agent opencode pre-tool-use",
+          {
+            input: hookInput,
+            encoding: "utf-8",
+            timeout: 10000,
           }
-        },
-        after: async (input, _output) => {
-          const hookInput = JSON.stringify({
-            tool: input.tool,
-            args: input,
-            directory,
-            hook_event_name: "tool.execute.after",
-          })
+        )
 
-          try {
-            execSync("clash hook --agent opencode post-tool-use", {
-              input: hookInput,
-              encoding: "utf-8",
-              timeout: 10000,
-            })
-          } catch {
-            // Post-tool is advisory, don't fail
-          }
-        },
-      },
+        const decision = JSON.parse(result)
+        if (decision.action === "deny") {
+          throw new Error(
+            `Clash policy denied: ${decision.reason || "blocked by policy"}`
+          )
+        }
+        if (decision.args) {
+          Object.assign(output.args, decision.args)
+        }
+      } catch (e: any) {
+        if (e.message?.startsWith("Clash policy denied:")) {
+          throw e
+        }
+        // Non-fatal: let the tool execute if clash fails
+        console.error(`[clash] hook error: ${e.message}`)
+      }
+    },
+    "tool.execute.after": async (input, _output) => {
+      const hookInput = JSON.stringify({
+        tool: input.tool,
+        args: input.args,
+        session_id: sessionId,
+        directory,
+        hook_event_name: "tool.execute.after",
+      })
+
+      try {
+        execSync("clash hook --agent opencode post-tool-use", {
+          input: hookInput,
+          encoding: "utf-8",
+          timeout: 10000,
+        })
+      } catch {
+        // Post-tool is advisory, don't fail
+      }
     },
   }
 }
+
+export default ClashPlugin

--- a/clash/src/agents/claude.rs
+++ b/clash/src/agents/claude.rs
@@ -9,7 +9,7 @@ use serde_json::Value;
 
 use super::protocol::HookProtocol;
 use super::{AgentKind, resolve_tool_name};
-use crate::hooks::{HookOutput, SessionStartHookInput, ToolUseHookInput};
+use crate::hooks::{HookOutput, SessionStartHookInput, StopHookInput, ToolUseHookInput};
 
 pub struct ClaudeProtocol;
 
@@ -28,6 +28,10 @@ impl HookProtocol for ClaudeProtocol {
     }
 
     fn parse_session_start(&self, raw: &Value) -> Result<SessionStartHookInput> {
+        Ok(serde_json::from_value(raw.clone())?)
+    }
+
+    fn parse_stop(&self, raw: &Value) -> Result<StopHookInput> {
         Ok(serde_json::from_value(raw.clone())?)
     }
 

--- a/clash/src/agents/mod.rs
+++ b/clash/src/agents/mod.rs
@@ -46,6 +46,41 @@ impl fmt::Display for AgentKind {
     }
 }
 
+impl crate::dialog::SelectItem for AgentKind {
+    fn label(&self) -> &str {
+        match self {
+            AgentKind::Claude => "Claude Code",
+            AgentKind::Gemini => "Gemini CLI",
+            AgentKind::Codex => "Codex CLI",
+            AgentKind::AmazonQ => "Amazon Q",
+            AgentKind::OpenCode => "OpenCode",
+            AgentKind::Copilot => "Copilot CLI",
+        }
+    }
+
+    fn description(&self) -> &str {
+        match self {
+            AgentKind::Claude => "Anthropic's coding agent",
+            AgentKind::Gemini => "Google's coding agent",
+            AgentKind::Codex => "OpenAI's coding agent",
+            AgentKind::AmazonQ => "Amazon's coding agent",
+            AgentKind::OpenCode => "Open-source coding agent",
+            AgentKind::Copilot => "GitHub's coding agent",
+        }
+    }
+
+    fn variants() -> &'static [Self] {
+        &[
+            AgentKind::Claude,
+            AgentKind::Gemini,
+            AgentKind::Codex,
+            AgentKind::AmazonQ,
+            AgentKind::OpenCode,
+            AgentKind::Copilot,
+        ]
+    }
+}
+
 impl FromStr for AgentKind {
     type Err = String;
 

--- a/clash/src/agents/protocol.rs
+++ b/clash/src/agents/protocol.rs
@@ -14,7 +14,7 @@ use anyhow::Result;
 use serde_json::Value;
 
 use super::AgentKind;
-use crate::hooks::{SessionStartHookInput, ToolUseHookInput};
+use crate::hooks::{SessionStartHookInput, StopHookInput, ToolUseHookInput};
 
 /// Abstraction over agent-specific hook JSON formats.
 ///
@@ -62,6 +62,18 @@ pub trait HookProtocol {
             hook_event_name: json_str_or(raw, "hook_event_name", "SessionStart").to_string(),
             source: raw.get("source").and_then(|v| v.as_str()).map(String::from),
             model: raw.get("model").and_then(|v| v.as_str()).map(String::from),
+        })
+    }
+
+    /// Parse the agent's Stop JSON.
+    ///
+    /// Default: extracts common fields (session_id, cwd).
+    fn parse_stop(&self, raw: &Value) -> Result<StopHookInput> {
+        Ok(StopHookInput {
+            session_id: json_str(raw, "session_id").to_string(),
+            transcript_path: json_str(raw, "transcript_path").to_string(),
+            cwd: json_str(raw, "cwd").to_string(),
+            hook_event_name: json_str_or(raw, "hook_event_name", "Stop").to_string(),
         })
     }
 

--- a/clash/src/cli.rs
+++ b/clash/src/cli.rs
@@ -199,9 +199,16 @@ pub enum Commands {
         /// Skip the interactive editor and create a sensible default policy
         #[arg(long)]
         quick: bool,
-        /// Which coding agent to set up (default: claude)
-        #[arg(long, default_value = "claude")]
-        agent: crate::agents::AgentKind,
+        /// Which coding agent to set up (prompts if omitted)
+        #[arg(long)]
+        agent: Option<crate::agents::AgentKind>,
+    },
+
+    /// Install the clash plugin/hooks for a coding agent (skip policy setup)
+    Install {
+        /// Which coding agent to install for (prompts if omitted)
+        #[arg(long)]
+        agent: Option<crate::agents::AgentKind>,
     },
 
     /// Remove clash: undo bypass permissions, uninstall plugin, remove config and binary

--- a/clash/src/cmd/doctor.rs
+++ b/clash/src/cmd/doctor.rs
@@ -230,7 +230,7 @@ fn run_onboard() -> Result<()> {
         );
         if offer_fix(OnboardFix::InstallPlugin)? {
             ui::progress("Installing plugin...");
-            match super::init::install_plugin() {
+            match super::init::install_plugin_from_marketplace() {
                 Ok(()) => fixed += 1,
                 Err(e) => {
                     warn!(error = %e, "Plugin install failed during onboard");

--- a/clash/src/cmd/hooks.rs
+++ b/clash/src/cmd/hooks.rs
@@ -13,6 +13,15 @@ use crate::session_policy;
 use crate::settings::{ClashSettings, HookContext};
 use crate::trace;
 
+/// Generate a fallback session ID when the agent doesn't provide one.
+///
+/// Uses the parent PID as a stable identifier — every `clash hook` invocation
+/// within the same agent session shares the same parent process.
+fn fallback_session_id(agent: AgentKind) -> String {
+    let ppid = std::os::unix::process::parent_id();
+    format!("{agent}-{ppid}")
+}
+
 use claude_settings::PermissionRule;
 
 impl HookCmd {
@@ -42,7 +51,7 @@ impl HookCmd {
         Ok(())
     }
 
-    #[instrument(level = Level::TRACE, skip(self))]
+    #[instrument(level = Level::TRACE, skip(self), fields(agent = %self.agent))]
     pub fn run(&self) -> Result<()> {
         if crate::settings::is_disabled() {
             return self.run_disabled();
@@ -207,15 +216,21 @@ impl HookCmd {
                 }
             }
             HookSubcommand::SessionStart => {
-                let input =
-                    crate::hooks::SessionStartHookInput::from_reader(std::io::stdin().lock())
-                        .context("parsing SessionStart hook input from stdin")?;
+                let mut input = self.parse_session_start_input()
+                    .context("parsing SessionStart hook input from stdin")?;
+                if input.session_id.is_empty() {
+                    input.session_id = fallback_session_id(self.agent);
+                    info!(session_id = %input.session_id, "Agent did not provide session_id, using fallback");
+                }
                 crate::handlers::handle_session_start(&input)?
             }
             HookSubcommand::Stop => {
-                // Read stdin to avoid broken pipe, extract session_id.
-                let input = crate::hooks::StopHookInput::from_reader(std::io::stdin().lock())
+                let mut input = self.parse_stop_input()
                     .context("parsing Stop hook input from stdin")?;
+                if input.session_id.is_empty() {
+                    input.session_id = fallback_session_id(self.agent);
+                    info!(session_id = %input.session_id, "Agent did not provide session_id, using fallback");
+                }
 
                 // Final catch-up sync for non-tool conversation turns.
                 if let Err(e) = trace::sync_trace(&input.session_id, None) {
@@ -242,17 +257,35 @@ impl HookCmd {
         Ok(())
     }
 
-    /// Parse tool-use input from stdin, using the agent's protocol for non-Claude agents.
+    /// Read stdin as raw JSON, then delegate to the agent's protocol.
+    fn read_stdin_json(&self) -> Result<serde_json::Value> {
+        Ok(serde_json::from_reader(std::io::stdin().lock())?)
+    }
+
+    /// Parse tool-use input from stdin via the agent's protocol.
     fn parse_tool_use_input(&self) -> Result<ToolUseHookInput> {
-        if self.agent == AgentKind::Claude {
-            let mut input = ToolUseHookInput::from_reader(std::io::stdin().lock())?;
-            input.agent = Some(AgentKind::Claude);
-            Ok(input)
-        } else {
-            let protocol = get_protocol(self.agent);
-            let raw: serde_json::Value = serde_json::from_reader(std::io::stdin().lock())?;
-            protocol.parse_tool_use(&raw)
+        let protocol = get_protocol(self.agent);
+        let raw = self.read_stdin_json()?;
+        let mut input = protocol.parse_tool_use(&raw)?;
+        if input.session_id.is_empty() {
+            input.session_id = fallback_session_id(self.agent);
+            info!(session_id = %input.session_id, "Agent did not provide session_id, using fallback");
         }
+        Ok(input)
+    }
+
+    /// Parse session-start input from stdin via the agent's protocol.
+    fn parse_session_start_input(&self) -> Result<crate::hooks::SessionStartHookInput> {
+        let protocol = get_protocol(self.agent);
+        let raw = self.read_stdin_json()?;
+        protocol.parse_session_start(&raw)
+    }
+
+    /// Parse stop input from stdin via the agent's protocol.
+    fn parse_stop_input(&self) -> Result<crate::hooks::StopHookInput> {
+        let protocol = get_protocol(self.agent);
+        let raw = self.read_stdin_json()?;
+        protocol.parse_stop(&raw)
     }
 }
 

--- a/clash/src/cmd/init.rs
+++ b/clash/src/cmd/init.rs
@@ -2,6 +2,7 @@ use anyhow::{Context, Result};
 use serde_json::json;
 use tracing::{Level, error, info, instrument, warn};
 
+use crate::agents::AgentKind;
 use crate::settings::ClashSettings;
 use crate::style;
 use crate::ui;
@@ -16,61 +17,78 @@ struct InitActions {
 /// GitHub repository used to install the clash plugin marketplace.
 const GITHUB_MARKETPLACE: &str = "empathic/clash";
 
+/// Embedded agent plugin files — compiled into the binary so `clash init --agent <name>`
+/// can install them without needing the source repo.
+const OPENCODE_PLUGIN_TS: &str = include_str!("../../../clash-opencode/plugin.ts");
+const COPILOT_HOOKS_JSON: &str = include_str!("../../../clash-copilot/.github/hooks/pre-tool-use.json");
+const CODEX_HOOKS_TOML: &str = include_str!("../../../clash-codex/hooks.toml");
+const AMAZONQ_AGENT_JSON: &str = include_str!("../../../clash-amazonq/agent.json");
+const GEMINI_EXTENSION_JSON: &str = include_str!("../../../clash-gemini-ext/gemini-extension.json");
+const GEMINI_HOOKS_JSON: &str = include_str!("../../../clash-gemini-ext/hooks/hooks.json");
+
 /// Initialize clash at the chosen scope.
 ///
-/// When `scope` is provided ("user" or "project"), initializes that scope
-/// directly. When omitted, runs the interactive policy editor.
-/// Only one scope is initialized per invocation.
-#[instrument(level = Level::TRACE)]
-pub fn run(scope: Option<String>, quick: bool, agent: crate::agents::AgentKind) -> Result<()> {
-    if agent != crate::agents::AgentKind::Claude {
-        return run_init_agent(agent, scope);
-    }
-    match scope.as_deref() {
-        Some("project") => run_init_project(),
-        _ if quick => run_init_quick(),
-        _ => run_init_user(),
-    }
-}
-
-/// Initialize or reconfigure the user-level policy via the interactive editor.
-fn run_init_user() -> Result<()> {
-    let mut actions = InitActions::default();
-
-    let policy_path = write_starter_policy()?;
-    crate::tui::run_with_options(&policy_path, false, true)?;
-    actions.policy_created = true;
-
-    // Always ensure settings.json records clash as an enabled plugin.
-    let claude = claude_settings::ClaudeSettings::new();
-    if let Err(e) = claude.set_plugin_enabled(claude_settings::SettingsLevel::User, "clash", true) {
-        warn!(error = %e, "Could not set enabledPlugins in Claude Code settings");
-    }
-
-    // Install the Claude Code plugin from GitHub.
-    match install_plugin() {
-        Ok(()) => {
-            actions.plugin_installed = true;
-        }
-        Err(e) => {
-            error!(error = %e, "Could not install clash plugin");
-            ui::warn(&format!(
-                "Could not install the clash plugin: {e}\n  \
-                 You can install it manually later:\n    \
-                 claude plugin marketplace add {GITHUB_MARKETPLACE}\n    \
-                 claude plugin install clash"
-            ));
-        }
+/// All agents share the same onboarding flow: agent selection (if not
+/// specified), policy setup (interactive, quick, or project), then
+/// agent-specific plugin installation.
+/// Install just the agent plugin/hooks, skipping policy setup.
+pub fn run_install(agent: Option<AgentKind>) -> Result<()> {
+    let agent = match agent {
+        Some(a) => a,
+        None => *crate::dialog::select::<AgentKind>("Which coding agent are you installing for?")?,
     };
 
-    // Install the status line so the user gets ambient policy visibility.
-    if let Err(e) = super::statusline::install() {
-        warn!(error = %e, "Could not install status line");
-    } else {
-        actions.statusline_installed = true;
+    let installed = install_agent_plugin(agent)?;
+    if installed {
+        println!();
+        println!(
+            "  Run: {}",
+            style::bold(&format!("clash doctor --agent {agent}"))
+        );
+        println!("  to verify the setup is correct.");
+    }
+    Ok(())
+}
+
+#[instrument(level = Level::TRACE)]
+pub fn run(scope: Option<String>, quick: bool, agent: Option<AgentKind>) -> Result<()> {
+    let agent = match agent {
+        Some(a) => a,
+        None => *crate::dialog::select::<AgentKind>("Which coding agent are you using?")?,
+    };
+
+    let mut actions = InitActions::default();
+
+    // 1. Policy setup — same for all agents.
+    match scope.as_deref() {
+        Some("project") => {
+            run_init_project()?;
+            actions.policy_created = true;
+        }
+        _ if quick => {
+            run_init_quick()?;
+            actions.policy_created = true;
+        }
+        _ => {
+            let policy_path = write_starter_policy()?;
+            crate::tui::run_with_options(&policy_path, false, true)?;
+            actions.policy_created = true;
+        }
     }
 
-    print_user_summary(&actions);
+    // 2. Agent-specific plugin installation.
+    actions.plugin_installed = install_agent_plugin(agent)?;
+
+    // 3. Claude-specific extras: status line.
+    if agent == AgentKind::Claude {
+        if let Err(e) = super::statusline::install() {
+            warn!(error = %e, "Could not install status line");
+        } else {
+            actions.statusline_installed = true;
+        }
+    }
+
+    print_summary(&actions, agent);
 
     Ok(())
 }
@@ -122,28 +140,6 @@ fn run_init_quick() -> Result<()> {
         policy_path.display()
     ));
 
-    // Ensure settings.json records clash as an enabled plugin.
-    let claude = claude_settings::ClaudeSettings::new();
-    if let Err(e) = claude.set_plugin_enabled(claude_settings::SettingsLevel::User, "clash", true) {
-        warn!(error = %e, "Could not set enabledPlugins in Claude Code settings");
-    }
-
-    // Install the Claude Code plugin from GitHub.
-    if let Err(e) = install_plugin() {
-        error!(error = %e, "Could not install clash plugin");
-        ui::warn(&format!(
-            "Could not install the clash plugin: {e}\n  \
-             You can install it manually later:\n    \
-             claude plugin marketplace add {GITHUB_MARKETPLACE}\n    \
-             claude plugin install clash"
-        ));
-    }
-
-    // Install the status line so the user gets ambient policy visibility.
-    if let Err(e) = super::statusline::install() {
-        warn!(error = %e, "Could not install status line");
-    }
-
     Ok(())
 }
 
@@ -174,26 +170,6 @@ fn run_init_project() -> Result<()> {
         "Project policy initialized at {}",
         policy_path.display()
     ));
-
-    println!();
-    println!("{}", style::bold("Setup complete!"));
-    println!();
-    ui::success(&format!(
-        "Project policy created at {}",
-        policy_path.display()
-    ));
-    println!();
-    println!("{}:", style::bold("Next steps"));
-    println!(
-        "  {}  {}",
-        style::dim("clash policy show"),
-        style::dim("# view the compiled policy")
-    );
-    println!(
-        "  {}  {}",
-        style::dim("clash policy validate"),
-        style::dim("# check for errors")
-    );
 
     Ok(())
 }
@@ -281,7 +257,193 @@ pub fn write_starter_policy() -> Result<std::path::PathBuf> {
     Ok(policy_path)
 }
 
-fn print_user_summary(actions: &InitActions) {
+// ---------------------------------------------------------------------------
+// Agent plugin installation
+// ---------------------------------------------------------------------------
+
+/// Install the agent-specific plugin/hooks. Returns true if installation succeeded.
+fn install_agent_plugin(agent: AgentKind) -> Result<bool> {
+    println!();
+    style::header(&format!("Installing {agent} plugin"));
+    println!();
+
+    match agent {
+        AgentKind::Claude => install_claude_plugin(),
+        AgentKind::Gemini => install_gemini_plugin(),
+        AgentKind::Codex => install_codex_plugin(),
+        AgentKind::AmazonQ => install_amazonq_plugin(),
+        AgentKind::OpenCode => install_opencode_plugin(),
+        AgentKind::Copilot => install_copilot_plugin(),
+    }
+}
+
+fn install_claude_plugin() -> Result<bool> {
+    // Ensure settings.json records clash as an enabled plugin.
+    let claude = claude_settings::ClaudeSettings::new();
+    if let Err(e) = claude.set_plugin_enabled(claude_settings::SettingsLevel::User, "clash", true) {
+        warn!(error = %e, "Could not set enabledPlugins in Claude Code settings");
+    }
+
+    match install_plugin_from_marketplace() {
+        Ok(()) => Ok(true),
+        Err(e) => {
+            error!(error = %e, "Could not install clash plugin");
+            ui::warn(&format!(
+                "Could not install the clash plugin: {e}\n  \
+                 You can install it manually later:\n    \
+                 claude plugin marketplace add {GITHUB_MARKETPLACE}\n    \
+                 claude plugin install clash"
+            ));
+            Ok(false)
+        }
+    }
+}
+
+fn install_gemini_plugin() -> Result<bool> {
+    let ext_dir = std::env::temp_dir().join("clash-gemini-ext");
+    let hooks_dir = ext_dir.join("hooks");
+    std::fs::create_dir_all(&hooks_dir)
+        .context("failed to create hooks directory in temp extension")?;
+    std::fs::write(ext_dir.join("gemini-extension.json"), GEMINI_EXTENSION_JSON)
+        .context("failed to write gemini-extension.json")?;
+    std::fs::write(hooks_dir.join("hooks.json"), GEMINI_HOOKS_JSON)
+        .context("failed to write hooks/hooks.json")?;
+
+    let output = std::process::Command::new("gemini")
+        .args(["extensions", "install", &ext_dir.display().to_string()])
+        .output();
+
+    match output {
+        Ok(o) if o.status.success() => {
+            ui::success("Clash extension installed in Gemini CLI");
+            Ok(true)
+        }
+        Ok(o) => {
+            let stderr = String::from_utf8_lossy(&o.stderr);
+            ui::warn(&format!(
+                "Could not install Gemini extension: {stderr}\n  \
+                 You can install it manually later:\n    \
+                 gemini extensions install <path-to-extension-dir>"
+            ));
+            Ok(false)
+        }
+        Err(e) => {
+            ui::warn(&format!(
+                "Could not run gemini CLI: {e}\n  \
+                 Install the Gemini CLI, then run:\n    \
+                 clash init --agent gemini"
+            ));
+            Ok(false)
+        }
+    }
+}
+
+fn install_codex_plugin() -> Result<bool> {
+    let codex_dir = dirs::home_dir()
+        .context("could not determine home directory")?
+        .join(".codex");
+    std::fs::create_dir_all(&codex_dir)
+        .with_context(|| format!("failed to create {}", codex_dir.display()))?;
+    let dest = codex_dir.join("config.toml");
+    let clash_hooks: toml::Value = toml::from_str(CODEX_HOOKS_TOML)
+        .context("failed to parse embedded Codex hooks TOML")?;
+    if dest.exists() {
+        let existing = std::fs::read_to_string(&dest)
+            .with_context(|| format!("failed to read {}", dest.display()))?;
+        let mut config: toml::Value = toml::from_str(&existing)
+            .with_context(|| format!("failed to parse {}", dest.display()))?;
+        // Merge clash hooks into the existing [hooks] table.
+        let hooks_table = config
+            .as_table_mut()
+            .context("codex config is not a TOML table")?
+            .entry("hooks")
+            .or_insert_with(|| toml::Value::Table(toml::Table::new()));
+        if let (Some(dst), Some(src)) =
+            (hooks_table.as_table_mut(), clash_hooks.get("hooks").and_then(|h| h.as_table()))
+        {
+            for (key, value) in src {
+                dst.insert(key.clone(), value.clone());
+            }
+        }
+        std::fs::write(&dest, toml::to_string_pretty(&config)?)
+            .with_context(|| format!("failed to write {}", dest.display()))?;
+        ui::success(&format!("Clash hooks merged into {}", dest.display()));
+    } else {
+        std::fs::write(&dest, CODEX_HOOKS_TOML)
+            .with_context(|| format!("failed to write {}", dest.display()))?;
+        ui::success(&format!("Hooks config installed at {}", dest.display()));
+    }
+    Ok(true)
+}
+
+fn install_amazonq_plugin() -> Result<bool> {
+    let amazonq_dir = dirs::home_dir()
+        .context("could not determine home directory")?
+        .join(".amazonq");
+    std::fs::create_dir_all(&amazonq_dir)
+        .with_context(|| format!("failed to create {}", amazonq_dir.display()))?;
+    let dest = amazonq_dir.join("agent.json");
+    let clash_hooks: serde_json::Value = serde_json::from_str(AMAZONQ_AGENT_JSON)
+        .context("failed to parse embedded Amazon Q hooks JSON")?;
+    if dest.exists() {
+        let existing = std::fs::read_to_string(&dest)
+            .with_context(|| format!("failed to read {}", dest.display()))?;
+        let mut config: serde_json::Value = serde_json::from_str(&existing)
+            .with_context(|| format!("failed to parse {}", dest.display()))?;
+        // Merge clash hook arrays into the existing "hooks" object.
+        let dst_hooks = config
+            .as_object_mut()
+            .context("amazonq config is not a JSON object")?
+            .entry("hooks")
+            .or_insert_with(|| json!({}));
+        if let (Some(dst), Some(src)) =
+            (dst_hooks.as_object_mut(), clash_hooks.get("hooks").and_then(|h| h.as_object()))
+        {
+            for (key, value) in src {
+                dst.insert(key.clone(), value.clone());
+            }
+        }
+        std::fs::write(&dest, serde_json::to_string_pretty(&config)?)
+            .with_context(|| format!("failed to write {}", dest.display()))?;
+        ui::success(&format!("Clash hooks merged into {}", dest.display()));
+    } else {
+        std::fs::write(&dest, AMAZONQ_AGENT_JSON)
+            .with_context(|| format!("failed to write {}", dest.display()))?;
+        ui::success(&format!("Hooks config installed at {}", dest.display()));
+    }
+    Ok(true)
+}
+
+fn install_opencode_plugin() -> Result<bool> {
+    let plugins_dir = dirs::home_dir()
+        .context("could not determine home directory")?
+        .join(".opencode")
+        .join("plugins");
+    std::fs::create_dir_all(&plugins_dir)
+        .context("failed to create ~/.opencode/plugins directory")?;
+    let dest = plugins_dir.join("clash.ts");
+    std::fs::write(&dest, OPENCODE_PLUGIN_TS)
+        .with_context(|| format!("failed to write {}", dest.display()))?;
+    ui::success(&format!("Plugin installed at {}", dest.display()));
+    Ok(true)
+}
+
+fn install_copilot_plugin() -> Result<bool> {
+    let hooks_dir = std::path::Path::new(".github/hooks");
+    std::fs::create_dir_all(hooks_dir)
+        .context("failed to create .github/hooks directory")?;
+    let dest = hooks_dir.join("pre-tool-use.json");
+    std::fs::write(&dest, COPILOT_HOOKS_JSON)
+        .with_context(|| format!("failed to write {}", dest.display()))?;
+    ui::success(&format!("Hooks installed at {}", dest.display()));
+    Ok(true)
+}
+
+// ---------------------------------------------------------------------------
+// Summary
+// ---------------------------------------------------------------------------
+
+fn print_summary(actions: &InitActions, agent: AgentKind) {
     let any_action =
         actions.policy_created || actions.plugin_installed || actions.statusline_installed;
     if !any_action {
@@ -299,7 +461,7 @@ fn print_user_summary(actions: &InitActions) {
         ui::success("Policy created");
     }
     if actions.plugin_installed {
-        ui::success("Clash plugin installed in Claude Code");
+        ui::success(&format!("Clash plugin installed for {agent}"));
     }
     if actions.statusline_installed {
         ui::success("Status line installed");
@@ -324,114 +486,22 @@ fn print_user_summary(actions: &InitActions) {
     println!("{}:", style::bold("Next steps"));
     println!(
         "  {}  {}",
-        style::dim("claude"),
-        style::dim("# start a session with clash active")
+        style::dim(&format!("clash doctor --agent {agent}")),
+        style::dim("# verify the setup is correct")
     );
     println!(
         "  {}  {}",
-        style::dim("/clash:status"),
-        style::dim("# check policy status inside a session")
-    );
-    println!(
-        "  {}  {}",
-        style::dim("/clash:edit"),
-        style::dim("# interactively edit your policy")
+        style::dim("clash policy show"),
+        style::dim("# view the compiled policy")
     );
 }
 
-/// Initialize clash for a non-Claude agent.
-///
-/// Creates the policy (same policy file — portable across agents) and prints
-/// agent-specific setup instructions.
-fn run_init_agent(agent: crate::agents::AgentKind, scope: Option<String>) -> Result<()> {
-    use crate::agents::AgentKind;
-
-    // Write the policy (same as Claude — policies are agent-agnostic).
-    let settings_dir = if scope.as_deref() == Some("project") {
-        let root = ClashSettings::project_root()
-            .context("could not find project root — are you inside a git repository?")?;
-        let dir = root.join(".clash");
-        std::fs::create_dir_all(&dir)?;
-        dir
-    } else {
-        let dir = ClashSettings::settings_dir()
-            .context("could not determine clash settings directory")?;
-        std::fs::create_dir_all(&dir)?;
-        dir
-    };
-
-    let policy_path = settings_dir.join("policy.star");
-    if !policy_path.exists() {
-        write_starter_policy()?;
-        ui::success(&format!("Policy created at {}", policy_path.display()));
-    } else {
-        ui::info(&format!(
-            "Policy already exists at {}",
-            policy_path.display()
-        ));
-    }
-
-    // Print agent-specific setup instructions.
-    println!();
-    style::header(&format!("Setup instructions for {agent}"));
-    println!();
-
-    match agent {
-        AgentKind::Gemini => {
-            println!("  Install the Clash extension for Gemini CLI:");
-            println!(
-                "    {}",
-                style::bold("gemini extensions install <path-to-clash-gemini-ext>")
-            );
-            println!();
-            println!("  Or copy hooks manually to ~/.gemini/settings.json.");
-        }
-        AgentKind::Codex => {
-            println!("  Add the following to your ~/.codex/config.toml:");
-            println!();
-            println!("    {}", style::dim("[hooks.pre_tool_use]"));
-            println!(
-                "    {}",
-                style::dim("command = \"clash hook --agent codex pre-tool-use\"")
-            );
-            println!("    {}", style::dim("timeout_seconds = 10"));
-            println!("    {}", style::dim("pattern = \"*\""));
-            println!();
-            println!("  See clash-codex/hooks.toml for the full configuration.");
-        }
-        AgentKind::AmazonQ => {
-            println!("  Add Clash hooks to your Amazon Q agent configuration.");
-            println!("  See clash-amazonq/agent.json for the hook definitions.");
-        }
-        AgentKind::OpenCode => {
-            println!("  Copy the Clash plugin to your OpenCode plugins directory:");
-            println!(
-                "    {}",
-                style::bold("cp clash-opencode/plugin.ts .opencode/plugins/clash.ts")
-            );
-        }
-        AgentKind::Copilot => {
-            println!("  Copy the hooks configuration to your repository:");
-            println!(
-                "    {}",
-                style::bold("cp -r clash-copilot/.github/hooks .github/hooks")
-            );
-        }
-        AgentKind::Claude => unreachable!(),
-    }
-
-    println!();
-    println!(
-        "  Then run: {}",
-        style::bold(&format!("clash doctor --agent {agent}"))
-    );
-    println!("  to verify the setup is correct.");
-
-    Ok(())
-}
+// ---------------------------------------------------------------------------
+// Claude marketplace helpers
+// ---------------------------------------------------------------------------
 
 /// Install the clash plugin into Claude Code from the GitHub marketplace.
-pub fn install_plugin() -> Result<()> {
+pub fn install_plugin_from_marketplace() -> Result<()> {
     ui::progress(&format!(
         "Installing clash plugin from {}...",
         GITHUB_MARKETPLACE,

--- a/clash/src/hooks.rs
+++ b/clash/src/hooks.rs
@@ -45,11 +45,15 @@ pub struct ToolUseHookInput {
 /// Hook input for SessionStart events
 #[derive(Debug, Clone, Deserialize, Default)]
 pub struct SessionStartHookInput {
+    #[serde(default)]
     pub session_id: String,
+    #[serde(default)]
     pub transcript_path: String,
+    #[serde(default)]
     pub cwd: String,
     #[serde(default)]
     pub permission_mode: Option<String>,
+    #[serde(default)]
     pub hook_event_name: String,
     #[serde(default)]
     pub source: Option<String>,
@@ -68,9 +72,13 @@ impl SessionStartHookInput {
 /// Hook input for Stop events (conversation turn ended without a tool call)
 #[derive(Debug, Clone, Deserialize, Default)]
 pub struct StopHookInput {
+    #[serde(default)]
     pub session_id: String,
+    #[serde(default)]
     pub transcript_path: String,
+    #[serde(default)]
     pub cwd: String,
+    #[serde(default)]
     pub hook_event_name: String,
 }
 

--- a/clash/src/main.rs
+++ b/clash/src/main.rs
@@ -26,6 +26,7 @@ fn main() -> Result<()> {
                     cmd::init::run(scope, quick, agent)
                 }
             }
+            Commands::Install { agent } => cmd::init::run_install(agent),
             Commands::Uninstall { yes } => cmd::uninstall::run(yes),
             Commands::Status { json } => cmd::status::run(json, cli.verbose),
             Commands::ShowCommands { json, all } => cmd::commands::run(json, all),


### PR DESCRIPTION
## Summary
- **Fix OpenCode plugin**: use flat hook keys (`tool.execute.before`) matching the actual OpenCode plugin API — this was why hooks never fired
- **Unify onboarding**: all agents now share the same init flow (interactive TUI / `--quick` / `--scope project`) instead of a stripped-down path for non-Claude agents
- **Add `clash install` command**: install agent plugins without re-running policy setup
- **Add agent selection dialog**: `clash init` without `--agent` prompts for selection
- **Route all hook events through protocol layer**: SessionStart and Stop now go through agent protocol parsing, same as tool-use hooks
- **Resilience fixes**: fallback session ID when agents don't provide one, `#[serde(default)]` on hook input fields, agent name in all log spans

## Test plan
- [ ] `clash init` shows agent selection dialog
- [ ] `clash init --agent opencode` runs full onboarding with TUI editor
- [ ] `clash install --agent opencode` installs plugin without policy setup
- [ ] OpenCode sessions appear in `clash session list` and `clash debug log`
- [ ] `cargo test -p clash` passes