### PR TITLE
feat(tui): require Enter to advance walkthrough, confirm on Esc, add back

### DIFF
--- a/clash/src/tui/app.rs
+++ b/clash/src/tui/app.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 use std::time::Instant;
 
 use anyhow::Result;
-use crossterm::event::{self, Event, KeyCode, KeyEvent, KeyModifiers, MouseEventKind};
+use crossterm::event::{self, Event, KeyCode, KeyEvent, KeyModifiers, MouseButton, MouseEventKind};
 use ratatui::Frame;
 use ratatui::Terminal;
 use ratatui::backend::Backend;
@@ -25,7 +25,7 @@ use super::tea::{Action, Component};
 use super::test_panel::{self, TestPanel, TestPanelAction};
 use super::tree_view::TreeView;
 use super::walkthrough::{self, WalkthroughState, WalkthroughStep};
-use super::widgets::{self, DiffLine, ScrollState};
+use super::widgets::{self, ClickAction, ClickRegions, DiffLine, ScrollState};
 
 /// Which tab is active.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -100,6 +100,8 @@ pub struct App {
     flash: Option<(String, Instant)>,
     /// Onboarding walkthrough state — persists across Mode transitions.
     walkthrough: Option<WalkthroughState>,
+    /// Mouse click targets populated each frame during `view()`.
+    click_regions: ClickRegions,
 }
 
 impl App {
@@ -153,6 +155,7 @@ impl App {
             dirty: false,
             flash,
             walkthrough: None,
+            click_regions: ClickRegions::default(),
         })
     }
 
