### PR TITLE
feat(tui): abort init flow when user quits walkthrough

### DIFF
--- a/clash/src/cmd/doctor.rs
+++ b/clash/src/cmd/doctor.rs
@@ -252,9 +252,15 @@ fn run_onboard() -> Result<()> {
         CheckResult::Fail(_) => {
             if offer_fix(OnboardFix::CreatePolicy)? {
                 ui::progress("Launching policy editor...");
-                match crate::cmd::init::write_starter_policy() {
-                    Ok(path) => match crate::tui::run_with_options(&path, false, true) {
-                        Ok(()) => fixed += 1,
+                match crate::cmd::init::ensure_starter_policy() {
+                    Ok((path, created_new)) => match crate::tui::run_with_options(&path, false, true) {
+                        Ok(crate::tui::TuiOutcome::Completed) => fixed += 1,
+                        Ok(crate::tui::TuiOutcome::Aborted) => {
+                            if created_new {
+                                let _ = std::fs::remove_file(&path);
+                            }
+                            ui::warn("Policy setup cancelled.");
+                        }
                         Err(e) => {
                             warn!(error = %e, "Policy editor failed during onboard");
                             ui::fail(&format!("Policy creation failed: {e}"));

--- a/clash/src/cmd/init.rs
+++ b/clash/src/cmd/init.rs
@@ -9,7 +9,10 @@ use crate::ui;
 
 #[derive(Default)]
 struct InitActions {
+    /// Whether a new policy file was created (false when one already existed).
     policy_created: bool,
+    /// Whether the policy was reviewed/edited via the TUI (true even for existing policies).
+    policy_reviewed: bool,
     plugin_installed: bool,
     statusline_installed: bool,
 }
@@ -60,7 +63,19 @@ pub fn run(agent: Option<AgentKind>) -> Result<()> {
 
     let mut actions = InitActions::default();
 
-    let policy_path = write_starter_policy()?;
+    let (policy_path, created_new) = ensure_starter_policy()?;
+    let outcome = crate::tui::run_with_options(&policy_path, false, true)?;
+    if outcome == crate::tui::TuiOutcome::Aborted {
+        if created_new {
+            let _ = std::fs::remove_file(&policy_path);
+        }
+        println!();
+        ui::warn("Setup cancelled. Run `clash init` to try again.");
+        return Ok(());
+    }
+    actions.policy_created = created_new;
+    actions.policy_reviewed = true;
+
     actions.plugin_installed = install_agent_plugin(agent)?;
     if agent == AgentKind::Claude {
         if let Err(e) = super::statusline::install() {
@@ -69,22 +84,26 @@ pub fn run(agent: Option<AgentKind>) -> Result<()> {
             actions.statusline_installed = true;
         }
     }
-    crate::tui::run_with_options(&policy_path, false, true)?;
-    actions.policy_created = true;
     print_summary(&actions, agent);
 
     Ok(())
 }
 
-/// Write the starter policy.star for onboarding.
+/// Ensure a compiled policy file exists, writing the starter template only if
+/// one doesn't already exist.
 ///
-/// Writes the default policy template as a `.star` file, and compiles it to
-/// a `.json` sibling for the runtime to consume.
-pub fn write_starter_policy() -> Result<std::path::PathBuf> {
+/// Returns `(path, created_new)` — callers use `created_new` to decide whether
+/// cleanup is safe on abort (only delete what we created).
+pub fn ensure_starter_policy() -> Result<(std::path::PathBuf, bool)> {
     use crate::settings::compile_default_policy_to_json;
 
     let policy_path = ClashSettings::policy_file()?;
     let json_path = policy_path.with_extension("json");
+
+    if json_path.exists() {
+        return Ok((json_path, false));
+    }
+
     let dir = json_path
         .parent()
         .context("policy file path has no parent directory")?;
@@ -94,7 +113,7 @@ pub fn write_starter_policy() -> Result<std::path::PathBuf> {
     std::fs::write(&json_path, &json)
         .with_context(|| format!("failed to write {}", json_path.display()))?;
 
-    Ok(json_path)
+    Ok((json_path, true))
 }
 
 // ---------------------------------------------------------------------------
@@ -362,8 +381,10 @@ fn install_copilot_plugin() -> Result<bool> {
 // ---------------------------------------------------------------------------
 
 fn print_summary(actions: &InitActions, agent: AgentKind) {
-    let any_action =
-        actions.policy_created || actions.plugin_installed || actions.statusline_installed;
+    let any_action = actions.policy_created
+        || actions.policy_reviewed
+        || actions.plugin_installed
+        || actions.statusline_installed;
     if !any_action {
         return;
     }
@@ -377,6 +398,8 @@ fn print_summary(actions: &InitActions, agent: AgentKind) {
 
     if actions.policy_created {
         ui::success("Policy created");
+    } else if actions.policy_reviewed {
+        ui::success("Policy reviewed");
     }
     if actions.plugin_installed {
         ui::success(&format!("Clash plugin installed for {agent}"));

--- a/clash/src/cmd/policy.rs
+++ b/clash/src/cmd/policy.rs
@@ -534,7 +534,8 @@ fn handle_edit(scope: Option<String>, raw: bool, test: bool) -> Result<()> {
 
     // Interactive TUI editor
     let path = resolve_manifest_path(scope)?;
-    crate::tui::run_with_options(&path, test, false)
+    crate::tui::run_with_options(&path, test, false)?;
+    Ok(())
 }
 
 // ---------------------------------------------------------------------------

--- a/clash/src/tui/app.rs
+++ b/clash/src/tui/app.rs
@@ -17,6 +17,7 @@ use similar::TextDiff;
 use crate::policy::match_tree::{CompiledPolicy, Node, PolicyManifest};
 use crate::policy_loader;
 
+use super::TuiOutcome;
 use super::includes_view::IncludesView;
 use super::inline_form::{FormEvent, FormState};
 use super::sandbox_view::SandboxView;
@@ -50,6 +51,8 @@ enum Mode {
 enum ConfirmAction {
     Quit,
     SkipWalkthrough,
+    /// Quit the editor entirely during walkthrough, discarding any changes.
+    QuitWalkthrough,
 }
 
 /// State for the diff review overlay.
@@ -176,7 +179,8 @@ impl App {
     pub fn run<B: Backend<Error: Send + Sync + 'static>>(
         &mut self,
         terminal: &mut Terminal<B>,
-    ) -> Result<()> {
+    ) -> Result<TuiOutcome> {
+        let mut outcome = TuiOutcome::Completed;
         loop {
             // Clone manifest for view to avoid borrow issues
             let manifest_snapshot = self.manifest.clone();
@@ -265,6 +269,9 @@ impl App {
             if matches!(self.mode, Mode::Walkthrough) {
                 if let Some(ref mut wt) = self.walkthrough {
                     match key.code {
+                        KeyCode::Char('q') => {
+                            self.mode = Mode::Confirm(ConfirmAction::QuitWalkthrough);
+                        }
                         KeyCode::Esc => {
                             self.mode = Mode::Confirm(ConfirmAction::SkipWalkthrough);
                         }
@@ -387,6 +394,10 @@ impl App {
                 let action = self.update_msg(msg);
                 match action {
                     Action::Quit => break,
+                    Action::Abort => {
+                        outcome = TuiOutcome::Aborted;
+                        break;
+                    }
                     Action::Modified => {
                         self.dirty = true;
                         self.rebuild_views();
@@ -403,7 +414,7 @@ impl App {
                 }
             }
         }
-        Ok(())
+        Ok(outcome)
     }
 
     /// Handle a key event when in Form mode.
@@ -621,6 +632,10 @@ impl App {
                 let mode = std::mem::replace(&mut self.mode, Mode::Normal);
                 match mode {
                     Mode::Confirm(ConfirmAction::Quit) => Action::Quit,
+                    Mode::Confirm(ConfirmAction::QuitWalkthrough) => {
+                        self.walkthrough = None;
+                        Action::Abort
+                    }
                     Mode::Confirm(ConfirmAction::SkipWalkthrough) => {
                         self.walkthrough = None;
                         Action::Flash("Walkthrough skipped — press ? for help".into())
@@ -669,7 +684,9 @@ impl App {
             }
             Msg::ConfirmNo => {
                 match &self.mode {
-                    Mode::Confirm(ConfirmAction::SkipWalkthrough) => {
+                    Mode::Confirm(
+                        ConfirmAction::SkipWalkthrough | ConfirmAction::QuitWalkthrough,
+                    ) => {
                         self.mode = Mode::Walkthrough;
                     }
                     _ => {
@@ -883,6 +900,9 @@ impl App {
                 let prompt = match action {
                     ConfirmAction::Quit => "Unsaved changes. Quit anyway?",
                     ConfirmAction::SkipWalkthrough => "Skip the walkthrough?",
+                    ConfirmAction::QuitWalkthrough => {
+                        "Quit without saving? Your policy will remain unchanged."
+                    }
                 };
                 let inner = widgets::render_confirm_overlay(frame, area, prompt);
                 for (rect, kc) in &inner.footer_buttons {
@@ -979,13 +999,36 @@ mod tests {
     /// Simulate pressing a key and rendering the result.
     /// Panics if the render crashes.
     fn press_and_render(app: &mut App, terminal: &mut Terminal<TestBackend>, key_event: KeyEvent) {
-        // Handle key
-        if matches!(app.mode, Mode::Form(_)) {
+        // Handle key — mirror the event loop dispatch order
+        if matches!(app.mode, Mode::Walkthrough) {
+            if let Some(ref mut wt) = app.walkthrough {
+                match key_event.code {
+                    KeyCode::Char('q') => {
+                        app.mode = Mode::Confirm(ConfirmAction::QuitWalkthrough);
+                    }
+                    KeyCode::Esc => {
+                        app.mode = Mode::Confirm(ConfirmAction::SkipWalkthrough);
+                    }
+                    KeyCode::Char('j') | KeyCode::Down => wt.scroll.scroll_down(),
+                    KeyCode::Char('k') | KeyCode::Up => wt.scroll.scroll_up(),
+                    KeyCode::Char('b') => wt.go_back(),
+                    KeyCode::Enter
+                        if matches!(
+                            wt.step,
+                            WalkthroughStep::Welcome | WalkthroughStep::BaseTools
+                        ) =>
+                    {
+                        wt.advance();
+                    }
+                    _ => {}
+                }
+            }
+        } else if matches!(app.mode, Mode::Form(_)) {
             let FormHandled::Continue = app.handle_form_key(key_event);
         } else if let Some(msg) = app.handle_key(key_event) {
             let action = app.update_msg(msg);
             match action {
-                Action::Quit => {}
+                Action::Quit | Action::Abort => {}
                 Action::Modified => {
                     app.dirty = true;
                     app.rebuild_views();
@@ -1227,6 +1270,95 @@ mod tests {
         assert!(
             clicks.is_empty(),
             "help overlay should have 0 click regions since no hints are single-key parseable"
+        );
+    }
+
+    // -- Walkthrough quit tests -----------------------------------------------
+
+    #[test]
+    fn walkthrough_q_opens_quit_confirm() {
+        let manifest = empty_manifest();
+        let mut app = App::new(PathBuf::from("/tmp/test.json"), manifest).unwrap();
+        app.start_walkthrough();
+        let backend = TestBackend::new(80, 24);
+        let mut terminal = Terminal::new(backend).unwrap();
+
+        // Initial render
+        let snap = app.manifest.clone();
+        terminal
+            .draw(|frame| app.view(frame, frame.area(), &snap))
+            .unwrap();
+
+        assert!(matches!(app.mode, Mode::Walkthrough));
+
+        // Press 'q' → should open QuitWalkthrough confirm
+        press_and_render(&mut app, &mut terminal, key(KeyCode::Char('q')));
+        assert!(matches!(
+            app.mode,
+            Mode::Confirm(ConfirmAction::QuitWalkthrough)
+        ));
+    }
+
+    #[test]
+    fn walkthrough_quit_confirm_yes_exits() {
+        let manifest = empty_manifest();
+        let mut app = App::new(PathBuf::from("/tmp/test.json"), manifest).unwrap();
+        app.start_walkthrough();
+
+        // Simulate 'q' → opens confirm
+        app.mode = Mode::Confirm(ConfirmAction::QuitWalkthrough);
+
+        // 'y' → should trigger Abort action
+        let msg = app.handle_key(KeyEvent::new(KeyCode::Char('y'), KeyModifiers::empty()));
+        assert!(matches!(msg, Some(Msg::ConfirmYes)));
+        let action = app.update_msg(msg.unwrap());
+        assert!(matches!(action, Action::Abort));
+        assert!(app.walkthrough.is_none(), "walkthrough should be cleared");
+    }
+
+    #[test]
+    fn walkthrough_quit_confirm_no_returns_to_walkthrough() {
+        let manifest = empty_manifest();
+        let mut app = App::new(PathBuf::from("/tmp/test.json"), manifest).unwrap();
+        app.start_walkthrough();
+
+        // Simulate 'q' → opens confirm
+        app.mode = Mode::Confirm(ConfirmAction::QuitWalkthrough);
+
+        // 'n' → should return to walkthrough
+        let msg = app.handle_key(KeyEvent::new(KeyCode::Char('n'), KeyModifiers::empty()));
+        assert!(matches!(msg, Some(Msg::ConfirmNo)));
+        app.update_msg(msg.unwrap());
+        assert!(
+            matches!(app.mode, Mode::Walkthrough),
+            "should return to walkthrough after 'n'"
+        );
+        assert!(
+            app.walkthrough.is_some(),
+            "walkthrough state should be preserved"
+        );
+    }
+
+    #[test]
+    fn walkthrough_q_clickable_in_footer() {
+        let manifest = empty_manifest();
+        let mut app = App::new(PathBuf::from("/tmp/test.json"), manifest).unwrap();
+        app.start_walkthrough();
+        let backend = TestBackend::new(80, 24);
+        let mut terminal = Terminal::new(backend).unwrap();
+
+        // Render to populate click regions
+        let clicks = render_and_snapshot_clicks(&mut app, &mut terminal);
+
+        // Should have a 'q' click region from the left footer
+        let q_regions: Vec<_> = clicks
+            .iter()
+            .filter(|(_, desc)| desc.contains("Key(Char('q'))"))
+            .collect();
+        assert_eq!(
+            q_regions.len(),
+            1,
+            "walkthrough overlay should have a 'q' click region"
         );
     }
 }

--- a/clash/src/tui/inline_form.rs
+++ b/clash/src/tui/inline_form.rs
@@ -2094,6 +2094,7 @@ impl FormState {
                 ("Tab", "next field"),
                 ("Esc", "cancel"),
             ],
+            footer_left: &[],
             footer_right: None,
             scroll: None,
         };

--- a/clash/src/tui/mod.rs
+++ b/clash/src/tui/mod.rs
@@ -29,6 +29,15 @@ use ratatui::backend::CrosstermBackend;
 
 use crate::policy_loader;
 
+/// Outcome of running the TUI.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TuiOutcome {
+    /// User finished normally (saved, quit after editing, etc.).
+    Completed,
+    /// User aborted during onboarding — caller should skip remaining setup.
+    Aborted,
+}
+
 /// Restore the terminal to its normal state.
 ///
 /// Idempotent — safe to call even if the terminal was never fully initialised.
@@ -44,12 +53,16 @@ pub(crate) fn restore_terminal() {
 }
 
 /// Launch the interactive policy editor TUI.
-pub fn run(path: &Path) -> Result<()> {
+pub fn run(path: &Path) -> Result<TuiOutcome> {
     run_with_options(path, false, false)
 }
 
 /// Launch the TUI with options.
-pub fn run_with_options(path: &Path, show_test_panel: bool, onboarding: bool) -> Result<()> {
+pub fn run_with_options(
+    path: &Path,
+    show_test_panel: bool,
+    onboarding: bool,
+) -> Result<TuiOutcome> {
     let manifest = policy_loader::read_manifest(path)
         .with_context(|| format!("failed to read {}", path.display()))?;
 
@@ -78,7 +91,7 @@ pub fn run_with_options(path: &Path, show_test_panel: bool, onboarding: bool) ->
 }
 
 /// Set up the terminal, run the TUI, and always restore before returning.
-fn setup_and_run(app: &mut app::App) -> Result<()> {
+fn setup_and_run(app: &mut app::App) -> Result<TuiOutcome> {
     enable_raw_mode()?;
 
     // Once raw mode is active we must restore no matter what, so run the rest

--- a/clash/src/tui/tea.rs
+++ b/clash/src/tui/tea.rs
@@ -15,6 +15,9 @@ pub enum Action {
     None,
     /// The component wants to quit.
     Quit,
+    /// The user aborted the onboarding walkthrough — caller should skip
+    /// remaining setup steps.
+    Abort,
     /// The manifest was modified — mark dirty.
     Modified,
     /// Request a dialoguer form (exits raw mode).

--- a/clash/src/tui/walkthrough.rs
+++ b/clash/src/tui/walkthrough.rs
@@ -92,6 +92,8 @@ impl WalkthroughState {
     }
 }
 
+type HintSlice = &'static [(&'static str, &'static str)];
+
 /// Render the walkthrough coach-mark overlay for the current step.
 ///
 /// Only renders for steps that show an overlay (not FillForm — that's
@@ -103,7 +105,7 @@ pub fn render_walkthrough_overlay(
     scroll: &mut ScrollState,
     clicks: &mut ClickRegions,
 ) {
-    let (content, footer): (Vec<Line>, &[(&str, &str)]) = match step {
+    let (content, footer, footer_left): (Vec<Line>, HintSlice, HintSlice) = match step {
         WalkthroughStep::Welcome => (
             vec![
                 styled_title("Welcome to the Policy Editor"),
@@ -115,6 +117,7 @@ pub fn render_walkthrough_overlay(
                 Line::from("Let's walk through your starter policy."),
             ],
             &[("Esc", "skip"), ("Enter", "continue")],
+            &[("q", "quit")],
         ),
         WalkthroughStep::BaseTools => (
             vec![
@@ -134,6 +137,7 @@ pub fn render_walkthrough_overlay(
                 Line::from("can add sandboxes for finer-grained control."),
             ],
             &[("Esc", "skip"), ("b", "back"), ("Enter", "continue")],
+            &[("q", "quit")],
         ),
         WalkthroughStep::AddRule => (
             vec![
@@ -146,6 +150,7 @@ pub fn render_walkthrough_overlay(
                 key_hint("a", "add a new rule"),
             ],
             &[("Esc", "skip"), ("b", "back"), ("a", "add rule")],
+            &[("q", "quit")],
         ),
         WalkthroughStep::FillForm => {
             // Overlay not rendered — form is visible with its own hints.
@@ -165,6 +170,7 @@ pub fn render_walkthrough_overlay(
                 key_hint("t", "open the test console"),
             ],
             &[("Esc", "skip"), ("b", "back"), ("t", "test console")],
+            &[("q", "quit")],
         ),
         WalkthroughStep::TypeTest => {
             // Test panel is focused — don't overlay, just let status bar guide.
@@ -182,6 +188,7 @@ pub fn render_walkthrough_overlay(
                 dim_hint("Come back anytime with: clash policy edit"),
             ],
             &[("Esc", "skip"), ("b", "back"), ("s", "save")],
+            &[("q", "quit")],
         ),
         WalkthroughStep::Done => return,
     };
@@ -195,6 +202,7 @@ pub fn render_walkthrough_overlay(
         border_color: Color::Cyan,
         title: "Walkthrough",
         footer,
+        footer_left,
         footer_right: None,
         scroll: Some(scroll.to_modal_scroll()),
     };
@@ -217,9 +225,14 @@ pub fn render_walkthrough_overlay(
 /// Status bar hints for each walkthrough step.
 pub fn walkthrough_status_hints(step: WalkthroughStep) -> Vec<(&'static str, &'static str)> {
     match step {
-        WalkthroughStep::Welcome => vec![("Esc", "skip walkthrough"), ("Enter", "continue")],
+        WalkthroughStep::Welcome => vec![
+            ("q", "quit"),
+            ("Esc", "skip walkthrough"),
+            ("Enter", "continue"),
+        ],
         WalkthroughStep::BaseTools => {
             vec![
+                ("q", "quit"),
                 ("Esc", "skip walkthrough"),
                 ("b", "back"),
                 ("Enter", "continue"),
@@ -227,6 +240,7 @@ pub fn walkthrough_status_hints(step: WalkthroughStep) -> Vec<(&'static str, &'s
         }
         WalkthroughStep::AddRule => {
             vec![
+                ("q", "quit"),
                 ("Esc", "skip walkthrough"),
                 ("b", "back"),
                 ("a", "add rule"),
@@ -240,6 +254,7 @@ pub fn walkthrough_status_hints(step: WalkthroughStep) -> Vec<(&'static str, &'s
         ],
         WalkthroughStep::TestIt => {
             vec![
+                ("q", "quit"),
                 ("Esc", "skip walkthrough"),
                 ("b", "back"),
                 ("t", "test console"),
@@ -251,7 +266,12 @@ pub fn walkthrough_status_hints(step: WalkthroughStep) -> Vec<(&'static str, &'s
             ("Esc", "skip walkthrough"),
         ],
         WalkthroughStep::SaveFinish => {
-            vec![("Esc", "skip walkthrough"), ("b", "back"), ("s", "save")]
+            vec![
+                ("q", "quit"),
+                ("Esc", "skip walkthrough"),
+                ("b", "back"),
+                ("s", "save"),
+            ]
         }
         WalkthroughStep::Done => vec![],
     }

--- a/clash/src/tui/widgets.rs
+++ b/clash/src/tui/widgets.rs
@@ -231,6 +231,7 @@ pub fn render_help_overlay(frame: &mut Frame, area: Rect, scroll: &mut ScrollSta
         border_color: Color::Cyan,
         title: "Help",
         footer: &[("j/k", "scroll"), ("any key", "close")],
+        footer_left: &[],
         footer_right: None,
         scroll: Some(scroll.to_modal_scroll()),
     };
@@ -256,6 +257,7 @@ pub fn render_confirm_overlay(frame: &mut Frame, area: Rect, prompt: &str) -> Mo
         border_color: Color::Yellow,
         title: "Confirm",
         footer: &[("y", "yes"), ("n", "no")],
+        footer_left: &[],
         footer_right: None,
         scroll: None,
     };
@@ -297,6 +299,7 @@ pub fn render_diff_overlay(
         border_color: Color::Cyan,
         title: "Save Review",
         footer: &[("y", "confirm"), ("n", "cancel"), ("j/k", "scroll")],
+        footer_left: &[],
         footer_right: scroll_info,
         scroll: Some(scroll.to_modal_scroll()),
     };
@@ -373,10 +376,12 @@ pub struct ModalOverlay<'a> {
     pub height: ModalHeight,
     pub border_color: Color,
     pub title: &'a str,
-    /// Key-hint pairs rendered as `title_bottom`; empty slice = no footer.
+    /// Key-hint pairs rendered right-aligned in the bottom border; empty = no footer.
     pub footer: &'a [(&'a str, &'a str)],
     /// Optional right-aligned footer text, e.g. scroll position "[3-10/20]".
     pub footer_right: Option<String>,
+    /// Key-hint pairs rendered left-aligned in the bottom border.
+    pub footer_left: &'a [(&'a str, &'a str)],
     /// When set, a vertical scrollbar is rendered on the right edge if content overflows.
     pub scroll: Option<ModalScroll>,
 }
@@ -560,6 +565,45 @@ impl ModalOverlay<'_> {
             block = block.title_bottom(Line::from(spans).alignment(Alignment::Right));
         }
 
+        // Left-aligned footer hints
+        if !self.footer_left.is_empty() {
+            let mut spans: Vec<Span> = Vec::new();
+            let mut char_offset: u16 = 0;
+
+            spans.push(Span::raw(" "));
+            char_offset += 1;
+
+            for (i, (key, desc)) in self.footer_left.iter().enumerate() {
+                if i > 0 {
+                    spans.push(Span::styled("  ", Style::default().fg(Color::DarkGray)));
+                    char_offset += 2;
+                }
+                let button_text = format!("{key} {desc}");
+                let button_width = button_text.len() as u16;
+                if let Some(kc) = parse_hint_key(key) {
+                    // Left-aligned: x starts at popup.x + 1 (inside left border)
+                    let btn_x = popup.x + 1 + char_offset;
+                    let btn_y = popup.y + popup.height.saturating_sub(1);
+                    footer_buttons.push((Rect::new(btn_x, btn_y, button_width, 1), kc));
+                }
+                spans.push(Span::styled(
+                    *key,
+                    Style::default()
+                        .fg(Color::Yellow)
+                        .add_modifier(Modifier::BOLD),
+                ));
+                char_offset += key.len() as u16;
+                spans.push(Span::styled(
+                    format!(" {desc}"),
+                    Style::default().fg(Color::DarkGray),
+                ));
+                char_offset += 1 + desc.len() as u16;
+            }
+            spans.push(Span::raw(" "));
+
+            block = block.title_bottom(Line::from(spans).alignment(Alignment::Left));
+        }
+
         let inner = block.inner(popup);
         frame.render_widget(block, popup);
 
@@ -732,6 +776,7 @@ mod tests {
                     border_color: Color::Yellow,
                     title: "Test",
                     footer: &[("y", "yes"), ("n", "no")],
+                    footer_left: &[],
                     footer_right: None,
                     scroll: None,
                 };
@@ -779,6 +824,7 @@ mod tests {
                     border_color: Color::Cyan,
                     title: "Help",
                     footer: &[("j/k", "scroll"), ("any key", "close")],
+                    footer_left: &[],
                     footer_right: None,
                     scroll: None,
                 };
@@ -804,6 +850,7 @@ mod tests {
                     border_color: Color::Cyan,
                     title: "Save Review",
                     footer: &[("y", "confirm"), ("n", "cancel"), ("j/k", "scroll")],
+                    footer_left: &[],
                     footer_right: None,
                     scroll: None,
                 };
@@ -831,6 +878,7 @@ mod tests {
                     border_color: Color::Yellow,
                     title: "Confirm",
                     footer: &[("y", "yes"), ("n", "no")],
+                    footer_left: &[],
                     footer_right: None,
                     scroll: None,
                 };


### PR DESCRIPTION
## Summary

- Quitting the walkthrough with `q` → `y` now fully aborts the `clash init` / `clash doctor --fix` flow instead of just exiting the TUI
- The starter policy file is cleaned up on abort, plugin installation is skipped, and the user sees "Setup cancelled. Run `clash init` to try again."
- Introduces `TuiOutcome` enum (`Completed` / `Aborted`) so callers can distinguish normal exit from walkthrough abort
- Adds `Action::Abort` variant to the TEA action type

## Test plan

- [x] `cargo check -p clash` — compiles cleanly
- [x] `cargo clippy -p clash` — no warnings
- [x] `cargo test -p clash --lib -- tui::` — all 68 tests pass
- [ ] Manual: `cargo run -p clash -- init` → press `q` during walkthrough → `y` → verify no "installing" output, policy file removed
- [ ] Manual: `cargo run -p clash -- init` → press `q` during walkthrough → `n` → verify returns to walkthrough