### PR TITLE
feat(tui): unify modal chrome, add scrollbar + viewport-aware scroll clamping

### DIFF
--- a/clash/src/cmd/hooks.rs
+++ b/clash/src/cmd/hooks.rs
@@ -216,7 +216,8 @@ impl HookCmd {
                 }
             }
             HookSubcommand::SessionStart => {
-                let mut input = self.parse_session_start_input()
+                let mut input = self
+                    .parse_session_start_input()
                     .context("parsing SessionStart hook input from stdin")?;
                 if input.session_id.is_empty() {
                     input.session_id = fallback_session_id(self.agent);
@@ -225,7 +226,8 @@ impl HookCmd {
                 crate::handlers::handle_session_start(&input)?
             }
             HookSubcommand::Stop => {
-                let mut input = self.parse_stop_input()
+                let mut input = self
+                    .parse_stop_input()
                     .context("parsing Stop hook input from stdin")?;
                 if input.session_id.is_empty() {
                     input.session_id = fallback_session_id(self.agent);

--- a/clash/src/cmd/init.rs
+++ b/clash/src/cmd/init.rs
@@ -20,7 +20,8 @@ const GITHUB_MARKETPLACE: &str = "empathic/clash";
 /// Embedded agent plugin files — compiled into the binary so `clash init --agent <name>`
 /// can install them without needing the source repo.
 const OPENCODE_PLUGIN_TS: &str = include_str!("../../clash-opencode/plugin.ts");
-const COPILOT_HOOKS_JSON: &str = include_str!("../../clash-copilot/.github/hooks/pre-tool-use.json");
+const COPILOT_HOOKS_JSON: &str =
+    include_str!("../../clash-copilot/.github/hooks/pre-tool-use.json");
 const CODEX_HOOKS_TOML: &str = include_str!("../../clash-codex/hooks.toml");
 const AMAZONQ_AGENT_JSON: &str = include_str!("../../clash-amazonq/agent.json");
 const GEMINI_EXTENSION_JSON: &str = include_str!("../../clash-gemini-ext/gemini-extension.json");
@@ -345,8 +346,8 @@ fn install_codex_plugin() -> Result<bool> {
     std::fs::create_dir_all(&codex_dir)
         .with_context(|| format!("failed to create {}", codex_dir.display()))?;
     let dest = codex_dir.join("config.toml");
-    let clash_hooks: toml::Value = toml::from_str(CODEX_HOOKS_TOML)
-        .context("failed to parse embedded Codex hooks TOML")?;
+    let clash_hooks: toml::Value =
+        toml::from_str(CODEX_HOOKS_TOML).context("failed to parse embedded Codex hooks TOML")?;
     if dest.exists() {
         let existing = std::fs::read_to_string(&dest)
             .with_context(|| format!("failed to read {}", dest.display()))?;
@@ -358,9 +359,10 @@ fn install_codex_plugin() -> Result<bool> {
             .context("codex config is not a TOML table")?
             .entry("hooks")
             .or_insert_with(|| toml::Value::Table(toml::Table::new()));
-        if let (Some(dst), Some(src)) =
-            (hooks_table.as_table_mut(), clash_hooks.get("hooks").and_then(|h| h.as_table()))
-        {
+        if let (Some(dst), Some(src)) = (
+            hooks_table.as_table_mut(),
+            clash_hooks.get("hooks").and_then(|h| h.as_table()),
+        ) {
             for (key, value) in src {
                 dst.insert(key.clone(), value.clone());
             }
@@ -396,9 +398,10 @@ fn install_amazonq_plugin() -> Result<bool> {
             .context("amazonq config is not a JSON object")?
             .entry("hooks")
             .or_insert_with(|| json!({}));
-        if let (Some(dst), Some(src)) =
-            (dst_hooks.as_object_mut(), clash_hooks.get("hooks").and_then(|h| h.as_object()))
-        {
+        if let (Some(dst), Some(src)) = (
+            dst_hooks.as_object_mut(),
+            clash_hooks.get("hooks").and_then(|h| h.as_object()),
+        ) {
             for (key, value) in src {
                 dst.insert(key.clone(), value.clone());
             }
@@ -430,8 +433,7 @@ fn install_opencode_plugin() -> Result<bool> {
 
 fn install_copilot_plugin() -> Result<bool> {
     let hooks_dir = std::path::Path::new(".github/hooks");
-    std::fs::create_dir_all(hooks_dir)
-        .context("failed to create .github/hooks directory")?;
+    std::fs::create_dir_all(hooks_dir).context("failed to create .github/hooks directory")?;
     let dest = hooks_dir.join("pre-tool-use.json");
     std::fs::write(&dest, COPILOT_HOOKS_JSON)
         .with_context(|| format!("failed to write {}", dest.display()))?;

--- a/clash/src/tui/app.rs
+++ b/clash/src/tui/app.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 use std::time::Instant;
 
 use anyhow::Result;
-use crossterm::event::{self, Event, KeyCode, KeyEvent, KeyModifiers};
+use crossterm::event::{self, Event, KeyCode, KeyEvent, KeyModifiers, MouseEventKind};
 use ratatui::Frame;
 use ratatui::Terminal;
 use ratatui::backend::Backend;
@@ -25,7 +25,7 @@ use super::tea::{Action, Component};
 use super::test_panel::{self, TestPanel, TestPanelAction};
 use super::tree_view::TreeView;
 use super::walkthrough::{self, WalkthroughState, WalkthroughStep};
-use super::widgets::{self, DiffLine};
+use super::widgets::{self, DiffLine, ScrollState};
 
 /// Which tab is active.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -39,7 +39,7 @@ pub enum Tab {
 /// Overlay mode the app can be in.
 enum Mode {
     Normal,
-    Help,
+    Help(ScrollState),
     Confirm(ConfirmAction),
     SaveReview(DiffState),
     Form(FormState),
@@ -54,7 +54,7 @@ enum ConfirmAction {
 /// State for the diff review overlay.
 struct DiffState {
     lines: Vec<DiffLine>,
-    scroll: usize,
+    scroll: ScrollState,
 }
 
 /// Messages for the App component.
@@ -71,6 +71,8 @@ pub enum Msg {
     ConfirmNo,
     DiffScrollDown,
     DiffScrollUp,
+    HelpScrollDown,
+    HelpScrollUp,
     TreeMsg(<TreeView as Component>::Msg),
     SandboxMsg(<SandboxView as Component>::Msg),
     IncludesMsg(<IncludesView as Component>::Msg),
@@ -180,6 +182,43 @@ impl App {
             if matches!(event, Event::Resize(_, _)) {
                 continue; // redraw with new dimensions
             }
+            // Mouse events: handle scroll in overlay modes, skip everything else
+            // to avoid busy-redraw loops from MouseEventKind::Moved.
+            if let Event::Mouse(mouse) = &event {
+                match mouse.kind {
+                    MouseEventKind::ScrollDown | MouseEventKind::ScrollUp => {
+                        let down = matches!(mouse.kind, MouseEventKind::ScrollDown);
+                        match &mut self.mode {
+                            Mode::Help(scroll) => {
+                                if down {
+                                    scroll.scroll_down();
+                                } else {
+                                    scroll.scroll_up();
+                                }
+                            }
+                            Mode::SaveReview(state) => {
+                                if down {
+                                    state.scroll.scroll_down();
+                                } else {
+                                    state.scroll.scroll_up();
+                                }
+                            }
+                            Mode::Walkthrough => {
+                                if let Some(wt) = &mut self.walkthrough {
+                                    if down {
+                                        wt.scroll.scroll_down();
+                                    } else {
+                                        wt.scroll.scroll_up();
+                                    }
+                                }
+                            }
+                            _ => {}
+                        }
+                    }
+                    _ => {}
+                }
+                continue;
+            }
             if let Event::Key(key) = event {
                 // Walkthrough mode intercepts keys to advance steps.
                 if matches!(self.mode, Mode::Walkthrough) {
@@ -192,6 +231,13 @@ impl App {
                                     "Walkthrough skipped — press ? for help".into(),
                                     Instant::now(),
                                 ));
+                            }
+                            // j/k/arrows scroll the walkthrough overlay
+                            KeyCode::Char('j') | KeyCode::Down => {
+                                wt.scroll.scroll_down();
+                            }
+                            KeyCode::Char('k') | KeyCode::Up => {
+                                wt.scroll.scroll_up();
                             }
                             _ => match wt.step {
                                 WalkthroughStep::Welcome | WalkthroughStep::BaseTools => {
@@ -222,9 +268,10 @@ impl App {
                                             .unwrap_or_default();
                                         let diff_lines =
                                             compute_diff(&self.original_json, &new_json);
+                                        let len = diff_lines.len();
                                         self.mode = Mode::SaveReview(DiffState {
                                             lines: diff_lines,
-                                            scroll: 0,
+                                            scroll: ScrollState::new(len),
                                         });
                                     } else {
                                         self.walkthrough = None;
@@ -413,7 +460,13 @@ impl App {
     fn handle_key(&self, key: KeyEvent) -> Option<Msg> {
         // Mode-specific key handling
         match &self.mode {
-            Mode::Help => return Some(Msg::ToggleHelp), // any key closes help
+            Mode::Help(_) => {
+                return match key.code {
+                    KeyCode::Char('j') | KeyCode::Down => Some(Msg::HelpScrollDown),
+                    KeyCode::Char('k') | KeyCode::Up => Some(Msg::HelpScrollUp),
+                    _ => Some(Msg::ToggleHelp),
+                };
+            }
             Mode::Confirm(_) => {
                 return match key.code {
                     KeyCode::Char('y') | KeyCode::Char('Y') => Some(Msg::ConfirmYes),
@@ -492,9 +545,10 @@ impl App {
                 }
                 let new_json = serde_json::to_string_pretty(&self.manifest).unwrap_or_default();
                 let diff_lines = compute_diff(&self.original_json, &new_json);
+                let len = diff_lines.len();
                 self.mode = Mode::SaveReview(DiffState {
                     lines: diff_lines,
-                    scroll: 0,
+                    scroll: ScrollState::new(len),
                 });
                 Action::None
             }
@@ -508,9 +562,21 @@ impl App {
             }
             Msg::ToggleHelp => {
                 self.mode = match self.mode {
-                    Mode::Help => Mode::Normal,
-                    _ => Mode::Help,
+                    Mode::Help(_) => Mode::Normal,
+                    _ => Mode::Help(ScrollState::new(widgets::help_content().len())),
                 };
+                Action::None
+            }
+            Msg::HelpScrollDown => {
+                if let Mode::Help(scroll) = &mut self.mode {
+                    scroll.scroll_down();
+                }
+                Action::None
+            }
+            Msg::HelpScrollUp => {
+                if let Mode::Help(scroll) = &mut self.mode {
+                    scroll.scroll_up();
+                }
                 Action::None
             }
             Msg::ConfirmYes => {
@@ -564,16 +630,14 @@ impl App {
                 Action::None
             }
             Msg::DiffScrollDown => {
-                if let Mode::SaveReview(ref mut state) = self.mode
-                    && state.scroll + 1 < state.lines.len()
-                {
-                    state.scroll += 1;
+                if let Mode::SaveReview(state) = &mut self.mode {
+                    state.scroll.scroll_down();
                 }
                 Action::None
             }
             Msg::DiffScrollUp => {
-                if let Mode::SaveReview(ref mut state) = self.mode {
-                    state.scroll = state.scroll.saturating_sub(1);
+                if let Mode::SaveReview(state) = &mut self.mode {
+                    state.scroll.scroll_up();
                 }
                 Action::None
             }
@@ -636,7 +700,7 @@ impl App {
         }
     }
 
-    fn view(&self, frame: &mut Frame, area: Rect, manifest: &PolicyManifest) {
+    fn view(&mut self, frame: &mut Frame, area: Rect, manifest: &PolicyManifest) {
         let chunks = Layout::vertical([
             Constraint::Length(2), // title + tab bar
             Constraint::Min(3),    // content
@@ -756,20 +820,20 @@ impl App {
         widgets::render_status_bar(frame, chunks[2], hints, flash_msg);
 
         // Overlays
-        match &self.mode {
-            Mode::Help => widgets::render_help_overlay(frame, area),
+        match &mut self.mode {
+            Mode::Help(scroll) => widgets::render_help_overlay(frame, area, scroll),
             Mode::Confirm(ConfirmAction::Quit) => {
                 widgets::render_confirm_overlay(frame, area, "Unsaved changes. Quit anyway?");
             }
             Mode::SaveReview(state) => {
-                widgets::render_diff_overlay(frame, area, &state.lines, state.scroll);
+                widgets::render_diff_overlay(frame, area, &state.lines, &mut state.scroll);
             }
             Mode::Form(form) => {
                 form.view(frame, area);
             }
             Mode::Walkthrough => {
-                if let Some(ref wt) = self.walkthrough {
-                    walkthrough::render_walkthrough_overlay(frame, area, wt.step);
+                if let Some(wt) = &mut self.walkthrough {
+                    walkthrough::render_walkthrough_overlay(frame, area, wt.step, &mut wt.scroll);
                 }
             }
             Mode::Normal => {}

--- a/clash/src/tui/inline_form.rs
+++ b/clash/src/tui/inline_form.rs
@@ -6,10 +6,12 @@
 
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use ratatui::Frame;
-use ratatui::layout::{Constraint, Layout, Rect};
+use ratatui::layout::Rect;
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
-use ratatui::widgets::{Block, Borders, Clear, Paragraph};
+use ratatui::widgets::Paragraph;
+
+use super::widgets::{ModalHeight, ModalOverlay};
 
 use crate::policy::manifest_edit;
 use crate::policy::match_tree::{
@@ -2040,21 +2042,26 @@ impl FormState {
             FormKind::AddChild { .. } => self.fields.len().max(5),
             _ => self.visible.len(),
         };
-        let height = (field_count as u16 * 3) + 6; // fields + hint + spacing + title + footer
-        let height_pct = ((height as f32 / area.height as f32) * 100.0)
-            .ceil()
-            .clamp(30.0, 80.0) as u16;
+        let content_lines = (field_count as u16 * 3) + 6; // fields + hint + spacing + title + footer
 
-        let popup = centered_rect(60, height_pct, area);
-        frame.render_widget(Clear, popup);
-
-        let block = Block::default()
-            .borders(Borders::ALL)
-            .border_style(Style::default().fg(Color::Cyan))
-            .title(format!(" {} ", self.title));
-
-        let inner = block.inner(popup);
-        frame.render_widget(block, popup);
+        let modal = ModalOverlay {
+            width_pct: 60,
+            height: ModalHeight::FitContent {
+                lines: content_lines,
+                floor_pct: 30,
+                ceil_pct: 80,
+            },
+            border_color: Color::Cyan,
+            title: &self.title,
+            footer: &[
+                ("Enter", "submit"),
+                ("Tab", "next field"),
+                ("Esc", "cancel"),
+            ],
+            footer_right: None,
+            scroll: None,
+        };
+        let inner = modal.render_chrome(frame, area);
 
         let mut lines: Vec<Line> = Vec::new();
         lines.push(Line::from(""));
@@ -2251,35 +2258,9 @@ impl FormState {
             lines.push(Line::from(""));
         }
 
-        // Footer
-        lines.push(Line::from(vec![
-            Span::styled("  Enter", Style::default().fg(Color::Yellow)),
-            Span::styled(" submit  ", Style::default().fg(Color::Gray)),
-            Span::styled("Tab", Style::default().fg(Color::Yellow)),
-            Span::styled(" next field  ", Style::default().fg(Color::Gray)),
-            Span::styled("Esc", Style::default().fg(Color::Yellow)),
-            Span::styled(" cancel", Style::default().fg(Color::Gray)),
-        ]));
-
         let para = Paragraph::new(lines);
-        frame.render_widget(para, inner);
+        frame.render_widget(para, inner.area);
     }
-}
-
-fn centered_rect(percent_x: u16, percent_y: u16, area: Rect) -> Rect {
-    let vertical = Layout::vertical([
-        Constraint::Percentage((100 - percent_y) / 2),
-        Constraint::Percentage(percent_y),
-        Constraint::Percentage((100 - percent_y) / 2),
-    ])
-    .split(area);
-
-    Layout::horizontal([
-        Constraint::Percentage((100 - percent_x) / 2),
-        Constraint::Percentage(percent_x),
-        Constraint::Percentage((100 - percent_x) / 2),
-    ])
-    .split(vertical[1])[1]
 }
 
 // ---------------------------------------------------------------------------

--- a/clash/src/tui/walkthrough.rs
+++ b/clash/src/tui/walkthrough.rs
@@ -8,9 +8,9 @@ use ratatui::Frame;
 use ratatui::layout::{Alignment, Rect};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
-use ratatui::widgets::{Block, Borders, Clear, Paragraph};
+use ratatui::widgets::Paragraph;
 
-use super::widgets::centered_rect;
+use super::widgets::{ModalHeight, ModalOverlay, ScrollState};
 
 /// Sequential steps of the onboarding walkthrough.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -51,12 +51,14 @@ impl WalkthroughStep {
 #[derive(Debug, Clone)]
 pub struct WalkthroughState {
     pub step: WalkthroughStep,
+    pub scroll: ScrollState,
 }
 
 impl Default for WalkthroughState {
     fn default() -> Self {
         Self {
             step: WalkthroughStep::Welcome,
+            scroll: ScrollState::new(0),
         }
     }
 }
@@ -68,6 +70,7 @@ impl WalkthroughState {
 
     pub fn advance(&mut self) {
         self.step = self.step.next();
+        self.scroll = ScrollState::new(0);
     }
 }
 
@@ -75,95 +78,118 @@ impl WalkthroughState {
 ///
 /// Only renders for steps that show an overlay (not FillForm — that's
 /// handled by the form itself, and not Done).
-pub fn render_walkthrough_overlay(frame: &mut Frame, area: Rect, step: WalkthroughStep) {
-    let lines = match step {
-        WalkthroughStep::Welcome => vec![
-            styled_title("Welcome to the Policy Editor"),
-            Line::from(""),
-            Line::from("Your policy controls what Claude can do."),
-            Line::from("It starts with a sensible default: ask for"),
-            Line::from("anything not explicitly allowed."),
-            Line::from(""),
-            Line::from("Let's walk through your starter policy."),
-            Line::from(""),
-            dim_hint("Press any key to continue  •  Esc to skip"),
-        ],
-        WalkthroughStep::BaseTools => vec![
-            styled_title("Base Tools — Pre-configured"),
-            Line::from(""),
-            Line::from("Your policy already allows the tools Claude"),
-            Line::from("uses most: Read, Write, Edit, Glob, and Grep."),
-            Line::from(""),
-            Line::from("These run inside a sandbox that limits file"),
-            Line::from("access to your project and temp directories."),
-            Line::from(""),
-            Line::from("Shell commands are more nuanced. Take git:"),
-            Line::from("status and log are read-only, commit writes"),
-            Line::from("locally, but push needs network access."),
-            Line::from(""),
-            Line::from("For now we'll allow all of git. Over time you"),
-            Line::from("can add sandboxes for finer-grained control."),
-            Line::from(""),
-            dim_hint("Press any key to continue  •  Esc to skip"),
-        ],
-        WalkthroughStep::AddRule => vec![
-            styled_title("Step 1: Allow git"),
-            Line::from(""),
-            Line::from("Let's add a rule that allows all git commands."),
-            Line::from("You can refine this later — e.g. deny push"),
-            Line::from("--force or sandbox network-dependent ops."),
-            Line::from(""),
-            key_hint("a", "add a new rule"),
-            Line::from(""),
-            dim_hint("Esc to skip walkthrough"),
-        ],
+pub fn render_walkthrough_overlay(
+    frame: &mut Frame,
+    area: Rect,
+    step: WalkthroughStep,
+    scroll: &mut ScrollState,
+) {
+    let (content, footer): (Vec<Line>, &[(&str, &str)]) = match step {
+        WalkthroughStep::Welcome => (
+            vec![
+                styled_title("Welcome to the Policy Editor"),
+                Line::from(""),
+                Line::from("Your policy controls what Claude can do."),
+                Line::from("It starts with a sensible default: ask for"),
+                Line::from("anything not explicitly allowed."),
+                Line::from(""),
+                Line::from("Let's walk through your starter policy."),
+            ],
+            &[("any key", "continue"), ("Esc", "skip")],
+        ),
+        WalkthroughStep::BaseTools => (
+            vec![
+                styled_title("Base Tools — Pre-configured"),
+                Line::from(""),
+                Line::from("Your policy already allows the tools Claude"),
+                Line::from("uses most: Read, Write, Edit, Glob, and Grep."),
+                Line::from(""),
+                Line::from("These run inside a sandbox that limits file"),
+                Line::from("access to your project and temp directories."),
+                Line::from(""),
+                Line::from("Shell commands are more nuanced. Take git:"),
+                Line::from("status and log are read-only, commit writes"),
+                Line::from("locally, but push needs network access."),
+                Line::from(""),
+                Line::from("For now we'll allow all of git. Over time you"),
+                Line::from("can add sandboxes for finer-grained control."),
+            ],
+            &[("any key", "continue"), ("Esc", "skip")],
+        ),
+        WalkthroughStep::AddRule => (
+            vec![
+                styled_title("Step 1: Allow git"),
+                Line::from(""),
+                Line::from("Let's add a rule that allows all git commands."),
+                Line::from("You can refine this later — e.g. deny push"),
+                Line::from("--force or sandbox network-dependent ops."),
+                Line::from(""),
+                key_hint("a", "add a new rule"),
+            ],
+            &[("a", "add rule"), ("Esc", "skip")],
+        ),
         WalkthroughStep::FillForm => {
             // Overlay not rendered — form is visible with its own hints.
             return;
         }
-        WalkthroughStep::TestIt => vec![
-            styled_title("Step 2: Test Your Rule"),
-            Line::from(""),
-            Line::from("The test console lets you check how your"),
-            Line::from("policy handles different commands."),
-            Line::from(""),
-            Line::from("Type a tool name followed by its arguments:"),
-            dim_hint("  bash git status"),
-            dim_hint("  Read /etc/hosts"),
-            Line::from(""),
-            key_hint("t", "open the test console"),
-            Line::from(""),
-            dim_hint("Esc to skip walkthrough"),
-        ],
+        WalkthroughStep::TestIt => (
+            vec![
+                styled_title("Step 2: Test Your Rule"),
+                Line::from(""),
+                Line::from("The test console lets you check how your"),
+                Line::from("policy handles different commands."),
+                Line::from(""),
+                Line::from("Type a tool name followed by its arguments:"),
+                dim_hint("  bash git status"),
+                dim_hint("  Read /etc/hosts"),
+                Line::from(""),
+                key_hint("t", "open the test console"),
+            ],
+            &[("t", "test console"), ("Esc", "skip")],
+        ),
         WalkthroughStep::TypeTest => {
             // Test panel is focused — don't overlay, just let status bar guide.
             return;
         }
-        WalkthroughStep::SaveFinish => vec![
-            styled_title("Step 3: Save"),
-            Line::from(""),
-            Line::from("Your rule is ready. Save your policy to"),
-            Line::from("start using it in Claude Code."),
-            Line::from(""),
-            key_hint("s", "save your policy"),
-            Line::from(""),
-            dim_hint("Come back anytime with: clash policy edit"),
-        ],
+        WalkthroughStep::SaveFinish => (
+            vec![
+                styled_title("Step 3: Save"),
+                Line::from(""),
+                Line::from("Your rule is ready. Save your policy to"),
+                Line::from("start using it in Claude Code."),
+                Line::from(""),
+                key_hint("s", "save your policy"),
+                Line::from(""),
+                dim_hint("Come back anytime with: clash policy edit"),
+            ],
+            &[("s", "save"), ("Esc", "skip")],
+        ),
         WalkthroughStep::Done => return,
     };
 
-    let popup = centered_rect(50, 45, area);
-    frame.render_widget(Clear, popup);
+    // Derive content length from the actual content — no hand-counted constants.
+    scroll.set_content_len(content.len());
 
-    let block = Block::default()
-        .borders(Borders::ALL)
-        .border_style(Style::default().fg(Color::Cyan))
-        .title(" Walkthrough ");
+    let modal = ModalOverlay {
+        width_pct: 50,
+        height: ModalHeight::Percent(45),
+        border_color: Color::Cyan,
+        title: "Walkthrough",
+        footer,
+        footer_right: None,
+        scroll: Some(scroll.to_modal_scroll()),
+    };
+    let inner = modal.render_chrome(frame, area);
+    scroll.update_viewport(inner.area.height as usize);
 
-    let para = Paragraph::new(lines)
-        .block(block)
-        .alignment(Alignment::Center);
-    frame.render_widget(para, popup);
+    let visible: Vec<Line> = content
+        .into_iter()
+        .skip(scroll.offset)
+        .take(inner.area.height as usize)
+        .collect();
+
+    let para = Paragraph::new(visible).alignment(Alignment::Center);
+    frame.render_widget(para, inner.area);
 }
 
 /// Status bar hints for each walkthrough step.

--- a/clash/src/tui/widgets.rs
+++ b/clash/src/tui/widgets.rs
@@ -4,7 +4,9 @@ use ratatui::Frame;
 use ratatui::layout::{Alignment, Constraint, Layout, Rect};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
-use ratatui::widgets::{Block, Borders, Clear, Paragraph};
+use ratatui::widgets::{
+    Block, Borders, Clear, Paragraph, Scrollbar, ScrollbarOrientation, ScrollbarState,
+};
 
 use super::app::Tab;
 
@@ -92,12 +94,10 @@ pub fn render_status_bar(
     frame.render_widget(bar, area);
 }
 
-/// Render a centered help popup listing all keybindings.
-pub fn render_help_overlay(frame: &mut Frame, area: Rect) {
-    let popup = centered_rect(60, 70, area);
-    frame.render_widget(Clear, popup);
-
-    let help_text = vec![
+/// Build the help content lines.  Used both for rendering and for deriving
+/// the content length when constructing `ScrollState`.
+pub fn help_content() -> Vec<Line<'static>> {
+    vec![
         Line::from(Span::styled(
             "Keybindings",
             Style::default()
@@ -157,69 +157,93 @@ pub fn render_help_overlay(frame: &mut Frame, area: Rect) {
             Span::styled("?      ", Style::default().fg(Color::Yellow)),
             Span::raw("Toggle this help"),
         ]),
-        Line::from(""),
-        Line::from(Span::styled(
-            "Press any key to close",
-            Style::default().fg(Color::DarkGray),
-        )),
-    ];
+    ]
+}
 
-    let block = Block::default()
-        .borders(Borders::ALL)
-        .border_style(Style::default().fg(Color::Cyan))
-        .title(" Help ");
+/// Render a centered help popup listing all keybindings.
+pub fn render_help_overlay(frame: &mut Frame, area: Rect, scroll: &mut ScrollState) {
+    let help_lines = help_content();
 
-    let para = Paragraph::new(help_text)
-        .block(block)
-        .alignment(Alignment::Left);
-    frame.render_widget(para, popup);
+    let modal = ModalOverlay {
+        width_pct: 60,
+        height: ModalHeight::Percent(70),
+        border_color: Color::Cyan,
+        title: "Help",
+        footer: &[("j/k", "scroll"), ("any key", "close")],
+        footer_right: None,
+        scroll: Some(scroll.to_modal_scroll()),
+    };
+    let inner = modal.render_chrome(frame, area);
+    scroll.update_viewport(inner.area.height as usize);
+
+    let visible: Vec<Line> = help_lines
+        .into_iter()
+        .skip(scroll.offset)
+        .take(inner.area.height as usize)
+        .collect();
+
+    let para = Paragraph::new(visible).alignment(Alignment::Left);
+    frame.render_widget(para, inner.area);
 }
 
 /// Render a confirmation dialog.
 pub fn render_confirm_overlay(frame: &mut Frame, area: Rect, prompt: &str) {
-    let popup = centered_rect(50, 20, area);
-    frame.render_widget(Clear, popup);
+    let modal = ModalOverlay {
+        width_pct: 50,
+        height: ModalHeight::Percent(20),
+        border_color: Color::Yellow,
+        title: "Confirm",
+        footer: &[("y", "yes"), ("n", "no")],
+        footer_right: None,
+        scroll: None,
+    };
+    let inner = modal.render_chrome(frame, area);
 
-    let text = vec![
-        Line::from(""),
-        Line::from(Span::raw(prompt)),
-        Line::from(""),
-        Line::from(vec![
-            Span::styled(
-                "y",
-                Style::default()
-                    .fg(Color::Green)
-                    .add_modifier(Modifier::BOLD),
-            ),
-            Span::raw(" yes  "),
-            Span::styled(
-                "n",
-                Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),
-            ),
-            Span::raw(" no"),
-        ]),
-    ];
+    let text = vec![Line::from(""), Line::from(Span::raw(prompt))];
 
-    let block = Block::default()
-        .borders(Borders::ALL)
-        .border_style(Style::default().fg(Color::Yellow))
-        .title(" Confirm ");
-
-    let para = Paragraph::new(text)
-        .block(block)
-        .alignment(Alignment::Center);
-    frame.render_widget(para, popup);
+    let para = Paragraph::new(text).alignment(Alignment::Center);
+    frame.render_widget(para, inner.area);
 }
 
 /// Render a scrollable diff overlay for save review.
-pub fn render_diff_overlay(frame: &mut Frame, area: Rect, diff_lines: &[DiffLine], scroll: usize) {
-    let popup = centered_rect(80, 80, area);
-    frame.render_widget(Clear, popup);
+pub fn render_diff_overlay(
+    frame: &mut Frame,
+    area: Rect,
+    diff_lines: &[DiffLine],
+    scroll: &mut ScrollState,
+) {
+    let total = diff_lines.len();
+    // Use the previous frame's real viewport for scroll_info (avoids estimate).
+    // On the very first frame viewport is 0, so scroll_info won't show — that's
+    // a single-frame cosmetic gap, far better than a permanent estimate error.
+    let viewport = scroll.viewport();
+    let scroll_info = if total > viewport && viewport > 0 {
+        Some(format!(
+            "[{}-{}/{}]",
+            scroll.offset + 1,
+            (scroll.offset + viewport).min(total),
+            total
+        ))
+    } else {
+        None
+    };
 
-    let visible_height = popup.height.saturating_sub(4) as usize; // borders + title + footer
+    let modal = ModalOverlay {
+        width_pct: 80,
+        height: ModalHeight::Percent(80),
+        border_color: Color::Cyan,
+        title: "Save Review",
+        footer: &[("y", "confirm"), ("n", "cancel"), ("j/k", "scroll")],
+        footer_right: scroll_info,
+        scroll: Some(scroll.to_modal_scroll()),
+    };
+    let inner = modal.render_chrome(frame, area);
+    scroll.update_viewport(inner.area.height as usize);
+
+    let visible_height = inner.area.height as usize;
     let visible_lines: Vec<Line> = diff_lines
         .iter()
-        .skip(scroll)
+        .skip(scroll.offset)
         .take(visible_height)
         .map(|dl| match dl {
             DiffLine::Context(s) => {
@@ -240,25 +264,8 @@ pub fn render_diff_overlay(frame: &mut Frame, area: Rect, diff_lines: &[DiffLine
         })
         .collect();
 
-    let scroll_info = if diff_lines.len() > visible_height {
-        format!(
-            " [{}-{}/{}] ",
-            scroll + 1,
-            (scroll + visible_height).min(diff_lines.len()),
-            diff_lines.len()
-        )
-    } else {
-        String::new()
-    };
-
-    let block = Block::default()
-        .borders(Borders::ALL)
-        .border_style(Style::default().fg(Color::Cyan))
-        .title(" Save Review — y to confirm, n/Esc to cancel ")
-        .title_bottom(Line::from(format!(" j/k scroll{scroll_info}")).alignment(Alignment::Right));
-
-    let para = Paragraph::new(visible_lines).block(block);
-    frame.render_widget(para, popup);
+    let para = Paragraph::new(visible_lines);
+    frame.render_widget(para, inner.area);
 }
 
 /// A line in a diff display.
@@ -267,6 +274,215 @@ pub enum DiffLine {
     Add(String),
     Remove(String),
     Header(String),
+}
+
+// ---------------------------------------------------------------------------
+// ModalOverlay — unified chrome for all popup modals
+// ---------------------------------------------------------------------------
+
+const MIN_INNER_WIDTH: u16 = 30;
+const MIN_INNER_HEIGHT: u16 = 6;
+
+/// How the modal's height is determined.
+pub enum ModalHeight {
+    /// Fixed percentage of the terminal height.
+    Percent(u16),
+    /// Fit to content with floor/ceiling bounds.
+    FitContent {
+        lines: u16,
+        floor_pct: u16,
+        ceil_pct: u16,
+    },
+}
+
+/// Scroll state for a modal — enables the scrollbar when present.
+pub struct ModalScroll {
+    /// Current scroll offset (0-based line index at top of viewport).
+    pub offset: usize,
+    /// Total number of content lines.
+    pub total: usize,
+}
+
+/// Configuration for a modal popup's chrome (border, title, footer).
+pub struct ModalOverlay<'a> {
+    pub width_pct: u16,
+    pub height: ModalHeight,
+    pub border_color: Color,
+    pub title: &'a str,
+    /// Key-hint pairs rendered as `title_bottom`; empty slice = no footer.
+    pub footer: &'a [(&'a str, &'a str)],
+    /// Optional right-aligned footer text, e.g. scroll position "[3-10/20]".
+    pub footer_right: Option<String>,
+    /// When set, a vertical scrollbar is rendered on the right edge if content overflows.
+    pub scroll: Option<ModalScroll>,
+}
+
+/// The inner area returned by [`ModalOverlay::render_chrome`].
+pub struct ModalInner {
+    pub area: Rect,
+}
+
+// ---------------------------------------------------------------------------
+// ScrollState — single source of truth for scroll offset clamping
+// ---------------------------------------------------------------------------
+
+/// Owns a scroll offset, the total content length, and the last-known viewport
+/// height.  All mutations go through [`scroll_down`] / [`scroll_up`] which
+/// clamp to `content_len - viewport` so the offset never overshoots.
+#[derive(Debug, Clone)]
+pub struct ScrollState {
+    pub offset: usize,
+    content_len: usize,
+    viewport: usize,
+}
+
+impl ScrollState {
+    pub fn new(content_len: usize) -> Self {
+        Self {
+            offset: 0,
+            content_len,
+            viewport: 0,
+        }
+    }
+
+    /// Maximum scroll offset given current content and viewport.
+    pub fn max_offset(&self) -> usize {
+        self.content_len.saturating_sub(self.viewport)
+    }
+
+    pub fn scroll_down(&mut self) {
+        self.offset = (self.offset + 1).min(self.max_offset());
+    }
+
+    pub fn scroll_up(&mut self) {
+        self.offset = self.offset.saturating_sub(1);
+    }
+
+    /// Called by render functions once the real viewport height is known.
+    /// Re-clamps offset in case the terminal was resized.
+    pub fn update_viewport(&mut self, viewport: usize) {
+        self.viewport = viewport;
+        self.offset = self.offset.min(self.max_offset());
+    }
+
+    pub fn content_len(&self) -> usize {
+        self.content_len
+    }
+
+    pub fn viewport(&self) -> usize {
+        self.viewport
+    }
+
+    /// Update content length (e.g. when walkthrough step changes) and re-clamp.
+    pub fn set_content_len(&mut self, len: usize) {
+        self.content_len = len;
+        self.offset = self.offset.min(self.max_offset());
+    }
+
+    pub fn to_modal_scroll(&self) -> ModalScroll {
+        ModalScroll {
+            offset: self.offset,
+            total: self.content_len,
+        }
+    }
+}
+
+impl ModalOverlay<'_> {
+    /// Render the modal border, title, and footer, returning the inner content area.
+    pub fn render_chrome(&self, frame: &mut Frame, area: Rect) -> ModalInner {
+        // Compute effective height percentage
+        let height_pct = match &self.height {
+            ModalHeight::Percent(p) => *p,
+            ModalHeight::FitContent {
+                lines,
+                floor_pct,
+                ceil_pct,
+            } => {
+                // +2 for top/bottom border
+                let needed = *lines + 2;
+                let pct = ((needed as f32 / area.height as f32) * 100.0).ceil() as u16;
+                pct.clamp(*floor_pct, *ceil_pct)
+            }
+        };
+
+        let mut popup = centered_rect(self.width_pct, height_pct, area);
+
+        // Enforce minimum inner dimensions by expanding + re-centering
+        let inner_w = popup.width.saturating_sub(2); // -2 for left/right border
+        let inner_h = popup.height.saturating_sub(2); // -2 for top/bottom border
+        if inner_w < MIN_INNER_WIDTH || inner_h < MIN_INNER_HEIGHT {
+            let needed_w = popup.width.max(MIN_INNER_WIDTH + 2);
+            let needed_h = popup.height.max(MIN_INNER_HEIGHT + 2);
+            // Clamp to terminal area
+            let w = needed_w.min(area.width);
+            let h = needed_h.min(area.height);
+            let x = area.x + area.width.saturating_sub(w) / 2;
+            let y = area.y + area.height.saturating_sub(h) / 2;
+            popup = Rect::new(x, y, w, h);
+        }
+
+        frame.render_widget(Clear, popup);
+
+        // Build footer line from key-hint pairs
+        let mut block = Block::default()
+            .borders(Borders::ALL)
+            .border_style(Style::default().fg(self.border_color))
+            .title(format!(" {} ", self.title));
+
+        if !self.footer.is_empty() || self.footer_right.is_some() {
+            let mut spans: Vec<Span> = Vec::new();
+            spans.push(Span::raw(" "));
+            for (i, (key, desc)) in self.footer.iter().enumerate() {
+                if i > 0 {
+                    spans.push(Span::styled("  ", Style::default().fg(Color::DarkGray)));
+                }
+                spans.push(Span::styled(
+                    *key,
+                    Style::default()
+                        .fg(Color::Yellow)
+                        .add_modifier(Modifier::BOLD),
+                ));
+                spans.push(Span::styled(
+                    format!(" {desc}"),
+                    Style::default().fg(Color::DarkGray),
+                ));
+            }
+            if let Some(ref right) = self.footer_right {
+                spans.push(Span::styled(
+                    format!(" {right}"),
+                    Style::default().fg(Color::DarkGray),
+                ));
+            }
+            spans.push(Span::raw(" "));
+            block = block.title_bottom(Line::from(spans).alignment(Alignment::Right));
+        }
+
+        let inner = block.inner(popup);
+        frame.render_widget(block, popup);
+
+        // Render scrollbar if content overflows
+        let content_area = if let Some(ref sc) = self.scroll {
+            if sc.total > inner.height as usize && inner.width > 1 {
+                let scrollbar = Scrollbar::new(ScrollbarOrientation::VerticalRight)
+                    .thumb_style(Style::default().fg(self.border_color))
+                    .track_style(Style::default().fg(Color::DarkGray))
+                    .begin_symbol(None)
+                    .end_symbol(None);
+                let mut sb_state = ScrollbarState::new(sc.total)
+                    .position(sc.offset)
+                    .viewport_content_length(inner.height as usize);
+                frame.render_stateful_widget(scrollbar, inner, &mut sb_state);
+                // Shrink content area by 1 column on the right to avoid overlap
+                Rect::new(inner.x, inner.y, inner.width - 1, inner.height)
+            } else {
+                inner
+            }
+        } else {
+            inner
+        };
+
+        ModalInner { area: content_area }
+    }
 }
 
 /// Compute a centered rect within `area`.


### PR DESCRIPTION
Introduce ModalOverlay abstraction that consolidates chrome rendering (border, title, footer, scrollbar, min-size guards) for all 5 modal overlays (Help, Confirm, Save Review, Form, Walkthrough).

Add ScrollState type that owns offset/content_len/viewport and clamps at mutation time to content_len - viewport, eliminating phantom scroll accumulation. Render functions call update_viewport() with the real inner area height so scroll bounds stay correct across terminal resizes.

- Help and walkthrough overlays now scroll with j/k, arrows, and mouse
- Diff overlay scroll_info uses previous frame's real viewport instead of an estimate
- Content lengths derived from actual content (no hand-counted constants)
- Mouse scroll events handled for all scrollable overlays
- Includes cargo fmt reformatting of hooks.rs and init.rs