@@ -183,8 +186,9 @@ impl App {
             if matches!(event, Event::Resize(_, _)) {
                 continue; // redraw with new dimensions
             }
-            // Mouse events: handle scroll in overlay modes, skip everything else
-            // to avoid busy-redraw loops from MouseEventKind::Moved.
+            // Mouse events: handle scroll in overlay modes, click on regions,
+            // skip everything else to avoid busy-redraw loops from MouseEventKind::Moved.
+            let mut synth_key: Option<KeyEvent> = None;
             if let Event::Mouse(mouse) = &event {
                 match mouse.kind {
                     MouseEventKind::ScrollDown | MouseEventKind::ScrollUp => {
@@ -216,153 +220,186 @@ impl App {
                             _ => {}
                         }
                     }
+                    MouseEventKind::Down(MouseButton::Left) => {
+                        if let Some(action) = self.click_regions.hit(mouse.column, mouse.row) {
+                            match action {
+                                ClickAction::Key(kc) => {
+                                    synth_key = Some(KeyEvent::new(*kc, KeyModifiers::empty()));
+                                }
+                                &ClickAction::FormField(vi) => {
+                                    if let Mode::Form(ref mut form) = self.mode {
+                                        form.set_active(vi);
+                                    }
+                                }
+                                &ClickAction::SelectOption { field, option } => {
+                                    if let Mode::Form(ref mut form) = self.mode {
+                                        form.set_active_for_field(field);
+                                        form.set_select_option(field, option);
+                                    }
+                                }
+                                &ClickAction::ToggleMultiSelect { field, option } => {
+                                    if let Mode::Form(ref mut form) = self.mode {
+                                        form.set_active_for_field(field);
+                                        form.toggle_multi(field, option);
+                                    }
+                                }
+                            }
+                        }
+                    }
                     _ => {}
+                }
+                if synth_key.is_none() {
+                    continue;
+                }
+            }
+
+            let key = if let Some(sk) = synth_key {
+                sk
+            } else if let Event::Key(k) = event {
+                k
+            } else {
+                continue;
+            };
+
+            // Walkthrough mode intercepts keys to advance steps.
+            if matches!(self.mode, Mode::Walkthrough) {
+                if let Some(ref mut wt) = self.walkthrough {
+                    match key.code {
+                        KeyCode::Esc => {
+                            self.mode = Mode::Confirm(ConfirmAction::SkipWalkthrough);
+                        }
+                        // j/k/arrows scroll the walkthrough overlay
+                        KeyCode::Char('j') | KeyCode::Down => {
+                            wt.scroll.scroll_down();
+                        }
+                        KeyCode::Char('k') | KeyCode::Up => {
+                            wt.scroll.scroll_up();
+                        }
+                        KeyCode::Char('b') => {
+                            wt.go_back();
+                        }
+                        KeyCode::Enter
+                            if matches!(
+                                wt.step,
+                                WalkthroughStep::Welcome | WalkthroughStep::BaseTools
+                            ) =>
+                        {
+                            wt.advance();
+                        }
+                        KeyCode::Char('a') if wt.step == WalkthroughStep::AddRule => {
+                            wt.step = WalkthroughStep::FillForm;
+                            let form = FormState::new_add_rule_prefilled(
+                                &self.manifest,
+                                Some(&self.included),
+                            );
+                            self.mode = Mode::Form(form);
+                        }
+                        KeyCode::Char('t') if wt.step == WalkthroughStep::TestIt => {
+                            wt.step = WalkthroughStep::TypeTest;
+                            self.test_panel.visible = true;
+                            self.test_panel.input_active = true;
+                            self.test_focused = true;
+                            self.mode = Mode::Normal;
+                        }
+                        KeyCode::Char('s') if wt.step == WalkthroughStep::SaveFinish => {
+                            wt.step = WalkthroughStep::Done;
+                            self.mode = Mode::Normal;
+                            // Trigger the save flow
+                            if self.dirty {
+                                let new_json = serde_json::to_string_pretty(&self.manifest)
+                                    .unwrap_or_default();
+                                let diff_lines = compute_diff(&self.original_json, &new_json);
+                                let len = diff_lines.len();
+                                self.mode = Mode::SaveReview(DiffState {
+                                    lines: diff_lines,
+                                    scroll: ScrollState::new(len),
+                                });
+                            } else {
+                                self.walkthrough = None;
+                                self.flash = Some((
+                                    "No changes to save — walkthrough complete!".into(),
+                                    Instant::now(),
+                                ));
+                            }
+                        }
+                        _ => {}
+                    }
                 }
                 continue;
             }
-            if let Event::Key(key) = event {
-                // Walkthrough mode intercepts keys to advance steps.
-                if matches!(self.mode, Mode::Walkthrough) {
-                    if let Some(ref mut wt) = self.walkthrough {
-                        match key.code {
-                            KeyCode::Esc => {
-                                self.mode = Mode::Confirm(ConfirmAction::SkipWalkthrough);
+
+            // Form mode handles keys directly — not via Msg
+            if matches!(self.mode, Mode::Form(_)) {
+                let FormHandled::Continue = self.handle_form_key(key);
+                continue;
+            }
+
+            // Test panel focused: route keys to the test panel.
+            // Esc returns focus to the left pane. Tab toggles input/history.
+            if self.test_panel.visible && self.test_focused && matches!(self.mode, Mode::Normal) {
+                match key.code {
+                    KeyCode::Esc => {
+                        // During walkthrough, Esc from test panel cancels walkthrough
+                        if self.walkthrough.is_some() {
+                            self.walkthrough = None;
+                            self.test_focused = false;
+                            self.flash = Some((
+                                "Walkthrough skipped — press ? for help".into(),
+                                Instant::now(),
+                            ));
+                        } else {
+                            // Return focus to the left pane
+                            self.test_focused = false;
+                        }
+                        continue;
+                    }
+                    KeyCode::Tab => {
+                        // Toggle between input and history within test panel
+                        self.test_panel.toggle_input_focus();
+                        continue;
+                    }
+                    _ => {
+                        if let Some(msg) = self.test_panel.handle_key(key) {
+                            let is_submit = matches!(msg, test_panel::Msg::InputSubmit);
+                            let compiled = self.current_compiled_policy();
+                            match self.test_panel.update(msg, compiled.as_ref()) {
+                                TestPanelAction::Flash(s) => {
+                                    self.flash = Some((s, Instant::now()));
+                                }
+                                TestPanelAction::None => {}
                             }
-                            // j/k/arrows scroll the walkthrough overlay
-                            KeyCode::Char('j') | KeyCode::Down => {
-                                wt.scroll.scroll_down();
-                            }
-                            KeyCode::Char('k') | KeyCode::Up => {
-                                wt.scroll.scroll_up();
-                            }
-                            KeyCode::Char('b') => {
-                                wt.go_back();
-                            }
-                            KeyCode::Enter
-                                if matches!(
-                                    wt.step,
-                                    WalkthroughStep::Welcome | WalkthroughStep::BaseTools
-                                ) =>
+                            // Advance walkthrough from TypeTest → SaveFinish on submit
+                            if is_submit
+                                && let Some(ref mut wt) = self.walkthrough
+                                && wt.step == WalkthroughStep::TypeTest
                             {
-                                wt.advance();
-                            }
-                            KeyCode::Char('a') if wt.step == WalkthroughStep::AddRule => {
-                                wt.step = WalkthroughStep::FillForm;
-                                let form = FormState::new_add_rule_prefilled(
-                                    &self.manifest,
-                                    Some(&self.included),
-                                );
-                                self.mode = Mode::Form(form);
-                            }
-                            KeyCode::Char('t') if wt.step == WalkthroughStep::TestIt => {
-                                wt.step = WalkthroughStep::TypeTest;
-                                self.test_panel.visible = true;
-                                self.test_panel.input_active = true;
-                                self.test_focused = true;
-                                self.mode = Mode::Normal;
-                            }
-                            KeyCode::Char('s') if wt.step == WalkthroughStep::SaveFinish => {
-                                wt.step = WalkthroughStep::Done;
-                                self.mode = Mode::Normal;
-                                // Trigger the save flow
-                                if self.dirty {
-                                    let new_json = serde_json::to_string_pretty(&self.manifest)
-                                        .unwrap_or_default();
-                                    let diff_lines =
-                                        compute_diff(&self.original_json, &new_json);
-                                    let len = diff_lines.len();
-                                    self.mode = Mode::SaveReview(DiffState {
-                                        lines: diff_lines,
-                                        scroll: ScrollState::new(len),
-                                    });
-                                } else {
-                                    self.walkthrough = None;
-                                    self.flash = Some((
-                                        "No changes to save — walkthrough complete!".into(),
-                                        Instant::now(),
-                                    ));
-                                }
-                            }
-                            _ => {}
-                        }
-                    }
-                    continue;
-                }
-
-                // Form mode handles keys directly — not via Msg
-                if matches!(self.mode, Mode::Form(_)) {
-                    let FormHandled::Continue = self.handle_form_key(key);
-                    continue;
-                }
-
-                // Test panel focused: route keys to the test panel.
-                // Esc returns focus to the left pane. Tab toggles input/history.
-                if self.test_panel.visible && self.test_focused && matches!(self.mode, Mode::Normal)
-                {
-                    match key.code {
-                        KeyCode::Esc => {
-                            // During walkthrough, Esc from test panel cancels walkthrough
-                            if self.walkthrough.is_some() {
-                                self.walkthrough = None;
+                                wt.step = WalkthroughStep::SaveFinish;
                                 self.test_focused = false;
-                                self.flash = Some((
-                                    "Walkthrough skipped — press ? for help".into(),
-                                    Instant::now(),
-                                ));
-                            } else {
-                                // Return focus to the left pane
-                                self.test_focused = false;
+                                self.mode = Mode::Walkthrough;
                             }
-                            continue;
                         }
-                        KeyCode::Tab => {
-                            // Toggle between input and history within test panel
-                            self.test_panel.toggle_input_focus();
-                            continue;
-                        }
-                        _ => {
-                            if let Some(msg) = self.test_panel.handle_key(key) {
-                                let is_submit = matches!(msg, test_panel::Msg::InputSubmit);
-                                let compiled = self.current_compiled_policy();
-                                match self.test_panel.update(msg, compiled.as_ref()) {
-                                    TestPanelAction::Flash(s) => {
-                                        self.flash = Some((s, Instant::now()));
-                                    }
-                                    TestPanelAction::None => {}
-                                }
-                                // Advance walkthrough from TypeTest → SaveFinish on submit
-                                if is_submit
-                                    && let Some(ref mut wt) = self.walkthrough
-                                    && wt.step == WalkthroughStep::TypeTest
-                                {
-                                    wt.step = WalkthroughStep::SaveFinish;
-                                    self.test_focused = false;
-                                    self.mode = Mode::Walkthrough;
-                                }
-                            }
-                            continue;
-                        }
+                        continue;
                     }
                 }
+            }
 
-                if let Some(msg) = self.handle_key(key) {
-                    let action = self.update_msg(msg);
-                    match action {
-                        Action::Quit => break,
-                        Action::Modified => {
-                            self.dirty = true;
-                            self.rebuild_views();
-                        }
-                        Action::RunForm(req) => {
-                            let form =
-                                FormState::from_request(&req, &self.manifest, Some(&self.included));
-                            self.mode = Mode::Form(form);
-                        }
-                        Action::Flash(s) => {
-                            self.flash = Some((s, Instant::now()));
-                        }
-                        Action::None => {}
+            if let Some(msg) = self.handle_key(key) {
+                let action = self.update_msg(msg);
+                match action {
+                    Action::Quit => break,
+                    Action::Modified => {
+                        self.dirty = true;
+                        self.rebuild_views();
                     }
+                    Action::RunForm(req) => {
+                        let form =
+                            FormState::from_request(&req, &self.manifest, Some(&self.included));
+                        self.mode = Mode::Form(form);
+                    }
+                    Action::Flash(s) => {
+                        self.flash = Some((s, Instant::now()));
+                    }
+                    Action::None => {}
                 }
             }
         }
@@ -831,29 +868,52 @@ impl App {
 
         widgets::render_status_bar(frame, chunks[2], hints, flash_msg);
 
-        // Overlays
+        // Overlays — take click_regions out to avoid double-borrow with &mut self.mode
+        let mut clicks = std::mem::take(&mut self.click_regions);
+        clicks.clear();
+
         match &mut self.mode {
-            Mode::Help(scroll) => widgets::render_help_overlay(frame, area, scroll),
+            Mode::Help(scroll) => {
+                let inner = widgets::render_help_overlay(frame, area, scroll);
+                for (rect, kc) in &inner.footer_buttons {
+                    clicks.push(*rect, ClickAction::Key(*kc));
+                }
+            }
             Mode::Confirm(action) => {
                 let prompt = match action {
                     ConfirmAction::Quit => "Unsaved changes. Quit anyway?",
                     ConfirmAction::SkipWalkthrough => "Skip the walkthrough?",
                 };
-                widgets::render_confirm_overlay(frame, area, prompt);
+                let inner = widgets::render_confirm_overlay(frame, area, prompt);
+                for (rect, kc) in &inner.footer_buttons {
+                    clicks.push(*rect, ClickAction::Key(*kc));
+                }
             }
             Mode::SaveReview(state) => {
-                widgets::render_diff_overlay(frame, area, &state.lines, &mut state.scroll);
+                let inner =
+                    widgets::render_diff_overlay(frame, area, &state.lines, &mut state.scroll);
+                for (rect, kc) in &inner.footer_buttons {
+                    clicks.push(*rect, ClickAction::Key(*kc));
+                }
             }
             Mode::Form(form) => {
-                form.view(frame, area);
+                form.view(frame, area, &mut clicks);
             }
             Mode::Walkthrough => {
                 if let Some(wt) = &mut self.walkthrough {
-                    walkthrough::render_walkthrough_overlay(frame, area, wt.step, &mut wt.scroll);
+                    walkthrough::render_walkthrough_overlay(
+                        frame,
+                        area,
+                        wt.step,
+                        &mut wt.scroll,
+                        &mut clicks,
+                    );
                 }
             }
             Mode::Normal => {}
         }
+
+        self.click_regions = clicks;
     }
 }
 
@@ -1004,5 +1064,169 @@ mod tests {
         // Render form overlay
         press_and_render(&mut app, &mut terminal, key(KeyCode::Esc));
         assert!(matches!(app.mode, Mode::Normal));
+    }
+
+    // -- Click region tests ---------------------------------------------------
+
+    /// Helper: render app to populate click_regions, then return a reference-safe
+    /// snapshot of the regions for assertions.
+    fn render_and_snapshot_clicks(
+        app: &mut App,
+        terminal: &mut Terminal<TestBackend>,
+    ) -> Vec<(Rect, String)> {
+        let snap = app.manifest.clone();
+        terminal
+            .draw(|frame| app.view(frame, frame.area(), &snap))
+            .unwrap();
+        // Convert to owned descriptions for assertions
+        app.click_regions
+            .0
+            .iter()
+            .map(|(r, a)| (*r, format!("{a:?}")))
+            .collect()
+    }
+
+    #[test]
+    fn confirm_overlay_populates_footer_click_regions() {
+        let manifest = empty_manifest();
+        let mut app = App::new(PathBuf::from("/tmp/test.json"), manifest).unwrap();
+        app.dirty = true; // so quit triggers confirm
+        let backend = TestBackend::new(80, 24);
+        let mut terminal = Terminal::new(backend).unwrap();
+
+        // Press 'q' to trigger confirm dialog
+        press_and_render(&mut app, &mut terminal, key(KeyCode::Char('q')));
+        assert!(matches!(app.mode, Mode::Confirm(ConfirmAction::Quit)));
+
+        // Render to populate click regions
+        let clicks = render_and_snapshot_clicks(&mut app, &mut terminal);
+
+        // Should have at least the "y" and "n" footer buttons
+        let y_regions: Vec<_> = clicks
+            .iter()
+            .filter(|(_, desc)| desc.contains("Key(Char('y'))"))
+            .collect();
+        let n_regions: Vec<_> = clicks
+            .iter()
+            .filter(|(_, desc)| desc.contains("Key(Char('n'))"))
+            .collect();
+        assert_eq!(y_regions.len(), 1, "should have one 'y' click region");
+        assert_eq!(n_regions.len(), 1, "should have one 'n' click region");
+    }
+
+    #[test]
+    fn synth_key_from_confirm_click_dismisses_dialog() {
+        let manifest = empty_manifest();
+        let mut app = App::new(PathBuf::from("/tmp/test.json"), manifest).unwrap();
+        app.dirty = true;
+        let backend = TestBackend::new(80, 24);
+        let mut terminal = Terminal::new(backend).unwrap();
+
+        // Open confirm dialog
+        press_and_render(&mut app, &mut terminal, key(KeyCode::Char('q')));
+        assert!(matches!(app.mode, Mode::Confirm(ConfirmAction::Quit)));
+
+        // Render to populate click regions
+        let snap = app.manifest.clone();
+        terminal
+            .draw(|frame| app.view(frame, frame.area(), &snap))
+            .unwrap();
+
+        // Find the "n" button rect
+        let n_rect = app
+            .click_regions
+            .0
+            .iter()
+            .find(|(_, a)| matches!(a, ClickAction::Key(KeyCode::Char('n'))))
+            .map(|(r, _)| *r)
+            .expect("should find 'n' click region");
+
+        // Simulate a click at the center of the "n" button
+        let hit = app.click_regions.hit(n_rect.x + n_rect.width / 2, n_rect.y);
+        assert!(
+            matches!(hit, Some(ClickAction::Key(KeyCode::Char('n')))),
+            "hit-testing 'n' button center should return Key('n')"
+        );
+
+        // Feeding the synth key 'n' through handle_key should dismiss the confirm
+        let msg = app.handle_key(KeyEvent::new(KeyCode::Char('n'), KeyModifiers::empty()));
+        assert!(matches!(msg, Some(Msg::ConfirmNo)));
+        app.update_msg(msg.unwrap());
+        assert!(
+            matches!(app.mode, Mode::Normal),
+            "mode should be Normal after 'n' dismisses confirm"
+        );
+    }
+
+    #[test]
+    fn form_overlay_populates_field_and_option_click_regions() {
+        let manifest = empty_manifest();
+        let mut app = App::new(PathBuf::from("/tmp/test.json"), manifest).unwrap();
+        let backend = TestBackend::new(100, 40);
+        let mut terminal = Terminal::new(backend).unwrap();
+
+        // Open add-rule form
+        press_and_render(&mut app, &mut terminal, key(KeyCode::Char('a')));
+        assert!(matches!(app.mode, Mode::Form(_)));
+
+        // Render to populate click regions
+        let clicks = render_and_snapshot_clicks(&mut app, &mut terminal);
+
+        // Should have FormField regions (at least for each visible field)
+        let field_regions: Vec<_> = clicks
+            .iter()
+            .filter(|(_, desc)| desc.starts_with("FormField"))
+            .collect();
+        assert!(
+            field_regions.len() >= 2,
+            "form should have at least 2 field click regions, got {}",
+            field_regions.len()
+        );
+
+        // The "Rule type" field (field index 0) is inline-select → should have
+        // SelectOption regions for its 3 options
+        let select_regions: Vec<_> = clicks
+            .iter()
+            .filter(|(_, desc)| desc.contains("SelectOption { field: 0"))
+            .collect();
+        assert_eq!(
+            select_regions.len(),
+            3,
+            "inline select should have 3 option click regions, got {}",
+            select_regions.len()
+        );
+
+        // Footer should have Enter, Tab, Esc buttons
+        let enter_regions: Vec<_> = clicks
+            .iter()
+            .filter(|(_, desc)| desc.contains("Key(Enter)"))
+            .collect();
+        let esc_regions: Vec<_> = clicks
+            .iter()
+            .filter(|(_, desc)| desc.contains("Key(Esc)"))
+            .collect();
+        assert_eq!(enter_regions.len(), 1, "should have Enter footer button");
+        assert_eq!(esc_regions.len(), 1, "should have Esc footer button");
+    }
+
+    #[test]
+    fn help_overlay_populates_no_clickable_buttons() {
+        // Help footer is ["j/k scroll", "any key close"] — neither is parseable
+        let manifest = empty_manifest();
+        let mut app = App::new(PathBuf::from("/tmp/test.json"), manifest).unwrap();
+        let backend = TestBackend::new(80, 24);
+        let mut terminal = Terminal::new(backend).unwrap();
+
+        // Open help
+        press_and_render(&mut app, &mut terminal, key(KeyCode::Char('?')));
+        assert!(matches!(app.mode, Mode::Help(_)));
+
+        let clicks = render_and_snapshot_clicks(&mut app, &mut terminal);
+
+        // No parseable single-key hints in the help footer
+        assert!(
+            clicks.is_empty(),
+            "help overlay should have 0 click regions since no hints are single-key parseable"
+        );
     }
 }

--- a/clash/src/tui/inline_form.rs
+++ b/clash/src/tui/inline_form.rs
@@ -11,7 +11,7 @@ use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::Paragraph;
 
-use super::widgets::{ModalHeight, ModalOverlay};
+use super::widgets::{ClickAction, ClickRegions, ModalHeight, ModalOverlay};
 
 use crate::policy::manifest_edit;
 use crate::policy::match_tree::{
@@ -1299,6 +1299,43 @@ impl FormState {
             (FormKind::AddRule | FormKind::EditRule { .. }, 0)
         )
     }
+
+    // -- Public mutation API for mouse click dispatch -------------------------
+
+    /// Activate a visible field by its visible-index.
+    pub fn set_active(&mut self, vi: usize) {
+        if vi < self.visible.len() {
+            self.active = vi;
+        }
+    }
+
+    /// Activate the visible field that corresponds to the raw field index `fi`.
+    pub fn set_active_for_field(&mut self, fi: usize) {
+        if let Some(vi) = self.visible.iter().position(|&f| f == fi) {
+            self.active = vi;
+        }
+    }
+
+    /// Select an option in a Select field by raw field index.
+    pub fn set_select_option(&mut self, fi: usize, opt: usize) {
+        if let FormField::Select {
+            options, selected, ..
+        } = &mut self.fields[fi]
+            && opt < options.len()
+        {
+            *selected = opt;
+            self.recompute_visible();
+        }
+    }
+
+    /// Toggle a MultiSelect checkbox by raw field index.
+    pub fn toggle_multi(&mut self, fi: usize, opt: usize) {
+        if let FormField::MultiSelect { toggled, .. } = &mut self.fields[fi]
+            && opt < toggled.len()
+        {
+            toggled[opt] = !toggled[opt];
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -2034,7 +2071,7 @@ impl FormState {
         self.fields[field_idx].hint()
     }
 
-    pub fn view(&self, frame: &mut Frame, area: Rect) {
+    pub fn view(&self, frame: &mut Frame, area: Rect, clicks: &mut ClickRegions) {
         // Use max possible field count for forms that change visibility dynamically,
         // so the popup stays in a fixed position when cycling options.
         let field_count = match &self.kind {
@@ -2063,12 +2100,29 @@ impl FormState {
         };
         let inner = modal.render_chrome(frame, area);
 
+        // Push footer button click regions
+        for (rect, kc) in &inner.footer_buttons {
+            clicks.push(*rect, ClickAction::Key(*kc));
+        }
+
         let mut lines: Vec<Line> = Vec::new();
         lines.push(Line::from(""));
+
+        // Track current_y for click region placement.
+        // Starts after the blank line at the top of inner.area.
+        let mut current_y = inner.area.y + 1; // +1 for the blank line
+        let inner_width = inner.area.width;
+        let inner_x = inner.area.x;
 
         for (vi, &fi) in self.visible.iter().enumerate() {
             let is_active = vi == self.active;
             let field = &self.fields[fi];
+
+            // Push a click region for the entire field row (less specific).
+            clicks.push(
+                Rect::new(inner_x, current_y, inner_width, 1),
+                ClickAction::FormField(vi),
+            );
 
             match field {
                 FormField::Text {
@@ -2147,12 +2201,17 @@ impl FormState {
                     };
 
                     if self.is_inline_select(fi) {
-                        // Inline mode: show all options, highlight selected
-                        let mut spans = vec![Span::styled(format!("  {label}: "), label_style)];
+                        // Inline mode: show all options, highlight selected.
+                        // Track x offset for each option's click region.
+                        let label_prefix = format!("  {label}: ");
+                        let mut x_off = inner_x + label_prefix.len() as u16;
+
+                        let mut spans = vec![Span::styled(label_prefix, label_style)];
                         for (i, opt) in options.iter().enumerate() {
                             if i > 0 {
                                 spans
                                     .push(Span::styled("  ", Style::default().fg(Color::DarkGray)));
+                                x_off += 2;
                             }
                             let style = if i == *selected {
                                 Style::default()
@@ -2162,7 +2221,17 @@ impl FormState {
                             } else {
                                 Style::default().fg(Color::DarkGray)
                             };
+                            let opt_width = opt.len() as u16;
+                            // Push a more-specific click region for this option
+                            clicks.push(
+                                Rect::new(x_off, current_y, opt_width, 1),
+                                ClickAction::SelectOption {
+                                    field: fi,
+                                    option: i,
+                                },
+                            );
                             spans.push(Span::styled(opt.as_str(), style));
+                            x_off += opt_width;
                         }
                         if is_active {
                             spans.push(Span::styled("  ←/→", Style::default().fg(Color::DarkGray)));
@@ -2221,7 +2290,9 @@ impl FormState {
                         Style::default().fg(Color::Gray)
                     };
 
-                    let mut spans = vec![Span::styled(format!("  {label}: "), label_style)];
+                    let label_prefix = format!("  {label}: ");
+                    let mut x_off = inner_x + label_prefix.len() as u16;
+                    let mut spans = vec![Span::styled(label_prefix, label_style)];
 
                     for (i, opt) in options.iter().enumerate() {
                         let checked = if toggled[i] { "[x]" } else { "[ ]" };
@@ -2236,9 +2307,21 @@ impl FormState {
                         } else {
                             Style::default().fg(Color::DarkGray)
                         };
-                        spans.push(Span::styled(format!("{checked} {opt}"), style));
+                        let item_text = format!("{checked} {opt}");
+                        let item_width = item_text.len() as u16;
+                        // Push a more-specific click region for this checkbox
+                        clicks.push(
+                            Rect::new(x_off, current_y, item_width, 1),
+                            ClickAction::ToggleMultiSelect {
+                                field: fi,
+                                option: i,
+                            },
+                        );
+                        spans.push(Span::styled(item_text, style));
+                        x_off += item_width;
                         if i + 1 < options.len() {
                             spans.push(Span::raw("  "));
+                            x_off += 2;
                         }
                     }
 
@@ -2246,16 +2329,20 @@ impl FormState {
                 }
             }
 
+            current_y += 1; // the field value line
+
             // Context hint for active field
             if is_active && let Some(hint) = self.field_hint(fi) {
                 lines.push(Line::from(Span::styled(
                     format!("    {hint}"),
                     Style::default().fg(Color::DarkGray),
                 )));
+                current_y += 1;
             }
 
             // Spacing between fields
             lines.push(Line::from(""));
+            current_y += 1;
         }
 
         let para = Paragraph::new(lines);

--- a/clash/src/tui/walkthrough.rs
+++ b/clash/src/tui/walkthrough.rs
@@ -10,7 +10,7 @@ use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::Paragraph;
 
-use super::widgets::{ModalHeight, ModalOverlay, ScrollState};
+use super::widgets::{ClickAction, ClickRegions, ModalHeight, ModalOverlay, ScrollState};
 
 /// Sequential steps of the onboarding walkthrough.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -101,6 +101,7 @@ pub fn render_walkthrough_overlay(
     area: Rect,
     step: WalkthroughStep,
     scroll: &mut ScrollState,
+    clicks: &mut ClickRegions,
 ) {
     let (content, footer): (Vec<Line>, &[(&str, &str)]) = match step {
         WalkthroughStep::Welcome => (
@@ -198,6 +199,9 @@ pub fn render_walkthrough_overlay(
         scroll: Some(scroll.to_modal_scroll()),
     };
     let inner = modal.render_chrome(frame, area);
+    for (rect, kc) in &inner.footer_buttons {
+        clicks.push(*rect, ClickAction::Key(*kc));
+    }
     scroll.update_viewport(inner.area.height as usize);
 
     let visible: Vec<Line> = content
@@ -215,10 +219,18 @@ pub fn walkthrough_status_hints(step: WalkthroughStep) -> Vec<(&'static str, &'s
     match step {
         WalkthroughStep::Welcome => vec![("Esc", "skip walkthrough"), ("Enter", "continue")],
         WalkthroughStep::BaseTools => {
-            vec![("Esc", "skip walkthrough"), ("b", "back"), ("Enter", "continue")]
+            vec![
+                ("Esc", "skip walkthrough"),
+                ("b", "back"),
+                ("Enter", "continue"),
+            ]
         }
         WalkthroughStep::AddRule => {
-            vec![("Esc", "skip walkthrough"), ("b", "back"), ("a", "add rule")]
+            vec![
+                ("Esc", "skip walkthrough"),
+                ("b", "back"),
+                ("a", "add rule"),
+            ]
         }
         WalkthroughStep::FillForm => vec![
             ("Tab", "next field"),
@@ -227,7 +239,11 @@ pub fn walkthrough_status_hints(step: WalkthroughStep) -> Vec<(&'static str, &'s
             ("Esc", "skip walkthrough"),
         ],
         WalkthroughStep::TestIt => {
-            vec![("Esc", "skip walkthrough"), ("b", "back"), ("t", "test console")]
+            vec![
+                ("Esc", "skip walkthrough"),
+                ("b", "back"),
+                ("t", "test console"),
+            ]
         }
         WalkthroughStep::TypeTest => vec![
             ("try", "bash git status"),

--- a/clash/src/tui/widgets.rs
+++ b/clash/src/tui/widgets.rs
@@ -1,7 +1,8 @@
 //! Shared ratatui widgets: tab bar, status bar, overlays.
 
+use crossterm::event::KeyCode;
 use ratatui::Frame;
-use ratatui::layout::{Alignment, Constraint, Layout, Rect};
+use ratatui::layout::{Alignment, Constraint, Layout, Position, Rect};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{
@@ -9,6 +10,66 @@ use ratatui::widgets::{
 };
 
 use super::app::Tab;
+
+// ---------------------------------------------------------------------------
+// Click regions — mouse click targets populated each frame during render
+// ---------------------------------------------------------------------------
+
+/// An action that a mouse click can trigger.
+#[derive(Debug)]
+pub enum ClickAction {
+    /// Simulate pressing a key (for footer buttons).
+    Key(KeyCode),
+    /// Activate a form field by its visible-index.
+    FormField(usize),
+    /// Select an inline-select option directly.
+    SelectOption { field: usize, option: usize },
+    /// Toggle a multiselect checkbox.
+    ToggleMultiSelect { field: usize, option: usize },
+}
+
+/// Clickable regions for the current frame.
+#[derive(Default)]
+pub struct ClickRegions(pub(crate) Vec<(Rect, ClickAction)>);
+
+impl ClickRegions {
+    pub fn clear(&mut self) {
+        self.0.clear();
+    }
+
+    pub fn push(&mut self, area: Rect, action: ClickAction) {
+        self.0.push((area, action));
+    }
+
+    /// Return the action for the *most specific* (last-added) region containing (col, row).
+    /// More-specific regions (inline options) are pushed after less-specific ones (field rows),
+    /// so searching in reverse gives correct precedence.
+    pub fn hit(&self, col: u16, row: u16) -> Option<&ClickAction> {
+        self.0
+            .iter()
+            .rev()
+            .find(|(r, _)| r.contains(Position { x: col, y: row }))
+            .map(|(_, a)| a)
+    }
+}
+
+/// Try to parse a footer key-hint string into a single `KeyCode`.
+/// Returns `None` for multi-key combos like `"j/k"`, `"←/→"`, `"any key"`, `"try"`.
+fn parse_hint_key(s: &str) -> Option<KeyCode> {
+    match s {
+        "Enter" => Some(KeyCode::Enter),
+        "Esc" => Some(KeyCode::Esc),
+        "Tab" => Some(KeyCode::Tab),
+        _ => {
+            let chars: Vec<char> = s.chars().collect();
+            if chars.len() == 1 {
+                Some(KeyCode::Char(chars[0]))
+            } else {
+                None
+            }
+        }
+    }
+}
 
 /// Render the tab bar at the top of the screen.
 pub fn render_tab_bar(frame: &mut Frame, area: Rect, active_tab: &Tab, dirty: bool) {
@@ -161,7 +222,7 @@ pub fn help_content() -> Vec<Line<'static>> {
 }
 
 /// Render a centered help popup listing all keybindings.
-pub fn render_help_overlay(frame: &mut Frame, area: Rect, scroll: &mut ScrollState) {
+pub fn render_help_overlay(frame: &mut Frame, area: Rect, scroll: &mut ScrollState) -> ModalInner {
     let help_lines = help_content();
 
     let modal = ModalOverlay {
@@ -184,10 +245,11 @@ pub fn render_help_overlay(frame: &mut Frame, area: Rect, scroll: &mut ScrollSta
 
     let para = Paragraph::new(visible).alignment(Alignment::Left);
     frame.render_widget(para, inner.area);
+    inner
 }
 
 /// Render a confirmation dialog.
-pub fn render_confirm_overlay(frame: &mut Frame, area: Rect, prompt: &str) {
+pub fn render_confirm_overlay(frame: &mut Frame, area: Rect, prompt: &str) -> ModalInner {
     let modal = ModalOverlay {
         width_pct: 50,
         height: ModalHeight::Percent(20),
@@ -203,6 +265,7 @@ pub fn render_confirm_overlay(frame: &mut Frame, area: Rect, prompt: &str) {
 
     let para = Paragraph::new(text).alignment(Alignment::Center);
     frame.render_widget(para, inner.area);
+    inner
 }
 
 /// Render a scrollable diff overlay for save review.
@@ -211,7 +274,7 @@ pub fn render_diff_overlay(
     area: Rect,
     diff_lines: &[DiffLine],
     scroll: &mut ScrollState,
-) {
+) -> ModalInner {
     let total = diff_lines.len();
     // Use the previous frame's real viewport for scroll_info (avoids estimate).
     // On the very first frame viewport is 0, so scroll_info won't show — that's
@@ -266,6 +329,7 @@ pub fn render_diff_overlay(
 
     let para = Paragraph::new(visible_lines);
     frame.render_widget(para, inner.area);
+    inner
 }
 
 /// A line in a diff display.
@@ -320,6 +384,8 @@ pub struct ModalOverlay<'a> {
 /// The inner area returned by [`ModalOverlay::render_chrome`].
 pub struct ModalInner {
     pub area: Rect,
+    /// (rect, key_code) for each parseable footer button.
+    pub footer_buttons: Vec<(Rect, KeyCode)>,
 }
 
 // ---------------------------------------------------------------------------
@@ -423,18 +489,35 @@ impl ModalOverlay<'_> {
 
         frame.render_widget(Clear, popup);
 
+        let mut footer_buttons: Vec<(Rect, KeyCode)> = Vec::new();
+
         // Build footer line from key-hint pairs
         let mut block = Block::default()
             .borders(Borders::ALL)
             .border_style(Style::default().fg(self.border_color))
             .title(format!(" {} ", self.title));
 
+        // Track button char offsets (from the start of the footer text) so we
+        // can compute screen rects after we know the right-aligned x origin.
+        // Each entry: (offset_in_footer, width, KeyCode).
+        let mut button_offsets: Vec<(u16, u16, KeyCode)> = Vec::new();
+
         if !self.footer.is_empty() || self.footer_right.is_some() {
             let mut spans: Vec<Span> = Vec::new();
+            let mut char_offset: u16 = 0;
+
             spans.push(Span::raw(" "));
+            char_offset += 1;
+
             for (i, (key, desc)) in self.footer.iter().enumerate() {
                 if i > 0 {
                     spans.push(Span::styled("  ", Style::default().fg(Color::DarkGray)));
+                    char_offset += 2;
+                }
+                let button_text = format!("{key} {desc}");
+                let button_width = button_text.len() as u16;
+                if let Some(kc) = parse_hint_key(key) {
+                    button_offsets.push((char_offset, button_width, kc));
                 }
                 spans.push(Span::styled(
                     *key,
@@ -442,18 +525,38 @@ impl ModalOverlay<'_> {
                         .fg(Color::Yellow)
                         .add_modifier(Modifier::BOLD),
                 ));
+                char_offset += key.len() as u16;
                 spans.push(Span::styled(
                     format!(" {desc}"),
                     Style::default().fg(Color::DarkGray),
                 ));
+                char_offset += 1 + desc.len() as u16;
             }
             if let Some(ref right) = self.footer_right {
+                let right_text = format!(" {right}");
                 spans.push(Span::styled(
-                    format!(" {right}"),
+                    right_text.clone(),
                     Style::default().fg(Color::DarkGray),
                 ));
+                char_offset += right_text.len() as u16;
             }
             spans.push(Span::raw(" "));
+            char_offset += 1;
+
+            // The footer is right-aligned: ratatui places it so the last char
+            // sits just inside the right border.
+            // footer_x = popup.x + popup.width - 1 (right border) - char_offset
+            let total_footer_width = char_offset;
+            let footer_x = popup
+                .x
+                .saturating_add(popup.width.saturating_sub(1 + total_footer_width));
+            let footer_y = popup.y + popup.height.saturating_sub(1);
+
+            // Convert button offsets to screen-space Rects
+            for (off, w, kc) in &button_offsets {
+                footer_buttons.push((Rect::new(footer_x + off, footer_y, *w, 1), *kc));
+            }
+
             block = block.title_bottom(Line::from(spans).alignment(Alignment::Right));
         }
 
@@ -491,7 +594,10 @@ impl ModalOverlay<'_> {
             inner
         };
 
-        ModalInner { area: content_area }
+        ModalInner {
+            area: content_area,
+            footer_buttons,
+        }
     }
 }
 
@@ -510,4 +616,255 @@ pub fn centered_rect(percent_x: u16, percent_y: u16, area: Rect) -> Rect {
         Constraint::Percentage((100 - percent_x) / 2),
     ])
     .split(vertical[1])[1]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ratatui::Terminal;
+    use ratatui::backend::TestBackend;
+
+    // -- parse_hint_key -------------------------------------------------------
+
+    #[test]
+    fn parse_hint_key_single_char() {
+        assert!(matches!(parse_hint_key("y"), Some(KeyCode::Char('y'))));
+        assert!(matches!(parse_hint_key("n"), Some(KeyCode::Char('n'))));
+        assert!(matches!(parse_hint_key("a"), Some(KeyCode::Char('a'))));
+        assert!(matches!(parse_hint_key("s"), Some(KeyCode::Char('s'))));
+        assert!(matches!(parse_hint_key("b"), Some(KeyCode::Char('b'))));
+        assert!(matches!(parse_hint_key("t"), Some(KeyCode::Char('t'))));
+        assert!(matches!(parse_hint_key("?"), Some(KeyCode::Char('?'))));
+    }
+
+    #[test]
+    fn parse_hint_key_named_keys() {
+        assert!(matches!(parse_hint_key("Enter"), Some(KeyCode::Enter)));
+        assert!(matches!(parse_hint_key("Esc"), Some(KeyCode::Esc)));
+        assert!(matches!(parse_hint_key("Tab"), Some(KeyCode::Tab)));
+    }
+
+    #[test]
+    fn parse_hint_key_multi_key_returns_none() {
+        assert!(parse_hint_key("j/k").is_none());
+        assert!(parse_hint_key("←/→").is_none());
+        assert!(parse_hint_key("any key").is_none());
+        assert!(parse_hint_key("try").is_none());
+        assert!(parse_hint_key("J/K").is_none());
+    }
+
+    // -- ClickRegions::hit ----------------------------------------------------
+
+    #[test]
+    fn hit_returns_none_when_empty() {
+        let cr = ClickRegions::default();
+        assert!(cr.hit(10, 10).is_none());
+    }
+
+    #[test]
+    fn hit_returns_action_when_inside_region() {
+        let mut cr = ClickRegions::default();
+        cr.push(Rect::new(5, 5, 10, 1), ClickAction::Key(KeyCode::Char('y')));
+        // Inside
+        assert!(matches!(
+            cr.hit(5, 5),
+            Some(ClickAction::Key(KeyCode::Char('y')))
+        ));
+        assert!(matches!(
+            cr.hit(14, 5),
+            Some(ClickAction::Key(KeyCode::Char('y')))
+        ));
+        // Outside
+        assert!(cr.hit(4, 5).is_none());
+        assert!(cr.hit(15, 5).is_none());
+        assert!(cr.hit(10, 4).is_none());
+        assert!(cr.hit(10, 6).is_none());
+    }
+
+    #[test]
+    fn hit_returns_most_specific_last_added_region() {
+        let mut cr = ClickRegions::default();
+        // Broad region first (field row)
+        cr.push(Rect::new(0, 10, 80, 1), ClickAction::FormField(0));
+        // Narrow region second (inline option)
+        cr.push(
+            Rect::new(20, 10, 8, 1),
+            ClickAction::SelectOption {
+                field: 0,
+                option: 1,
+            },
+        );
+
+        // Click inside the narrow region → gets the more-specific action
+        assert!(matches!(
+            cr.hit(22, 10),
+            Some(ClickAction::SelectOption {
+                field: 0,
+                option: 1
+            })
+        ));
+        // Click outside the narrow region but inside the broad one → gets FormField
+        assert!(matches!(cr.hit(5, 10), Some(ClickAction::FormField(0))));
+    }
+
+    #[test]
+    fn hit_clear_removes_all_regions() {
+        let mut cr = ClickRegions::default();
+        cr.push(Rect::new(0, 0, 80, 24), ClickAction::Key(KeyCode::Enter));
+        assert!(cr.hit(10, 10).is_some());
+        cr.clear();
+        assert!(cr.hit(10, 10).is_none());
+    }
+
+    // -- Footer button rects via render_chrome --------------------------------
+
+    #[test]
+    fn render_chrome_produces_footer_buttons_for_parseable_hints() {
+        let backend = TestBackend::new(80, 24);
+        let mut terminal = Terminal::new(backend).unwrap();
+
+        terminal
+            .draw(|frame| {
+                let area = frame.area();
+                let modal = ModalOverlay {
+                    width_pct: 50,
+                    height: ModalHeight::Percent(20),
+                    border_color: Color::Yellow,
+                    title: "Test",
+                    footer: &[("y", "yes"), ("n", "no")],
+                    footer_right: None,
+                    scroll: None,
+                };
+                let inner = modal.render_chrome(frame, area);
+
+                // Both "y" and "n" are parseable single-char keys
+                assert_eq!(inner.footer_buttons.len(), 2);
+
+                let (rect_y, kc_y) = &inner.footer_buttons[0];
+                assert!(matches!(kc_y, KeyCode::Char('y')));
+
+                let (rect_n, kc_n) = &inner.footer_buttons[1];
+                assert!(matches!(kc_n, KeyCode::Char('n')));
+
+                // Both rects should be on the same row (the bottom border)
+                assert_eq!(rect_y.y, rect_n.y, "both buttons on same row");
+                // The row should be within the terminal area
+                assert!(rect_y.y < area.height, "button row within terminal");
+
+                // Rects should have width matching "y yes" (5) and "n no" (4)
+                assert_eq!(rect_y.width, 5, "y-button width = 'y yes'");
+                assert_eq!(rect_n.width, 4, "n-button width = 'n no'");
+
+                // n-button should start after y-button + 2-char separator
+                assert_eq!(
+                    rect_n.x,
+                    rect_y.x + rect_y.width + 2,
+                    "n-button follows y-button with separator gap"
+                );
+            })
+            .unwrap();
+    }
+
+    #[test]
+    fn render_chrome_skips_unparseable_footer_hints() {
+        let backend = TestBackend::new(80, 24);
+        let mut terminal = Terminal::new(backend).unwrap();
+
+        terminal
+            .draw(|frame| {
+                let area = frame.area();
+                let modal = ModalOverlay {
+                    width_pct: 60,
+                    height: ModalHeight::Percent(70),
+                    border_color: Color::Cyan,
+                    title: "Help",
+                    footer: &[("j/k", "scroll"), ("any key", "close")],
+                    footer_right: None,
+                    scroll: None,
+                };
+                let inner = modal.render_chrome(frame, area);
+
+                // Neither "j/k" nor "any key" is parseable → no buttons
+                assert_eq!(inner.footer_buttons.len(), 0);
+            })
+            .unwrap();
+    }
+
+    #[test]
+    fn render_chrome_mixed_parseable_and_unparseable() {
+        let backend = TestBackend::new(100, 30);
+        let mut terminal = Terminal::new(backend).unwrap();
+
+        terminal
+            .draw(|frame| {
+                let area = frame.area();
+                let modal = ModalOverlay {
+                    width_pct: 80,
+                    height: ModalHeight::Percent(80),
+                    border_color: Color::Cyan,
+                    title: "Save Review",
+                    footer: &[("y", "confirm"), ("n", "cancel"), ("j/k", "scroll")],
+                    footer_right: None,
+                    scroll: None,
+                };
+                let inner = modal.render_chrome(frame, area);
+
+                // Only "y" and "n" are parseable; "j/k" is not
+                assert_eq!(inner.footer_buttons.len(), 2);
+                assert!(matches!(inner.footer_buttons[0].1, KeyCode::Char('y')));
+                assert!(matches!(inner.footer_buttons[1].1, KeyCode::Char('n')));
+            })
+            .unwrap();
+    }
+
+    #[test]
+    fn footer_button_rects_are_hittable_by_click_regions() {
+        let backend = TestBackend::new(80, 24);
+        let mut terminal = Terminal::new(backend).unwrap();
+
+        terminal
+            .draw(|frame| {
+                let area = frame.area();
+                let modal = ModalOverlay {
+                    width_pct: 50,
+                    height: ModalHeight::Percent(20),
+                    border_color: Color::Yellow,
+                    title: "Confirm",
+                    footer: &[("y", "yes"), ("n", "no")],
+                    footer_right: None,
+                    scroll: None,
+                };
+                let inner = modal.render_chrome(frame, area);
+
+                // Feed the footer buttons into a ClickRegions
+                let mut clicks = ClickRegions::default();
+                for (rect, kc) in &inner.footer_buttons {
+                    clicks.push(*rect, ClickAction::Key(*kc));
+                }
+
+                // The "y" button rect should be hittable at its midpoint
+                let (ry, _) = &inner.footer_buttons[0];
+                let hit = clicks.hit(ry.x + ry.width / 2, ry.y);
+                assert!(
+                    matches!(hit, Some(ClickAction::Key(KeyCode::Char('y')))),
+                    "clicking center of y-button should yield Key('y')"
+                );
+
+                // The "n" button rect should be hittable
+                let (rn, _) = &inner.footer_buttons[1];
+                let hit = clicks.hit(rn.x + rn.width / 2, rn.y);
+                assert!(
+                    matches!(hit, Some(ClickAction::Key(KeyCode::Char('n')))),
+                    "clicking center of n-button should yield Key('n')"
+                );
+
+                // Clicking outside both buttons on the same row → no hit
+                let outside_x = if ry.x > 0 { ry.x - 1 } else { rn.x + rn.width };
+                assert!(
+                    clicks.hit(outside_x, ry.y).is_none(),
+                    "clicking outside footer buttons should miss"
+                );
+            })
+            .unwrap();
+    }
 }


### PR DESCRIPTION
- Welcome/BaseTools steps now require Enter instead of any key
- Esc opens a "Skip the walkthrough?" y/n confirm dialog
- Pressing 'n' returns to the walkthrough, 'y' skips it
- Add 'b' key to go back to the previous walkthrough step
- Reorder footer/status hints: Esc left, action key right