### PR TITLE
fix(tui): redraw on terminal resize events

### DIFF
--- a/clash/src/tui/app.rs
+++ b/clash/src/tui/app.rs
@@ -177,6 +177,9 @@ impl App {
             terminal.draw(|frame| self.view(frame, frame.area(), &manifest_snapshot))?;
 
             let event = event::read()?;
+            if matches!(event, Event::Resize(_, _)) {
+                continue; // redraw with new dimensions
+            }
             if let Event::Key(key) = event {
                 // Walkthrough mode intercepts keys to advance steps.
                 if matches!(self.mode, Mode::Walkthrough) {


### PR DESCRIPTION
Previously resize events were silently ignored since the event loop only matched Key events, leaving the UI stale until the next keypress.