### PR TITLE
feat(tui): add semantic theme system with adaptive terminal support

### DIFF
--- a/clash/src/tui/app.rs
+++ b/clash/src/tui/app.rs
@@ -9,7 +9,6 @@ use ratatui::Frame;
 use ratatui::Terminal;
 use ratatui::backend::Backend;
 use ratatui::layout::{Alignment, Constraint, Layout, Rect};
-use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::Paragraph;
 use similar::TextDiff;
@@ -24,6 +23,7 @@ use super::sandbox_view::SandboxView;
 use super::settings_view::SettingsView;
 use super::tea::{Action, Component};
 use super::test_panel::{self, TestPanel, TestPanelAction};
+use super::theme::{Theme, ViewContext};
 use super::tree_view::TreeView;
 use super::walkthrough::{self, WalkthroughState, WalkthroughStep};
 use super::widgets::{self, ClickAction, ClickRegions, DiffLine, ScrollState};
@@ -105,6 +105,8 @@ pub struct App {
     walkthrough: Option<WalkthroughState>,
     /// Mouse click targets populated each frame during `view()`.
     click_regions: ClickRegions,
+    /// Visual theme for all TUI rendering.
+    theme: Theme,
 }
 
 impl App {
@@ -159,6 +161,7 @@ impl App {
             flash,
             walkthrough: None,
             click_regions: ClickRegions::default(),
+            theme: Theme::from_env(),
         })
     }
 
@@ -612,7 +615,7 @@ impl App {
             Msg::ToggleHelp => {
                 self.mode = match self.mode {
                     Mode::Help(_) => Mode::Normal,
-                    _ => Mode::Help(ScrollState::new(widgets::help_content().len())),
+                    _ => Mode::Help(ScrollState::new(widgets::help_content(&self.theme).len())),
                 };
                 Action::None
             }
@@ -767,6 +770,12 @@ impl App {
     }
 
     fn view(&mut self, frame: &mut Frame, area: Rect, manifest: &PolicyManifest) {
+        let t = &self.theme;
+        let ctx = ViewContext {
+            manifest,
+            theme: t,
+        };
+
         let chunks = Layout::vertical([
             Constraint::Length(2), // title + tab bar
             Constraint::Min(3),    // content
@@ -776,15 +785,10 @@ impl App {
 
         // Title bar
         let title = Line::from(vec![
-            Span::styled(
-                " clash policy editor ",
-                Style::default()
-                    .fg(Color::Cyan)
-                    .add_modifier(Modifier::BOLD),
-            ),
+            Span::styled(" clash policy editor ", t.text_emphasis),
             Span::styled(
                 format!("-- {} ", self.path.display()),
-                Style::default().fg(Color::DarkGray),
+                t.text_disabled,
             ),
         ]);
         frame.render_widget(
@@ -798,6 +802,7 @@ impl App {
             Rect::new(chunks[0].x, chunks[0].y + 1, chunks[0].width, 1),
             &self.active_tab,
             self.dirty,
+            t,
         );
 
         // Content area — split horizontally if test panel is visible
@@ -812,16 +817,16 @@ impl App {
 
         // Active tab content
         match self.active_tab {
-            Tab::Tree => self.tree_view.view(frame, content_area, manifest),
-            Tab::Sandboxes => self.sandbox_view.view(frame, content_area, manifest),
-            Tab::Includes => self.includes_view.view(frame, content_area, manifest),
-            Tab::Settings => self.settings_view.view(frame, content_area, manifest),
+            Tab::Tree => self.tree_view.view(frame, content_area, &ctx),
+            Tab::Sandboxes => self.sandbox_view.view(frame, content_area, &ctx),
+            Tab::Includes => self.includes_view.view(frame, content_area, &ctx),
+            Tab::Settings => self.settings_view.view(frame, content_area, &ctx),
         }
 
         // Test panel (side panel)
         if let Some(area) = test_area {
             self.test_panel
-                .view_with_focus(frame, area, self.test_focused);
+                .view_with_focus(frame, area, self.test_focused, t);
         }
 
         // Status bar
@@ -883,7 +888,7 @@ impl App {
             }
         };
 
-        widgets::render_status_bar(frame, chunks[2], hints, flash_msg);
+        widgets::render_status_bar(frame, chunks[2], hints, flash_msg, t);
 
         // Overlays — take click_regions out to avoid double-borrow with &mut self.mode
         let mut clicks = std::mem::take(&mut self.click_regions);
@@ -891,7 +896,7 @@ impl App {
 
         match &mut self.mode {
             Mode::Help(scroll) => {
-                let inner = widgets::render_help_overlay(frame, area, scroll);
+                let inner = widgets::render_help_overlay(frame, area, scroll, t);
                 for (rect, kc) in &inner.footer_buttons {
                     clicks.push(*rect, ClickAction::Key(*kc));
                 }
@@ -904,20 +909,20 @@ impl App {
                         "Quit without saving? Your policy will remain unchanged."
                     }
                 };
-                let inner = widgets::render_confirm_overlay(frame, area, prompt);
+                let inner = widgets::render_confirm_overlay(frame, area, prompt, t);
                 for (rect, kc) in &inner.footer_buttons {
                     clicks.push(*rect, ClickAction::Key(*kc));
                 }
             }
             Mode::SaveReview(state) => {
                 let inner =
-                    widgets::render_diff_overlay(frame, area, &state.lines, &mut state.scroll);
+                    widgets::render_diff_overlay(frame, area, &state.lines, &mut state.scroll, t);
                 for (rect, kc) in &inner.footer_buttons {
                     clicks.push(*rect, ClickAction::Key(*kc));
                 }
             }
             Mode::Form(form) => {
-                form.view(frame, area, &mut clicks);
+                form.view(frame, area, &mut clicks, t);
             }
             Mode::Walkthrough => {
                 if let Some(wt) = &mut self.walkthrough {
@@ -927,6 +932,7 @@ impl App {
                         wt.step,
                         &mut wt.scroll,
                         &mut clicks,
+                        t,
                     );
                 }
             }

--- a/clash/src/tui/includes_view.rs
+++ b/clash/src/tui/includes_view.rs
@@ -3,11 +3,11 @@
 use crossterm::event::{KeyCode, KeyEvent};
 use ratatui::Frame;
 use ratatui::layout::Rect;
-use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Paragraph};
 
 use super::tea::{Action, Component, FormRequest};
+use super::theme::ViewContext;
 use crate::policy::match_tree::PolicyManifest;
 
 pub struct IncludesView {
@@ -108,27 +108,21 @@ impl Component for IncludesView {
         }
     }
 
-    fn view(&self, frame: &mut Frame, area: Rect, manifest: &PolicyManifest) {
+    fn view(&self, frame: &mut Frame, area: Rect, ctx: &ViewContext) {
+        let t = ctx.theme;
+        let manifest = ctx.manifest;
         let block = Block::default()
             .borders(Borders::LEFT | Borders::RIGHT)
-            .border_style(Style::default().fg(Color::DarkGray));
+            .border_style(t.border_unfocused);
 
         let inner = block.inner(area);
         frame.render_widget(block, area);
 
         if manifest.includes.is_empty() {
             let empty = Paragraph::new(Line::from(vec![
-                Span::styled(
-                    "  No includes. Press ",
-                    Style::default().fg(Color::DarkGray),
-                ),
-                Span::styled(
-                    "a",
-                    Style::default()
-                        .fg(Color::Yellow)
-                        .add_modifier(Modifier::BOLD),
-                ),
-                Span::styled(" to add one.", Style::default().fg(Color::DarkGray)),
+                Span::styled("  No includes. Press ", t.text_disabled),
+                Span::styled("a", t.hint_key),
+                Span::styled(" to add one.", t.text_disabled),
             ]));
             frame.render_widget(empty, inner);
             return;
@@ -140,20 +134,14 @@ impl Component for IncludesView {
             .enumerate()
             .map(|(i, include)| {
                 let style = if i == self.selected {
-                    Style::default()
-                        .bg(Color::DarkGray)
-                        .fg(Color::White)
-                        .add_modifier(Modifier::BOLD)
+                    t.selection
                 } else {
-                    Style::default().fg(Color::White)
+                    t.text_primary
                 };
 
                 let priority = format!("[{}]", i + 1);
                 Line::from(vec![
-                    Span::styled(
-                        format!("  {priority} "),
-                        Style::default().fg(Color::DarkGray),
-                    ),
+                    Span::styled(format!("  {priority} "), t.text_disabled),
                     Span::styled(&include.path, style),
                 ])
             })

--- a/clash/src/tui/inline_form.rs
+++ b/clash/src/tui/inline_form.rs
@@ -7,10 +7,11 @@
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use ratatui::Frame;
 use ratatui::layout::Rect;
-use ratatui::style::{Color, Modifier, Style};
+use ratatui::style::Modifier;
 use ratatui::text::{Line, Span};
 use ratatui::widgets::Paragraph;
 
+use super::theme::Theme;
 use super::widgets::{ClickAction, ClickRegions, ModalHeight, ModalOverlay};
 
 use crate::policy::manifest_edit;
@@ -2070,7 +2071,7 @@ impl FormState {
         self.fields[field_idx].hint()
     }
 
-    pub fn view(&self, frame: &mut Frame, area: Rect, clicks: &mut ClickRegions) {
+    pub fn view(&self, frame: &mut Frame, area: Rect, clicks: &mut ClickRegions, t: &Theme) {
         // Use max possible field count for forms that change visibility dynamically,
         // so the popup stays in a fixed position when cycling options.
         let field_count = match &self.kind {
@@ -2087,7 +2088,7 @@ impl FormState {
                 floor_pct: 30,
                 ceil_pct: 80,
             },
-            border_color: Color::Cyan,
+            border_style: t.border_focused,
             title: &self.title,
             footer: &[
                 ("Enter", "submit"),
@@ -2097,6 +2098,7 @@ impl FormState {
             footer_left: &[],
             footer_right: None,
             scroll: None,
+            theme: Some(t),
         };
         let inner = modal.render_chrome(frame, area);
 
@@ -2133,11 +2135,9 @@ impl FormState {
                     ..
                 } => {
                     let label_style = if is_active {
-                        Style::default()
-                            .fg(Color::White)
-                            .add_modifier(Modifier::BOLD)
+                        t.field_label_active
                     } else {
-                        Style::default().fg(Color::Gray)
+                        t.field_label_inactive
                     };
 
                     let display_value = if value.is_empty() && !is_active {
@@ -2149,11 +2149,11 @@ impl FormState {
                     };
 
                     let value_style = if value.is_empty() && !is_active {
-                        Style::default().fg(Color::DarkGray)
+                        t.field_value_placeholder
                     } else if is_active {
-                        Style::default().fg(Color::White)
+                        t.field_value_active
                     } else {
-                        Style::default().fg(Color::Cyan)
+                        t.field_value_inactive
                     };
 
                     if is_active && !value.is_empty() {
@@ -2168,16 +2168,13 @@ impl FormState {
                         lines.push(Line::from(vec![
                             Span::styled(format!("  {label}: "), label_style),
                             Span::styled(before, value_style),
-                            Span::styled(
-                                cursor_char.to_string(),
-                                Style::default().fg(Color::Black).bg(Color::White),
-                            ),
+                            Span::styled(cursor_char.to_string(), t.cursor),
                             Span::styled(after, value_style),
                         ]));
                     } else if is_active && value.is_empty() {
                         lines.push(Line::from(vec![
                             Span::styled(format!("  {label}: "), label_style),
-                            Span::styled(" ", Style::default().fg(Color::Black).bg(Color::White)),
+                            Span::styled(" ", t.cursor),
                         ]));
                     } else {
                         lines.push(Line::from(vec![
@@ -2193,36 +2190,28 @@ impl FormState {
                     ..
                 } => {
                     let label_style = if is_active {
-                        Style::default()
-                            .fg(Color::White)
-                            .add_modifier(Modifier::BOLD)
+                        t.field_label_active
                     } else {
-                        Style::default().fg(Color::Gray)
+                        t.field_label_inactive
                     };
 
                     if self.is_inline_select(fi) {
                         // Inline mode: show all options, highlight selected.
-                        // Track x offset for each option's click region.
                         let label_prefix = format!("  {label}: ");
                         let mut x_off = inner_x + label_prefix.len() as u16;
 
                         let mut spans = vec![Span::styled(label_prefix, label_style)];
                         for (i, opt) in options.iter().enumerate() {
                             if i > 0 {
-                                spans
-                                    .push(Span::styled("  ", Style::default().fg(Color::DarkGray)));
+                                spans.push(Span::styled("  ", t.field_option_unselected));
                                 x_off += 2;
                             }
                             let style = if i == *selected {
-                                Style::default()
-                                    .fg(Color::Cyan)
-                                    .add_modifier(Modifier::BOLD)
-                                    .add_modifier(Modifier::UNDERLINED)
+                                t.field_option_selected
                             } else {
-                                Style::default().fg(Color::DarkGray)
+                                t.field_option_unselected
                             };
                             let opt_width = opt.len() as u16;
-                            // Push a more-specific click region for this option
                             clicks.push(
                                 Rect::new(x_off, current_y, opt_width, 1),
                                 ClickAction::SelectOption {
@@ -2234,7 +2223,7 @@ impl FormState {
                             x_off += opt_width;
                         }
                         if is_active {
-                            spans.push(Span::styled("  ←/→", Style::default().fg(Color::DarkGray)));
+                            spans.push(Span::styled("  ←/→", t.text_disabled));
                         }
                         lines.push(Line::from(spans));
                     } else {
@@ -2246,32 +2235,21 @@ impl FormState {
                             ("  ", "  ")
                         };
                         let value_style = if is_active {
-                            Style::default()
-                                .fg(Color::Cyan)
-                                .add_modifier(Modifier::BOLD)
+                            t.field_value_inactive.add_modifier(Modifier::BOLD)
                         } else {
-                            Style::default().fg(Color::Cyan)
+                            t.field_value_inactive
+                        };
+                        let arrow_style = if is_active {
+                            t.field_arrows_active
+                        } else {
+                            t.field_arrows_inactive
                         };
 
                         lines.push(Line::from(vec![
                             Span::styled(format!("  {label}: "), label_style),
-                            Span::styled(
-                                arrows.0,
-                                Style::default().fg(if is_active {
-                                    Color::Yellow
-                                } else {
-                                    Color::DarkGray
-                                }),
-                            ),
+                            Span::styled(arrows.0, arrow_style),
                             Span::styled(option.as_str(), value_style),
-                            Span::styled(
-                                arrows.1,
-                                Style::default().fg(if is_active {
-                                    Color::Yellow
-                                } else {
-                                    Color::DarkGray
-                                }),
-                            ),
+                            Span::styled(arrows.1, arrow_style),
                         ]));
                     }
                 }
@@ -2283,11 +2261,9 @@ impl FormState {
                     ..
                 } => {
                     let label_style = if is_active {
-                        Style::default()
-                            .fg(Color::White)
-                            .add_modifier(Modifier::BOLD)
+                        t.field_label_active
                     } else {
-                        Style::default().fg(Color::Gray)
+                        t.field_label_inactive
                     };
 
                     let label_prefix = format!("  {label}: ");
@@ -2298,18 +2274,14 @@ impl FormState {
                         let checked = if toggled[i] { "[x]" } else { "[ ]" };
                         let is_cursor = is_active && i == *cursor;
                         let style = if is_cursor {
-                            Style::default()
-                                .fg(Color::White)
-                                .bg(Color::DarkGray)
-                                .add_modifier(Modifier::BOLD)
+                            t.field_multi_cursor
                         } else if toggled[i] {
-                            Style::default().fg(Color::Green)
+                            t.field_multi_checked
                         } else {
-                            Style::default().fg(Color::DarkGray)
+                            t.field_multi_unchecked
                         };
                         let item_text = format!("{checked} {opt}");
                         let item_width = item_text.len() as u16;
-                        // Push a more-specific click region for this checkbox
                         clicks.push(
                             Rect::new(x_off, current_y, item_width, 1),
                             ClickAction::ToggleMultiSelect {
@@ -2335,7 +2307,7 @@ impl FormState {
             if is_active && let Some(hint) = self.field_hint(fi) {
                 lines.push(Line::from(Span::styled(
                     format!("    {hint}"),
-                    Style::default().fg(Color::DarkGray),
+                    t.text_disabled,
                 )));
                 current_y += 1;
             }

--- a/clash/src/tui/mod.rs
+++ b/clash/src/tui/mod.rs
@@ -10,6 +10,7 @@ pub mod sandbox_view;
 pub mod settings_view;
 pub mod tea;
 pub mod test_panel;
+pub mod theme;
 pub mod tool_registry;
 pub mod tree_view;
 pub mod walkthrough;

--- a/clash/src/tui/sandbox_view.rs
+++ b/clash/src/tui/sandbox_view.rs
@@ -3,11 +3,11 @@
 use crossterm::event::{KeyCode, KeyEvent};
 use ratatui::Frame;
 use ratatui::layout::{Constraint, Layout, Rect};
-use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Paragraph};
 
 use super::tea::{Action, Component, FormRequest};
+use super::theme::{Theme, ViewContext};
 use crate::policy::match_tree::{CompiledPolicy, PolicyManifest};
 use crate::policy::sandbox_types::{RuleEffect, SandboxPolicy};
 
@@ -293,28 +293,28 @@ impl Component for SandboxView {
         }
     }
 
-    fn view(&self, frame: &mut Frame, area: Rect, _manifest: &PolicyManifest) {
+    fn view(&self, frame: &mut Frame, area: Rect, ctx: &ViewContext) {
         let chunks = Layout::horizontal([Constraint::Percentage(30), Constraint::Percentage(70)])
             .split(area);
 
         // Left pane: sandbox list
-        self.render_sandbox_list(frame, chunks[0]);
+        self.render_sandbox_list(frame, chunks[0], ctx.theme);
 
         // Right pane: sandbox detail + rules
-        self.render_sandbox_detail(frame, chunks[1]);
+        self.render_sandbox_detail(frame, chunks[1], ctx.theme);
     }
 }
 
 impl SandboxView {
-    fn render_sandbox_list(&self, frame: &mut Frame, area: Rect) {
-        let border_color = if self.focus == Focus::SandboxList {
-            Color::Blue
+    fn render_sandbox_list(&self, frame: &mut Frame, area: Rect, t: &Theme) {
+        let border_style = if self.focus == Focus::SandboxList {
+            t.border_active
         } else {
-            Color::DarkGray
+            t.border_unfocused
         };
         let block = Block::default()
             .borders(Borders::ALL)
-            .border_style(Style::default().fg(border_color))
+            .border_style(border_style)
             .title(" Sandboxes ");
 
         let inner = block.inner(area);
@@ -322,17 +322,9 @@ impl SandboxView {
 
         if self.sandbox_names.is_empty() {
             let empty = Paragraph::new(Line::from(vec![
-                Span::styled(
-                    "  No sandboxes. Press ",
-                    Style::default().fg(Color::DarkGray),
-                ),
-                Span::styled(
-                    "a",
-                    Style::default()
-                        .fg(Color::Yellow)
-                        .add_modifier(Modifier::BOLD),
-                ),
-                Span::styled(" to add one.", Style::default().fg(Color::DarkGray)),
+                Span::styled("  No sandboxes. Press ", t.text_disabled),
+                Span::styled("a", t.hint_key),
+                Span::styled(" to add one.", t.text_disabled),
             ]));
             frame.render_widget(empty, inner);
             return;
@@ -350,18 +342,13 @@ impl SandboxView {
                     format!("  {name}")
                 };
                 let style = if i == self.selected_sandbox && self.focus == Focus::SandboxList {
-                    Style::default()
-                        .bg(Color::DarkGray)
-                        .fg(Color::White)
-                        .add_modifier(Modifier::BOLD)
+                    t.selection
                 } else if i == self.selected_sandbox {
-                    Style::default().fg(Color::Cyan)
+                    t.text_emphasis
                 } else if is_included {
-                    Style::default()
-                        .fg(Color::White)
-                        .add_modifier(Modifier::DIM)
+                    t.effect_read_only(None)
                 } else {
-                    Style::default().fg(Color::White)
+                    t.text_primary
                 };
                 Line::from(Span::styled(display, style))
             })
@@ -371,15 +358,15 @@ impl SandboxView {
         frame.render_widget(para, inner);
     }
 
-    fn render_sandbox_detail(&self, frame: &mut Frame, area: Rect) {
-        let border_color = if self.focus == Focus::RuleList {
-            Color::Blue
+    fn render_sandbox_detail(&self, frame: &mut Frame, area: Rect, t: &Theme) {
+        let border_style = if self.focus == Focus::RuleList {
+            t.border_active
         } else {
-            Color::DarkGray
+            t.border_unfocused
         };
         let block = Block::default()
             .borders(Borders::ALL)
-            .border_style(Style::default().fg(border_color))
+            .border_style(border_style)
             .title(" Details ");
 
         let inner = block.inner(area);
@@ -393,49 +380,31 @@ impl SandboxView {
 
         // Header info
         lines.push(Line::from(vec![
-            Span::styled("  Default: ", Style::default().fg(Color::DarkGray)),
-            Span::styled(sb.default.display(), Style::default().fg(Color::Cyan)),
+            Span::styled("  Default: ", t.detail_label),
+            Span::styled(sb.default.display(), t.detail_value),
         ]));
         lines.push(Line::from(vec![
-            Span::styled("  Network: ", Style::default().fg(Color::DarkGray)),
-            Span::styled(
-                format_network(&sb.network),
-                Style::default().fg(Color::Cyan),
-            ),
+            Span::styled("  Network: ", t.detail_label),
+            Span::styled(format_network(&sb.network), t.detail_value),
         ]));
         if let Some(doc) = &sb.doc {
             lines.push(Line::from(Span::styled(
                 format!("  Doc: {doc}"),
-                Style::default().fg(Color::DarkGray),
+                t.detail_label,
             )));
         }
         lines.push(Line::from(""));
-        lines.push(Line::from(Span::styled(
-            "  Rules:",
-            Style::default()
-                .fg(Color::White)
-                .add_modifier(Modifier::BOLD),
-        )));
+        lines.push(Line::from(Span::styled("  Rules:", t.section_header)));
 
         if sb.rules.is_empty() {
-            lines.push(Line::from(Span::styled(
-                "    (no rules)",
-                Style::default().fg(Color::DarkGray),
-            )));
+            lines.push(Line::from(Span::styled("    (no rules)", t.text_disabled)));
         } else {
             for (i, rule) in sb.rules.iter().enumerate() {
-                let effect_color = match rule.effect {
-                    RuleEffect::Allow => Color::Green,
-                    RuleEffect::Deny => Color::Red,
-                };
                 let selected = i == self.selected_rule && self.focus == Focus::RuleList;
                 let style = if selected {
-                    Style::default()
-                        .bg(Color::DarkGray)
-                        .fg(Color::White)
-                        .add_modifier(Modifier::BOLD)
+                    t.selection
                 } else {
-                    Style::default().fg(effect_color)
+                    t.sandbox_effect(rule.effect)
                 };
                 let effect_str = match rule.effect {
                     RuleEffect::Allow => "allow",

--- a/clash/src/tui/settings_view.rs
+++ b/clash/src/tui/settings_view.rs
@@ -3,11 +3,12 @@
 use crossterm::event::{KeyCode, KeyEvent};
 use ratatui::Frame;
 use ratatui::layout::Rect;
-use ratatui::style::{Color, Modifier, Style};
+use ratatui::style::Modifier;
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Paragraph};
 
 use super::tea::{Action, Component};
+use super::theme::ViewContext;
 use crate::policy::Effect;
 use crate::policy::match_tree::PolicyManifest;
 
@@ -108,20 +109,18 @@ impl Component for SettingsView {
         }
     }
 
-    fn view(&self, frame: &mut Frame, area: Rect, manifest: &PolicyManifest) {
+    fn view(&self, frame: &mut Frame, area: Rect, ctx: &ViewContext) {
+        let t = ctx.theme;
+        let manifest = ctx.manifest;
         let block = Block::default()
             .borders(Borders::LEFT | Borders::RIGHT)
-            .border_style(Style::default().fg(Color::DarkGray));
+            .border_style(t.border_unfocused);
 
         let inner = block.inner(area);
         frame.render_widget(block, area);
 
         let effect_str = manifest.policy.default_effect.to_string();
-        let effect_color = match manifest.policy.default_effect {
-            Effect::Allow => Color::Green,
-            Effect::Deny => Color::Red,
-            Effect::Ask => Color::Yellow,
-        };
+        let effect_style = t.policy_effect(manifest.policy.default_effect);
 
         let sandbox_str = manifest
             .policy
@@ -130,29 +129,24 @@ impl Component for SettingsView {
             .unwrap_or("(none)");
 
         let fields = [
-            ("default_effect", effect_str.as_str(), effect_color),
-            ("default_sandbox", sandbox_str, Color::Cyan),
+            ("default_effect", effect_str.as_str(), effect_style),
+            ("default_sandbox", sandbox_str, t.detail_value),
         ];
 
         let lines: Vec<Line> = fields
             .iter()
             .enumerate()
-            .flat_map(|(i, (label, value, color))| {
+            .flat_map(|(i, (label, value, base_style))| {
                 let selected = i == self.selected_field;
                 let label_style = if selected {
-                    Style::default()
-                        .fg(Color::White)
-                        .add_modifier(Modifier::BOLD)
+                    t.field_label_active
                 } else {
-                    Style::default().fg(Color::Gray)
+                    t.field_label_inactive
                 };
                 let value_style = if selected {
-                    Style::default()
-                        .fg(*color)
-                        .bg(Color::DarkGray)
-                        .add_modifier(Modifier::BOLD)
+                    base_style.add_modifier(Modifier::BOLD).patch(t.selection)
                 } else {
-                    Style::default().fg(*color)
+                    *base_style
                 };
 
                 let hint = if selected {
@@ -166,7 +160,7 @@ impl Component for SettingsView {
                     Line::from(vec![
                         Span::styled(format!("  {label}: "), label_style),
                         Span::styled(*value, value_style),
-                        Span::styled(hint, Style::default().fg(Color::DarkGray)),
+                        Span::styled(hint, t.text_disabled),
                     ]),
                 ]
             })

--- a/clash/src/tui/tea.rs
+++ b/clash/src/tui/tea.rs
@@ -8,6 +8,7 @@ use ratatui::Frame;
 use ratatui::layout::Rect;
 
 use crate::policy::match_tree::PolicyManifest;
+use super::theme::ViewContext;
 
 /// An action returned from [`Component::update`] to signal the parent.
 pub enum Action {
@@ -65,5 +66,5 @@ pub trait Component {
     fn update(&mut self, msg: Self::Msg, manifest: &mut PolicyManifest) -> Action;
 
     /// Render the component into a ratatui Frame area.
-    fn view(&self, frame: &mut Frame, area: Rect, manifest: &PolicyManifest);
+    fn view(&self, frame: &mut Frame, area: Rect, ctx: &ViewContext);
 }

--- a/clash/src/tui/test_panel.rs
+++ b/clash/src/tui/test_panel.rs
@@ -7,10 +7,11 @@
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use ratatui::Frame;
 use ratatui::layout::{Constraint, Layout, Rect};
-use ratatui::style::{Color, Modifier, Style};
+use ratatui::style::Style;
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Paragraph};
 
+use super::theme::Theme;
 use crate::policy::Effect;
 use crate::policy::match_tree::CompiledPolicy;
 use crate::policy::test_eval;
@@ -344,20 +345,20 @@ impl TestPanel {
     }
 
     /// Render the test panel into the given area.
-    pub fn view(&self, frame: &mut Frame, area: Rect) {
-        self.view_with_focus(frame, area, true)
+    pub fn view(&self, frame: &mut Frame, area: Rect, t: &Theme) {
+        self.view_with_focus(frame, area, true, t)
     }
 
     /// Render the test panel, with focus indicator.
-    pub fn view_with_focus(&self, frame: &mut Frame, area: Rect, focused: bool) {
-        let border_color = if focused {
-            Color::Blue
+    pub fn view_with_focus(&self, frame: &mut Frame, area: Rect, focused: bool, t: &Theme) {
+        let border_style = if focused {
+            t.border_active
         } else {
-            Color::DarkGray
+            t.border_unfocused
         };
         let block = Block::default()
             .borders(Borders::ALL)
-            .border_style(Style::default().fg(border_color))
+            .border_style(border_style)
             .title(" Test Console ");
 
         let inner = block.inner(area);
@@ -374,15 +375,15 @@ impl TestPanel {
         ])
         .split(inner);
 
-        self.render_history(frame, chunks[0]);
-        self.render_input(frame, chunks[1]);
+        self.render_history(frame, chunks[0], t);
+        self.render_input(frame, chunks[1], t);
     }
 
-    fn render_history(&self, frame: &mut Frame, area: Rect) {
+    fn render_history(&self, frame: &mut Frame, area: Rect, t: &Theme) {
         if self.cases.is_empty() {
             let empty = Paragraph::new(Line::from(Span::styled(
                 " Type a test below...",
-                Style::default().fg(Color::DarkGray),
+                t.text_disabled,
             )));
             frame.render_widget(empty, area);
             return;
@@ -415,7 +416,7 @@ impl TestPanel {
             if case.pinned && has_pinned {
                 continue; // Render pinned separately below
             }
-            lines.push(self.render_case(i, case));
+            lines.push(self.render_case(i, case, t));
         }
 
         // Pinned divider + pinned cases
@@ -428,15 +429,12 @@ impl TestPanel {
                 .collect();
 
             if !pinned_cases.is_empty() && lines.len() + 1 < visible_height {
-                lines.push(Line::from(Span::styled(
-                    " ┄┄ pinned ┄┄",
-                    Style::default().fg(Color::DarkGray),
-                )));
+                lines.push(Line::from(Span::styled(" ┄┄ pinned ┄┄", t.text_disabled)));
                 for (i, case) in pinned_cases {
                     if lines.len() >= visible_height {
                         break;
                     }
-                    lines.push(self.render_case(i, case));
+                    lines.push(self.render_case(i, case, t));
                 }
             }
         }
@@ -445,7 +443,7 @@ impl TestPanel {
         frame.render_widget(para, area);
     }
 
-    fn render_case(&self, index: usize, case: &TestCase) -> Line<'static> {
+    fn render_case(&self, index: usize, case: &TestCase, t: &Theme) -> Line<'static> {
         let is_selected = index == self.selected && !self.input_active;
         let pin_marker = if case.pinned { "* " } else { "  " };
         let changed_badge = if case.changed { " [CHG]" } else { "" };
@@ -456,64 +454,40 @@ impl TestPanel {
             Effect::Ask => "?",
         };
 
-        let effect_color = match case.effect {
-            Effect::Allow => Color::Green,
-            Effect::Deny => Color::Red,
-            Effect::Ask => Color::Yellow,
-        };
+        let effect_style = t.policy_effect(case.effect);
 
-        let style = if is_selected {
-            Style::default()
-                .bg(Color::DarkGray)
-                .fg(Color::White)
-                .add_modifier(Modifier::BOLD)
-        } else {
-            Style::default()
-        };
+        let style = if is_selected { t.selection } else { Style::default() };
 
         let mut spans = vec![
             Span::styled(pin_marker.to_string(), style),
             Span::styled(
                 format!("{effect_icon} "),
-                if is_selected {
-                    style
-                } else {
-                    Style::default().fg(effect_color)
-                },
+                if is_selected { style } else { effect_style },
             ),
-            Span::styled(truncate_input(&case.input, 20), style.fg(Color::White)),
+            Span::styled(truncate_input(&case.input, 20), style.patch(t.text_primary)),
             Span::styled(
                 format!(" {}", case.summary),
-                if is_selected {
-                    style
-                } else {
-                    Style::default().fg(effect_color)
-                },
+                if is_selected { style } else { effect_style },
             ),
         ];
 
         if !changed_badge.is_empty() {
-            spans.push(Span::styled(
-                changed_badge.to_string(),
-                Style::default()
-                    .fg(Color::Magenta)
-                    .add_modifier(Modifier::BOLD),
-            ));
+            spans.push(Span::styled(changed_badge.to_string(), t.test_changed_badge));
         }
 
         Line::from(spans)
     }
 
-    fn render_input(&self, frame: &mut Frame, area: Rect) {
+    fn render_input(&self, frame: &mut Frame, area: Rect, t: &Theme) {
         if area.height < 1 {
             return;
         }
 
         // Input line
         let prompt_style = if self.input_active {
-            Style::default().fg(Color::Cyan)
+            t.test_input_active
         } else {
-            Style::default().fg(Color::DarkGray)
+            t.test_input_inactive
         };
 
         let input_display = if self.input_line.is_empty() && self.input_active {
@@ -523,11 +497,11 @@ impl TestPanel {
         };
 
         let input_style = if self.input_line.is_empty() && self.input_active {
-            Style::default().fg(Color::DarkGray)
+            t.text_disabled
         } else if self.input_active {
-            Style::default().fg(Color::White)
+            t.text_primary
         } else {
-            Style::default().fg(Color::DarkGray)
+            t.text_disabled
         };
 
         let input_line = Line::from(vec![
@@ -542,17 +516,14 @@ impl TestPanel {
             if let Some(ref flash) = self.flash {
                 lines.push(Line::from(Span::styled(
                     format!("   {flash}"),
-                    Style::default().fg(Color::Red),
+                    t.test_error,
                 )));
             } else {
                 let hint = match &self.mode {
                     Some(m) => format!("   mode: {m}  |  Tab: history  p: pin"),
                     None => "   mode <name> to set  |  Tab: history  p: pin".to_string(),
                 };
-                lines.push(Line::from(Span::styled(
-                    hint,
-                    Style::default().fg(Color::DarkGray),
-                )));
+                lines.push(Line::from(Span::styled(hint, t.text_disabled)));
             }
         }
 

--- a/clash/src/tui/theme.rs
+++ b/clash/src/tui/theme.rs
@@ -1,0 +1,373 @@
+//! Semantic theme system for the TUI.
+//!
+//! Every style token describes *what it means*, not what it looks like.
+//! Components never reference `Color::` directly — they use `Theme` fields.
+
+use ratatui::style::{Color, Modifier, Style};
+
+/// A complete visual theme for the TUI.
+///
+/// Field names are semantic — they describe purpose, not appearance.
+#[derive(Debug, Clone)]
+pub struct Theme {
+    // -- Text hierarchy -------------------------------------------------------
+    /// Primary text (default foreground).
+    pub text_primary: Style,
+    /// Disabled / placeholder text.
+    pub text_disabled: Style,
+    /// Emphasized text (bold headings, titles).
+    pub text_emphasis: Style,
+
+    // -- Semantic effects (Allow / Deny / Ask) --------------------------------
+    pub effect_allow: Style,
+    pub effect_deny: Style,
+    pub effect_ask: Style,
+
+    // -- Interactive elements -------------------------------------------------
+    /// Selected / highlighted row.
+    pub selection: Style,
+    /// Keybind hints in status/footer bars.
+    pub hint_key: Style,
+    /// Description text next to keybind hints.
+    pub hint_desc: Style,
+    /// Text cursor (e.g. in text fields).
+    pub cursor: Style,
+
+    // -- Borders & chrome -----------------------------------------------------
+    /// Focused panel / modal border.
+    pub border_focused: Style,
+    /// Unfocused / inactive border.
+    pub border_unfocused: Style,
+    /// Active / focused panel border (e.g. test panel, sandbox panes).
+    pub border_active: Style,
+
+    // -- Tab bar --------------------------------------------------------------
+    pub tab_active: Style,
+    pub tab_inactive: Style,
+    pub tab_separator: Style,
+    /// Background for the tab bar and status bar.
+    pub bar_bg: Style,
+
+    // -- Status bar -----------------------------------------------------------
+    pub flash_message: Style,
+
+    // -- Diff view ------------------------------------------------------------
+    pub diff_add: Style,
+    pub diff_remove: Style,
+    pub diff_context: Style,
+    pub diff_header: Style,
+
+    // -- Modal overlays -------------------------------------------------------
+    pub modal_confirm_border: Style,
+
+    // -- Walkthrough ----------------------------------------------------------
+    pub walkthrough_title: Style,
+
+    // -- Form fields ----------------------------------------------------------
+    pub field_label_active: Style,
+    pub field_label_inactive: Style,
+    pub field_value_active: Style,
+    pub field_value_inactive: Style,
+    pub field_value_placeholder: Style,
+    /// Currently selected inline-select option.
+    pub field_option_selected: Style,
+    /// Unselected inline-select option.
+    pub field_option_unselected: Style,
+    /// Select arrows when active.
+    pub field_arrows_active: Style,
+    /// Select arrows when inactive.
+    pub field_arrows_inactive: Style,
+    /// Multiselect cursor (highlighted checkbox).
+    pub field_multi_cursor: Style,
+    /// Multiselect checked item.
+    pub field_multi_checked: Style,
+    /// Multiselect unchecked item.
+    pub field_multi_unchecked: Style,
+
+    // -- Test panel -----------------------------------------------------------
+    pub test_input_active: Style,
+    pub test_input_inactive: Style,
+    pub test_error: Style,
+    pub test_changed_badge: Style,
+
+    // -- Scrollbar ------------------------------------------------------------
+    pub scrollbar_thumb: Style,
+    pub scrollbar_track: Style,
+
+    // -- Miscellaneous --------------------------------------------------------
+    /// Provenance / source annotations (e.g. "(rules.star)").
+    pub provenance: Style,
+    /// Section headers within views (e.g. "Rules:").
+    pub section_header: Style,
+    /// Label-value pairs in detail views (label portion).
+    pub detail_label: Style,
+    /// Label-value pairs in detail views (value portion).
+    pub detail_value: Style,
+}
+
+impl Theme {
+    /// The default dark theme — matches the original hardcoded palette.
+    pub fn default_dark() -> Self {
+        Theme {
+            // Text hierarchy
+            text_primary: Style::default().fg(Color::White),
+            text_disabled: Style::default().fg(Color::DarkGray),
+            text_emphasis: Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
+
+            // Effects
+            effect_allow: Style::default().fg(Color::Green),
+            effect_deny: Style::default().fg(Color::Red),
+            effect_ask: Style::default().fg(Color::Yellow),
+
+            // Interactive
+            selection: Style::default()
+                .bg(Color::DarkGray)
+                .fg(Color::White)
+                .add_modifier(Modifier::BOLD),
+            hint_key: Style::default()
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::BOLD),
+            hint_desc: Style::default().fg(Color::Gray),
+            cursor: Style::default().fg(Color::Black).bg(Color::White),
+
+            // Borders
+            border_focused: Style::default().fg(Color::Cyan),
+            border_unfocused: Style::default().fg(Color::DarkGray),
+            border_active: Style::default().fg(Color::Blue),
+
+            // Tab bar
+            tab_active: Style::default()
+                .fg(Color::White)
+                .bg(Color::Blue)
+                .add_modifier(Modifier::BOLD),
+            tab_inactive: Style::default().fg(Color::Gray),
+            tab_separator: Style::default().fg(Color::DarkGray),
+            bar_bg: Style::default().bg(Color::Black),
+
+            // Status bar
+            flash_message: Style::default()
+                .fg(Color::Green)
+                .add_modifier(Modifier::BOLD),
+
+            // Diff
+            diff_add: Style::default().fg(Color::Green),
+            diff_remove: Style::default().fg(Color::Red),
+            diff_context: Style::default().fg(Color::Gray),
+            diff_header: Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
+
+            // Modals
+            modal_confirm_border: Style::default().fg(Color::Yellow),
+
+            // Walkthrough
+            walkthrough_title: Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
+
+            // Form fields
+            field_label_active: Style::default()
+                .fg(Color::White)
+                .add_modifier(Modifier::BOLD),
+            field_label_inactive: Style::default().fg(Color::Gray),
+            field_value_active: Style::default().fg(Color::White),
+            field_value_inactive: Style::default().fg(Color::Cyan),
+            field_value_placeholder: Style::default().fg(Color::DarkGray),
+            field_option_selected: Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD)
+                .add_modifier(Modifier::UNDERLINED),
+            field_option_unselected: Style::default().fg(Color::DarkGray),
+            field_arrows_active: Style::default().fg(Color::Yellow),
+            field_arrows_inactive: Style::default().fg(Color::DarkGray),
+            field_multi_cursor: Style::default()
+                .fg(Color::White)
+                .bg(Color::DarkGray)
+                .add_modifier(Modifier::BOLD),
+            field_multi_checked: Style::default().fg(Color::Green),
+            field_multi_unchecked: Style::default().fg(Color::DarkGray),
+
+            // Test panel
+            test_input_active: Style::default().fg(Color::Cyan),
+            test_input_inactive: Style::default().fg(Color::DarkGray),
+            test_error: Style::default().fg(Color::Red),
+            test_changed_badge: Style::default()
+                .fg(Color::Magenta)
+                .add_modifier(Modifier::BOLD),
+
+            // Scrollbar
+            scrollbar_thumb: Style::default().fg(Color::Cyan),
+            scrollbar_track: Style::default().fg(Color::DarkGray),
+
+            // Misc
+            provenance: Style::default().fg(Color::DarkGray),
+            detail_label: Style::default().fg(Color::DarkGray),
+            detail_value: Style::default().fg(Color::Cyan),
+            section_header: Style::default()
+                .fg(Color::White)
+                .add_modifier(Modifier::BOLD),
+        }
+    }
+
+    /// An adaptive theme that uses terminal ANSI colors, inheriting the user's
+    /// palette. Works well on solarized, dracula, gruvbox, etc.
+    pub fn adaptive() -> Self {
+        // Start from default_dark and override colors that conflict with
+        // common terminal palettes. The key insight: avoid Color::DarkGray
+        // for important elements (it maps to "bright black" which is invisible
+        // on many dark backgrounds) and avoid Color::Black for backgrounds
+        // (it clashes with light terminal themes).
+        Theme {
+            // Text — use Reset to inherit terminal fg
+            text_primary: Style::default(),
+            text_disabled: Style::default().add_modifier(Modifier::DIM),
+            text_emphasis: Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
+
+            // Effects — ANSI colors adapt to the palette
+            effect_allow: Style::default().fg(Color::Green),
+            effect_deny: Style::default().fg(Color::Red),
+            effect_ask: Style::default().fg(Color::Yellow),
+
+            // Interactive
+            selection: Style::default()
+                .fg(Color::Black)
+                .bg(Color::White)
+                .add_modifier(Modifier::BOLD),
+            hint_key: Style::default()
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::BOLD),
+            hint_desc: Style::default().add_modifier(Modifier::DIM),
+            cursor: Style::default().fg(Color::Black).bg(Color::White),
+
+            // Borders — use DIM instead of DarkGray for unfocused
+            border_focused: Style::default().fg(Color::Cyan),
+            border_unfocused: Style::default().add_modifier(Modifier::DIM),
+            border_active: Style::default().fg(Color::Blue),
+
+            // Tab bar — no explicit bg, inherit terminal
+            tab_active: Style::default()
+                .fg(Color::Black)
+                .bg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
+            tab_inactive: Style::default().add_modifier(Modifier::DIM),
+            tab_separator: Style::default().add_modifier(Modifier::DIM),
+            bar_bg: Style::default(),
+
+            // Status
+            flash_message: Style::default()
+                .fg(Color::Green)
+                .add_modifier(Modifier::BOLD),
+
+            // Diff
+            diff_add: Style::default().fg(Color::Green),
+            diff_remove: Style::default().fg(Color::Red),
+            diff_context: Style::default().add_modifier(Modifier::DIM),
+            diff_header: Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
+
+            // Modals
+            modal_confirm_border: Style::default().fg(Color::Yellow),
+
+            // Walkthrough
+            walkthrough_title: Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
+
+            // Form fields
+            field_label_active: Style::default().add_modifier(Modifier::BOLD),
+            field_label_inactive: Style::default().add_modifier(Modifier::DIM),
+            field_value_active: Style::default(),
+            field_value_inactive: Style::default().fg(Color::Cyan),
+            field_value_placeholder: Style::default().add_modifier(Modifier::DIM),
+            field_option_selected: Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD)
+                .add_modifier(Modifier::UNDERLINED),
+            field_option_unselected: Style::default().add_modifier(Modifier::DIM),
+            field_arrows_active: Style::default().fg(Color::Yellow),
+            field_arrows_inactive: Style::default().add_modifier(Modifier::DIM),
+            field_multi_cursor: Style::default()
+                .fg(Color::Black)
+                .bg(Color::White)
+                .add_modifier(Modifier::BOLD),
+            field_multi_checked: Style::default().fg(Color::Green),
+            field_multi_unchecked: Style::default().add_modifier(Modifier::DIM),
+
+            // Test panel
+            test_input_active: Style::default().fg(Color::Cyan),
+            test_input_inactive: Style::default().add_modifier(Modifier::DIM),
+            test_error: Style::default().fg(Color::Red),
+            test_changed_badge: Style::default()
+                .fg(Color::Magenta)
+                .add_modifier(Modifier::BOLD),
+
+            // Scrollbar
+            scrollbar_thumb: Style::default().fg(Color::Cyan),
+            scrollbar_track: Style::default().add_modifier(Modifier::DIM),
+
+            // Misc
+            provenance: Style::default().add_modifier(Modifier::DIM),
+            detail_label: Style::default().add_modifier(Modifier::DIM),
+            detail_value: Style::default().fg(Color::Cyan),
+            section_header: Style::default().add_modifier(Modifier::BOLD),
+        }
+    }
+
+    /// Select a theme from the `CLASH_THEME` environment variable.
+    ///
+    /// Supported values: `dark`, `adaptive`. Defaults to `dark`.
+    pub fn from_env() -> Self {
+        match std::env::var("CLASH_THEME").as_deref() {
+            Ok("adaptive") => Self::adaptive(),
+            _ => Self::default_dark(),
+        }
+    }
+
+    // -- Convenience helpers for compound styles ------------------------------
+
+    /// Style for a decision effect (Allow/Deny/Ask/None).
+    pub fn effect(&self, decision: Option<&crate::policy::match_tree::Decision>) -> Style {
+        match decision {
+            Some(crate::policy::match_tree::Decision::Allow(_)) => self.effect_allow,
+            Some(crate::policy::match_tree::Decision::Deny) => self.effect_deny,
+            Some(crate::policy::match_tree::Decision::Ask(_)) => self.effect_ask,
+            None => self.text_primary,
+        }
+    }
+
+    /// Style for a policy effect (Allow/Deny/Ask).
+    pub fn policy_effect(&self, effect: crate::policy::Effect) -> Style {
+        match effect {
+            crate::policy::Effect::Allow => self.effect_allow,
+            crate::policy::Effect::Deny => self.effect_deny,
+            crate::policy::Effect::Ask => self.effect_ask,
+        }
+    }
+
+    /// Style for a sandbox rule effect (Allow/Deny).
+    pub fn sandbox_effect(&self, effect: crate::policy::sandbox_types::RuleEffect) -> Style {
+        match effect {
+            crate::policy::sandbox_types::RuleEffect::Allow => self.effect_allow,
+            crate::policy::sandbox_types::RuleEffect::Deny => self.effect_deny,
+        }
+    }
+
+    /// Effect style for read-only / included items (dimmed decision color).
+    pub fn effect_read_only(
+        &self,
+        decision: Option<&crate::policy::match_tree::Decision>,
+    ) -> Style {
+        self.effect(decision).add_modifier(Modifier::DIM)
+    }
+}
+
+/// Read-only rendering context passed to every [`Component::view`].
+pub struct ViewContext<'a> {
+    pub manifest: &'a crate::policy::match_tree::PolicyManifest,
+    pub theme: &'a Theme,
+}

--- a/clash/src/tui/tree_view.rs
+++ b/clash/src/tui/tree_view.rs
@@ -5,11 +5,11 @@ use std::collections::HashSet;
 use crossterm::event::{KeyCode, KeyEvent};
 use ratatui::Frame;
 use ratatui::layout::Rect;
-use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Paragraph};
 
 use super::tea::{Action, Component, FormRequest};
+use super::theme::ViewContext;
 use crate::policy::format::{format_condition, format_decision};
 use crate::policy::match_tree::{CompiledPolicy, Decision, Node, PolicyManifest};
 
@@ -518,10 +518,11 @@ impl Component for TreeView {
         }
     }
 
-    fn view(&self, frame: &mut Frame, area: Rect, _manifest: &PolicyManifest) {
+    fn view(&self, frame: &mut Frame, area: Rect, ctx: &ViewContext) {
+        let t = ctx.theme;
         let block = Block::default()
             .borders(Borders::LEFT | Borders::RIGHT)
-            .border_style(Style::default().fg(Color::DarkGray));
+            .border_style(t.border_unfocused);
 
         let inner = block.inner(area);
         frame.render_widget(block, area);
@@ -569,19 +570,13 @@ impl Component for TreeView {
                 };
 
                 let style = if i == self.selected {
-                    Style::default()
-                        .bg(Color::DarkGray)
-                        .fg(Color::White)
-                        .add_modifier(Modifier::BOLD)
+                    t.selection
                 } else if node.is_root {
-                    Style::default()
-                        .fg(Color::Cyan)
-                        .add_modifier(Modifier::BOLD)
+                    t.text_emphasis
                 } else if node.read_only {
-                    // Included rules are dimmed
-                    decision_style(node.decision.as_ref()).add_modifier(Modifier::DIM)
+                    t.effect_read_only(node.decision.as_ref())
                 } else {
-                    decision_style(node.decision.as_ref())
+                    t.effect(node.decision.as_ref())
                 };
 
                 let mut spans = vec![Span::styled(
@@ -589,10 +584,7 @@ impl Component for TreeView {
                     style,
                 )];
                 if let Some(ref src) = node.source {
-                    spans.push(Span::styled(
-                        format!("  ({src})"),
-                        Style::default().fg(Color::DarkGray),
-                    ));
+                    spans.push(Span::styled(format!("  ({src})"), t.provenance));
                 }
                 Line::from(spans)
             })
@@ -619,14 +611,6 @@ impl TreeView {
     }
 }
 
-fn decision_style(decision: Option<&Decision>) -> Style {
-    match decision {
-        Some(Decision::Allow(_)) => Style::default().fg(Color::Green),
-        Some(Decision::Deny) => Style::default().fg(Color::Red),
-        Some(Decision::Ask(_)) => Style::default().fg(Color::Yellow),
-        None => Style::default().fg(Color::White),
-    }
-}
 
 #[cfg(test)]
 mod tests {

--- a/clash/src/tui/walkthrough.rs
+++ b/clash/src/tui/walkthrough.rs
@@ -6,10 +6,10 @@
 
 use ratatui::Frame;
 use ratatui::layout::{Alignment, Rect};
-use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::Paragraph;
 
+use super::theme::Theme;
 use super::widgets::{ClickAction, ClickRegions, ModalHeight, ModalOverlay, ScrollState};
 
 /// Sequential steps of the onboarding walkthrough.
@@ -104,11 +104,12 @@ pub fn render_walkthrough_overlay(
     step: WalkthroughStep,
     scroll: &mut ScrollState,
     clicks: &mut ClickRegions,
+    t: &Theme,
 ) {
     let (content, footer, footer_left): (Vec<Line>, HintSlice, HintSlice) = match step {
         WalkthroughStep::Welcome => (
             vec![
-                styled_title("Welcome to the Policy Editor"),
+                styled_title("Welcome to the Policy Editor", t),
                 Line::from(""),
                 Line::from("Your policy controls what Claude can do."),
                 Line::from("It starts with a sensible default: ask for"),
@@ -121,7 +122,7 @@ pub fn render_walkthrough_overlay(
         ),
         WalkthroughStep::BaseTools => (
             vec![
-                styled_title("Base Tools — Pre-configured"),
+                styled_title("Base Tools — Pre-configured", t),
                 Line::from(""),
                 Line::from("Your policy already allows the tools Claude"),
                 Line::from("uses most: Read, Write, Edit, Glob, and Grep."),
@@ -141,13 +142,13 @@ pub fn render_walkthrough_overlay(
         ),
         WalkthroughStep::AddRule => (
             vec![
-                styled_title("Step 1: Allow git"),
+                styled_title("Step 1: Allow git", t),
                 Line::from(""),
                 Line::from("Let's add a rule that allows all git commands."),
                 Line::from("You can refine this later — e.g. deny push"),
                 Line::from("--force or sandbox network-dependent ops."),
                 Line::from(""),
-                key_hint("a", "add a new rule"),
+                key_hint("a", "add a new rule", t),
             ],
             &[("Esc", "skip"), ("b", "back"), ("a", "add rule")],
             &[("q", "quit")],
@@ -158,16 +159,16 @@ pub fn render_walkthrough_overlay(
         }
         WalkthroughStep::TestIt => (
             vec![
-                styled_title("Step 2: Test Your Rule"),
+                styled_title("Step 2: Test Your Rule", t),
                 Line::from(""),
                 Line::from("The test console lets you check how your"),
                 Line::from("policy handles different commands."),
                 Line::from(""),
                 Line::from("Type a tool name followed by its arguments:"),
-                dim_hint("  bash git status"),
-                dim_hint("  Read /etc/hosts"),
+                dim_hint("  bash git status", t),
+                dim_hint("  Read /etc/hosts", t),
                 Line::from(""),
-                key_hint("t", "open the test console"),
+                key_hint("t", "open the test console", t),
             ],
             &[("Esc", "skip"), ("b", "back"), ("t", "test console")],
             &[("q", "quit")],
@@ -178,14 +179,14 @@ pub fn render_walkthrough_overlay(
         }
         WalkthroughStep::SaveFinish => (
             vec![
-                styled_title("Step 3: Save"),
+                styled_title("Step 3: Save", t),
                 Line::from(""),
                 Line::from("Your rule is ready. Save your policy to"),
                 Line::from("start using it in Claude Code."),
                 Line::from(""),
-                key_hint("s", "save your policy"),
+                key_hint("s", "save your policy", t),
                 Line::from(""),
-                dim_hint("Come back anytime with: clash policy edit"),
+                dim_hint("Come back anytime with: clash policy edit", t),
             ],
             &[("Esc", "skip"), ("b", "back"), ("s", "save")],
             &[("q", "quit")],
@@ -199,12 +200,13 @@ pub fn render_walkthrough_overlay(
     let modal = ModalOverlay {
         width_pct: 50,
         height: ModalHeight::Percent(45),
-        border_color: Color::Cyan,
+        border_style: t.border_focused,
         title: "Walkthrough",
         footer,
         footer_left,
         footer_right: None,
         scroll: Some(scroll.to_modal_scroll()),
+        theme: Some(t),
     };
     let inner = modal.render_chrome(frame, area);
     for (rect, kc) in &inner.footer_buttons {
@@ -277,28 +279,18 @@ pub fn walkthrough_status_hints(step: WalkthroughStep) -> Vec<(&'static str, &'s
     }
 }
 
-fn styled_title(text: &str) -> Line<'_> {
-    Line::from(Span::styled(
-        text,
-        Style::default()
-            .fg(Color::Cyan)
-            .add_modifier(Modifier::BOLD),
-    ))
+fn styled_title<'a>(text: &'a str, t: &Theme) -> Line<'a> {
+    Line::from(Span::styled(text, t.walkthrough_title))
 }
 
-fn key_hint<'a>(key: &'a str, description: &'a str) -> Line<'a> {
+fn key_hint<'a>(key: &'a str, description: &'a str, t: &Theme) -> Line<'a> {
     Line::from(vec![
         Span::raw("Press "),
-        Span::styled(
-            key,
-            Style::default()
-                .fg(Color::Yellow)
-                .add_modifier(Modifier::BOLD),
-        ),
+        Span::styled(key, t.hint_key),
         Span::raw(format!(" to {description}")),
     ])
 }
 
-fn dim_hint(text: &str) -> Line<'_> {
-    Line::from(Span::styled(text, Style::default().fg(Color::DarkGray)))
+fn dim_hint<'a>(text: &'a str, t: &Theme) -> Line<'a> {
+    Line::from(Span::styled(text, t.text_disabled))
 }

--- a/clash/src/tui/widgets.rs
+++ b/clash/src/tui/widgets.rs
@@ -10,6 +10,7 @@ use ratatui::widgets::{
 };
 
 use super::app::Tab;
+use super::theme::Theme;
 
 // ---------------------------------------------------------------------------
 // Click regions — mouse click targets populated each frame during render
@@ -72,7 +73,7 @@ fn parse_hint_key(s: &str) -> Option<KeyCode> {
 }
 
 /// Render the tab bar at the top of the screen.
-pub fn render_tab_bar(frame: &mut Frame, area: Rect, active_tab: &Tab, dirty: bool) {
+pub fn render_tab_bar(frame: &mut Frame, area: Rect, active_tab: &Tab, dirty: bool, t: &Theme) {
     let tabs = [
         (Tab::Tree, "Tree"),
         (Tab::Sandboxes, "Sandboxes"),
@@ -84,31 +85,22 @@ pub fn render_tab_bar(frame: &mut Frame, area: Rect, active_tab: &Tab, dirty: bo
     spans.push(Span::raw("  "));
     for (i, (tab, label)) in tabs.iter().enumerate() {
         if i > 0 {
-            spans.push(Span::styled("  ", Style::default().fg(Color::DarkGray)));
+            spans.push(Span::styled("  ", t.tab_separator));
         }
         if tab == active_tab {
-            spans.push(Span::styled(
-                format!(" {label} "),
-                Style::default()
-                    .fg(Color::White)
-                    .bg(Color::Blue)
-                    .add_modifier(Modifier::BOLD),
-            ));
+            spans.push(Span::styled(format!(" {label} "), t.tab_active));
         } else {
-            spans.push(Span::styled(
-                format!(" {label} "),
-                Style::default().fg(Color::Gray),
-            ));
+            spans.push(Span::styled(format!(" {label} "), t.tab_inactive));
         }
     }
 
     let dirty_indicator = if dirty { " [modified]" } else { "" };
     spans.push(Span::styled(
         format!("    ? help{dirty_indicator}"),
-        Style::default().fg(Color::DarkGray),
+        t.text_disabled,
     ));
 
-    let bar = Paragraph::new(Line::from(spans)).style(Style::default().bg(Color::Black));
+    let bar = Paragraph::new(Line::from(spans)).style(t.bar_bg);
     frame.render_widget(bar, area);
 }
 
@@ -118,14 +110,10 @@ pub fn render_status_bar(
     area: Rect,
     hints: &[(&str, &str)],
     flash: Option<&str>,
+    t: &Theme,
 ) {
     let line = if let Some(msg) = flash {
-        Line::from(Span::styled(
-            format!("  {msg}"),
-            Style::default()
-                .fg(Color::Green)
-                .add_modifier(Modifier::BOLD),
-        ))
+        Line::from(Span::styled(format!("  {msg}"), t.flash_message))
     } else {
         let spans: Vec<Span> = hints
             .iter()
@@ -133,107 +121,101 @@ pub fn render_status_bar(
             .flat_map(|(i, (key, desc))| {
                 let mut s = Vec::new();
                 if i > 0 {
-                    s.push(Span::styled("  ", Style::default().fg(Color::DarkGray)));
+                    s.push(Span::styled("  ", t.text_disabled));
                 }
-                s.push(Span::styled(
-                    key.to_string(),
-                    Style::default()
-                        .fg(Color::Yellow)
-                        .add_modifier(Modifier::BOLD),
-                ));
-                s.push(Span::styled(
-                    format!(" {desc}"),
-                    Style::default().fg(Color::Gray),
-                ));
+                s.push(Span::styled(key.to_string(), t.hint_key));
+                s.push(Span::styled(format!(" {desc}"), t.hint_desc));
                 s
             })
             .collect();
         Line::from(spans)
     };
 
-    let bar = Paragraph::new(line).style(Style::default().bg(Color::Black));
+    let bar = Paragraph::new(line).style(t.bar_bg);
     frame.render_widget(bar, area);
 }
 
 /// Build the help content lines.  Used both for rendering and for deriving
 /// the content length when constructing `ScrollState`.
-pub fn help_content() -> Vec<Line<'static>> {
+pub fn help_content(t: &Theme) -> Vec<Line<'static>> {
+    let key = t.hint_key;
     vec![
-        Line::from(Span::styled(
-            "Keybindings",
-            Style::default()
-                .fg(Color::Cyan)
-                .add_modifier(Modifier::BOLD),
-        )),
+        Line::from(Span::styled("Keybindings", t.text_emphasis)),
         Line::from(""),
         Line::from(vec![
-            Span::styled("1-5    ", Style::default().fg(Color::Yellow)),
+            Span::styled("1-5    ", key),
             Span::raw("Switch tabs"),
         ]),
         Line::from(vec![
-            Span::styled("j/k    ", Style::default().fg(Color::Yellow)),
+            Span::styled("j/k    ", key),
             Span::raw("Move down/up"),
         ]),
         Line::from(vec![
-            Span::styled("h/l    ", Style::default().fg(Color::Yellow)),
+            Span::styled("h/l    ", key),
             Span::raw("Collapse/expand (tree) or focus (sandboxes)"),
         ]),
         Line::from(vec![
-            Span::styled("g/G    ", Style::default().fg(Color::Yellow)),
+            Span::styled("g/G    ", key),
             Span::raw("Jump to top/bottom"),
         ]),
         Line::from(vec![
-            Span::styled("Space  ", Style::default().fg(Color::Yellow)),
+            Span::styled("Space  ", key),
             Span::raw("Toggle expand/collapse"),
         ]),
         Line::from(vec![
-            Span::styled("e/Tab  ", Style::default().fg(Color::Yellow)),
+            Span::styled("e/Tab  ", key),
             Span::raw("Cycle effect on selected rule"),
         ]),
         Line::from(vec![
-            Span::styled("a      ", Style::default().fg(Color::Yellow)),
+            Span::styled("a      ", key),
             Span::raw("Add new item"),
         ]),
         Line::from(vec![
-            Span::styled("d      ", Style::default().fg(Color::Yellow)),
+            Span::styled("d      ", key),
             Span::raw("Delete selected item"),
         ]),
         Line::from(vec![
-            Span::styled("J/K    ", Style::default().fg(Color::Yellow)),
+            Span::styled("J/K    ", key),
             Span::raw("Move item up/down (includes)"),
         ]),
         Line::from(vec![
-            Span::styled("t      ", Style::default().fg(Color::Yellow)),
+            Span::styled("t      ", key),
             Span::raw("Toggle test console panel"),
         ]),
         Line::from(vec![
-            Span::styled("s      ", Style::default().fg(Color::Yellow)),
+            Span::styled("s      ", key),
             Span::raw("Save (review diff first)"),
         ]),
         Line::from(vec![
-            Span::styled("q/Esc  ", Style::default().fg(Color::Yellow)),
+            Span::styled("q/Esc  ", key),
             Span::raw("Quit (confirms if unsaved)"),
         ]),
         Line::from(vec![
-            Span::styled("?      ", Style::default().fg(Color::Yellow)),
+            Span::styled("?      ", key),
             Span::raw("Toggle this help"),
         ]),
     ]
 }
 
 /// Render a centered help popup listing all keybindings.
-pub fn render_help_overlay(frame: &mut Frame, area: Rect, scroll: &mut ScrollState) -> ModalInner {
-    let help_lines = help_content();
+pub fn render_help_overlay(
+    frame: &mut Frame,
+    area: Rect,
+    scroll: &mut ScrollState,
+    t: &Theme,
+) -> ModalInner {
+    let help_lines = help_content(t);
 
     let modal = ModalOverlay {
         width_pct: 60,
         height: ModalHeight::Percent(70),
-        border_color: Color::Cyan,
+        border_style: t.border_focused,
         title: "Help",
         footer: &[("j/k", "scroll"), ("any key", "close")],
         footer_left: &[],
         footer_right: None,
         scroll: Some(scroll.to_modal_scroll()),
+        theme: Some(t),
     };
     let inner = modal.render_chrome(frame, area);
     scroll.update_viewport(inner.area.height as usize);
@@ -250,16 +232,22 @@ pub fn render_help_overlay(frame: &mut Frame, area: Rect, scroll: &mut ScrollSta
 }
 
 /// Render a confirmation dialog.
-pub fn render_confirm_overlay(frame: &mut Frame, area: Rect, prompt: &str) -> ModalInner {
+pub fn render_confirm_overlay(
+    frame: &mut Frame,
+    area: Rect,
+    prompt: &str,
+    t: &Theme,
+) -> ModalInner {
     let modal = ModalOverlay {
         width_pct: 50,
         height: ModalHeight::Percent(20),
-        border_color: Color::Yellow,
+        border_style: t.modal_confirm_border,
         title: "Confirm",
         footer: &[("y", "yes"), ("n", "no")],
         footer_left: &[],
         footer_right: None,
         scroll: None,
+        theme: Some(t),
     };
     let inner = modal.render_chrome(frame, area);
 
@@ -276,11 +264,9 @@ pub fn render_diff_overlay(
     area: Rect,
     diff_lines: &[DiffLine],
     scroll: &mut ScrollState,
+    t: &Theme,
 ) -> ModalInner {
     let total = diff_lines.len();
-    // Use the previous frame's real viewport for scroll_info (avoids estimate).
-    // On the very first frame viewport is 0, so scroll_info won't show — that's
-    // a single-frame cosmetic gap, far better than a permanent estimate error.
     let viewport = scroll.viewport();
     let scroll_info = if total > viewport && viewport > 0 {
         Some(format!(
@@ -296,12 +282,13 @@ pub fn render_diff_overlay(
     let modal = ModalOverlay {
         width_pct: 80,
         height: ModalHeight::Percent(80),
-        border_color: Color::Cyan,
+        border_style: t.border_focused,
         title: "Save Review",
         footer: &[("y", "confirm"), ("n", "cancel"), ("j/k", "scroll")],
         footer_left: &[],
         footer_right: scroll_info,
         scroll: Some(scroll.to_modal_scroll()),
+        theme: Some(t),
     };
     let inner = modal.render_chrome(frame, area);
     scroll.update_viewport(inner.area.height as usize);
@@ -312,21 +299,10 @@ pub fn render_diff_overlay(
         .skip(scroll.offset)
         .take(visible_height)
         .map(|dl| match dl {
-            DiffLine::Context(s) => {
-                Line::from(Span::styled(s.as_str(), Style::default().fg(Color::Gray)))
-            }
-            DiffLine::Add(s) => {
-                Line::from(Span::styled(s.as_str(), Style::default().fg(Color::Green)))
-            }
-            DiffLine::Remove(s) => {
-                Line::from(Span::styled(s.as_str(), Style::default().fg(Color::Red)))
-            }
-            DiffLine::Header(s) => Line::from(Span::styled(
-                s.as_str(),
-                Style::default()
-                    .fg(Color::Cyan)
-                    .add_modifier(Modifier::BOLD),
-            )),
+            DiffLine::Context(s) => Line::from(Span::styled(s.as_str(), t.diff_context)),
+            DiffLine::Add(s) => Line::from(Span::styled(s.as_str(), t.diff_add)),
+            DiffLine::Remove(s) => Line::from(Span::styled(s.as_str(), t.diff_remove)),
+            DiffLine::Header(s) => Line::from(Span::styled(s.as_str(), t.diff_header)),
         })
         .collect();
 
@@ -374,7 +350,7 @@ pub struct ModalScroll {
 pub struct ModalOverlay<'a> {
     pub width_pct: u16,
     pub height: ModalHeight,
-    pub border_color: Color,
+    pub border_style: Style,
     pub title: &'a str,
     /// Key-hint pairs rendered right-aligned in the bottom border; empty = no footer.
     pub footer: &'a [(&'a str, &'a str)],
@@ -384,6 +360,8 @@ pub struct ModalOverlay<'a> {
     pub footer_left: &'a [(&'a str, &'a str)],
     /// When set, a vertical scrollbar is rendered on the right edge if content overflows.
     pub scroll: Option<ModalScroll>,
+    /// Optional theme for styling footer hints and scrollbar.
+    pub theme: Option<&'a Theme>,
 }
 
 /// The inner area returned by [`ModalOverlay::render_chrome`].
@@ -499,13 +477,24 @@ impl ModalOverlay<'_> {
         // Build footer line from key-hint pairs
         let mut block = Block::default()
             .borders(Borders::ALL)
-            .border_style(Style::default().fg(self.border_color))
+            .border_style(self.border_style)
             .title(format!(" {} ", self.title));
 
         // Track button char offsets (from the start of the footer text) so we
         // can compute screen rects after we know the right-aligned x origin.
         // Each entry: (offset_in_footer, width, KeyCode).
         let mut button_offsets: Vec<(u16, u16, KeyCode)> = Vec::new();
+
+        // Resolve theme-aware styles (fall back to hardcoded defaults when no theme is provided,
+        // keeping the test suite working without requiring a Theme everywhere).
+        let hint_key_style = self
+            .theme
+            .map(|t| t.hint_key)
+            .unwrap_or_else(|| Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD));
+        let hint_desc_style = self
+            .theme
+            .map(|t| t.text_disabled)
+            .unwrap_or_else(|| Style::default().fg(Color::DarkGray));
 
         if !self.footer.is_empty() || self.footer_right.is_some() {
             let mut spans: Vec<Span> = Vec::new();
@@ -516,7 +505,7 @@ impl ModalOverlay<'_> {
 
             for (i, (key, desc)) in self.footer.iter().enumerate() {
                 if i > 0 {
-                    spans.push(Span::styled("  ", Style::default().fg(Color::DarkGray)));
+                    spans.push(Span::styled("  ", hint_desc_style));
                     char_offset += 2;
                 }
                 let button_text = format!("{key} {desc}");
@@ -524,25 +513,14 @@ impl ModalOverlay<'_> {
                 if let Some(kc) = parse_hint_key(key) {
                     button_offsets.push((char_offset, button_width, kc));
                 }
-                spans.push(Span::styled(
-                    *key,
-                    Style::default()
-                        .fg(Color::Yellow)
-                        .add_modifier(Modifier::BOLD),
-                ));
+                spans.push(Span::styled(*key, hint_key_style));
                 char_offset += key.len() as u16;
-                spans.push(Span::styled(
-                    format!(" {desc}"),
-                    Style::default().fg(Color::DarkGray),
-                ));
+                spans.push(Span::styled(format!(" {desc}"), hint_desc_style));
                 char_offset += 1 + desc.len() as u16;
             }
             if let Some(ref right) = self.footer_right {
                 let right_text = format!(" {right}");
-                spans.push(Span::styled(
-                    right_text.clone(),
-                    Style::default().fg(Color::DarkGray),
-                ));
+                spans.push(Span::styled(right_text.clone(), hint_desc_style));
                 char_offset += right_text.len() as u16;
             }
             spans.push(Span::raw(" "));
@@ -575,7 +553,7 @@ impl ModalOverlay<'_> {
 
             for (i, (key, desc)) in self.footer_left.iter().enumerate() {
                 if i > 0 {
-                    spans.push(Span::styled("  ", Style::default().fg(Color::DarkGray)));
+                    spans.push(Span::styled("  ", hint_desc_style));
                     char_offset += 2;
                 }
                 let button_text = format!("{key} {desc}");
@@ -586,17 +564,9 @@ impl ModalOverlay<'_> {
                     let btn_y = popup.y + popup.height.saturating_sub(1);
                     footer_buttons.push((Rect::new(btn_x, btn_y, button_width, 1), kc));
                 }
-                spans.push(Span::styled(
-                    *key,
-                    Style::default()
-                        .fg(Color::Yellow)
-                        .add_modifier(Modifier::BOLD),
-                ));
+                spans.push(Span::styled(*key, hint_key_style));
                 char_offset += key.len() as u16;
-                spans.push(Span::styled(
-                    format!(" {desc}"),
-                    Style::default().fg(Color::DarkGray),
-                ));
+                spans.push(Span::styled(format!(" {desc}"), hint_desc_style));
                 char_offset += 1 + desc.len() as u16;
             }
             spans.push(Span::raw(" "));
@@ -611,9 +581,17 @@ impl ModalOverlay<'_> {
         let content_area = if let Some(ref sc) = self.scroll {
             let viewport = inner.height as usize;
             if sc.total > viewport && inner.width > 1 {
+                let thumb_style = self
+                    .theme
+                    .map(|t| t.scrollbar_thumb)
+                    .unwrap_or(self.border_style);
+                let track_style = self
+                    .theme
+                    .map(|t| t.scrollbar_track)
+                    .unwrap_or_else(|| Style::default().fg(Color::DarkGray));
                 let scrollbar = Scrollbar::new(ScrollbarOrientation::VerticalRight)
-                    .thumb_style(Style::default().fg(self.border_color))
-                    .track_style(Style::default().fg(Color::DarkGray))
+                    .thumb_style(thumb_style)
+                    .track_style(track_style)
                     .begin_symbol(None)
                     .end_symbol(None);
                 // Ratatui positions the thumb at the bottom only when
@@ -773,12 +751,13 @@ mod tests {
                 let modal = ModalOverlay {
                     width_pct: 50,
                     height: ModalHeight::Percent(20),
-                    border_color: Color::Yellow,
+                    border_style: Style::default().fg(Color::Yellow),
                     title: "Test",
                     footer: &[("y", "yes"), ("n", "no")],
                     footer_left: &[],
                     footer_right: None,
                     scroll: None,
+                    theme: None,
                 };
                 let inner = modal.render_chrome(frame, area);
 
@@ -821,12 +800,13 @@ mod tests {
                 let modal = ModalOverlay {
                     width_pct: 60,
                     height: ModalHeight::Percent(70),
-                    border_color: Color::Cyan,
+                    border_style: Style::default().fg(Color::Cyan),
                     title: "Help",
                     footer: &[("j/k", "scroll"), ("any key", "close")],
                     footer_left: &[],
                     footer_right: None,
                     scroll: None,
+                    theme: None,
                 };
                 let inner = modal.render_chrome(frame, area);
 
@@ -847,12 +827,13 @@ mod tests {
                 let modal = ModalOverlay {
                     width_pct: 80,
                     height: ModalHeight::Percent(80),
-                    border_color: Color::Cyan,
+                    border_style: Style::default().fg(Color::Cyan),
                     title: "Save Review",
                     footer: &[("y", "confirm"), ("n", "cancel"), ("j/k", "scroll")],
                     footer_left: &[],
                     footer_right: None,
                     scroll: None,
+                    theme: None,
                 };
                 let inner = modal.render_chrome(frame, area);
 
@@ -875,12 +856,13 @@ mod tests {
                 let modal = ModalOverlay {
                     width_pct: 50,
                     height: ModalHeight::Percent(20),
-                    border_color: Color::Yellow,
+                    border_style: Style::default().fg(Color::Yellow),
                     title: "Confirm",
                     footer: &[("y", "yes"), ("n", "no")],
                     footer_left: &[],
                     footer_right: None,
                     scroll: None,
+                    theme: None,
                 };
                 let inner = modal.render_chrome(frame, area);
 


### PR DESCRIPTION
Centralize all TUI color/style decisions into a Theme struct with semantic tokens (e.g. `selection`, `effect_allow`, `border_focused`) instead of ~141 scattered inline Color:: references. Thread theme through Component::view via ViewContext, add two presets (default_dark, adaptive), and wire up CLASH_THEME env var for theme selection.

The adaptive preset uses Modifier::DIM instead of Color::DarkGray and avoids explicit backgrounds, making the TUI work correctly on solarized, gruvbox, dracula, and other terminal palettes.