### PR TITLE
refactor: remove unused dependencies across workspace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -728,7 +728,6 @@ dependencies = [
  "clash-brush-builtins",
  "clash-brush-core",
  "clash-brush-interactive",
- "clash-brush-parser",
  "clash_notify",
  "clash_starlark",
  "claude_settings",
@@ -736,7 +735,6 @@ dependencies = [
  "crossterm",
  "dialoguer",
  "dirs",
- "figment",
  "flate2",
  "fs2",
  "hotln",
@@ -747,16 +745,13 @@ dependencies = [
  "landlock",
  "libc",
  "mockito",
- "nu-ansi-term",
  "proptest",
  "ratatui",
- "reedline",
  "regex",
  "seccompiler",
  "semver",
  "serde",
  "serde_json",
- "serde_regex",
  "serde_yaml",
  "sha2",
  "similar",
@@ -770,7 +765,6 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "ureq",
- "uuid",
  "which",
 ]
 
@@ -816,7 +810,6 @@ dependencies = [
  "command-fds",
  "fancy-regex 0.17.0",
  "futures",
- "getrandom 0.4.2",
  "hostname",
  "inherent",
  "itertools 0.14.0",
@@ -833,7 +826,6 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
- "uuid",
  "uzers",
  "whoami",
 ]
@@ -865,7 +857,6 @@ dependencies = [
  "bon",
  "cached",
  "criterion",
- "getrandom 0.4.2",
  "indenter",
  "insta",
  "miette",
@@ -877,7 +868,6 @@ dependencies = [
  "thiserror 2.0.18",
  "tracing",
  "utf8-chars",
- "uuid",
  "winnow",
 ]
 
@@ -898,7 +888,6 @@ dependencies = [
  "anyhow",
  "include_dir",
  "indoc",
- "itertools 0.14.0",
  "pretty_assertions",
  "regex",
  "serde",
@@ -915,14 +904,12 @@ name = "claude_settings"
 version = "0.6.2"
 dependencies = [
  "anyhow",
- "dirs",
  "figment",
  "regex",
  "serde",
  "serde_json",
  "tempfile",
  "thiserror 2.0.18",
- "toml",
  "tracing",
 ]
 
@@ -1965,13 +1952,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.0",
  "wasip2",
  "wasip3",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -4144,16 +4129,6 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
-]
-
-[[package]]
-name = "serde_regex"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8136f1a4ea815d7eac4101cfd0b16dc0cb5e1fe1b8609dfd728058656b7badf"
-dependencies = [
- "regex",
- "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,6 @@ fs2 = "0.4"
 figment = { version = "0.10", features = ["json", "toml", "yaml"] }
 flate2 = "1"
 futures = "0.3.32"
-getrandom = { version = "0.4.1", features = ["wasm_js"] }
 hostname = "0.4.2"
 hotln = "0.2.1"
 http-body-util = "0.1"
@@ -77,8 +76,6 @@ notify-rust = "4"
 nu-ansi-term = "0.50"
 nucleo-matcher = "0.3"
 peg = "0.8.5"
-pest = "2"
-pest_derive = "2"
 pretty_assertions = { version = "1.4.1", features = ["unstable"] }
 indoc = "2"
 procfs = "0.18.0"
@@ -94,7 +91,6 @@ rpds = "1.2.0"
 semver = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde_regex = "1"
 serde_yaml = "0.9"
 sha2 = "0.10"
 shlex = "1"
@@ -131,7 +127,6 @@ tracing-subscriber = { version = "0.3.22", features = [
 ] }
 ureq = "2"
 utf8-chars = "3.0.6"
-uuid = { version = "1", features = ["v4"] }
 uucore = { version = "0.6.0", default-features = false, features = ["format"] }
 uzers = "0.12.2"
 which = "7"

--- a/clash-brush-core/Cargo.toml
+++ b/clash-brush-core/Cargo.toml
@@ -58,10 +58,6 @@ nix = { workspace = true }
 terminfo = { workspace = true }
 uzers = { workspace = true }
 
-[target.wasm32-unknown-unknown.dependencies]
-getrandom = { workspace = true }
-uuid = { workspace = true, features = ["js"] }
-
 [dev-dependencies]
 anyhow = { workspace = true }
 pretty_assertions = { workspace = true }

--- a/clash-brush-parser/Cargo.toml
+++ b/clash-brush-parser/Cargo.toml
@@ -25,7 +25,6 @@ arbitrary = { workspace = true, optional = true }
 bon = { workspace = true }
 cached = { workspace = true }
 indenter = { workspace = true }
-insta = { workspace = true, features = ["redactions"] }
 miette = { workspace = true, optional = true }
 peg = { workspace = true }
 serde = { workspace = true, optional = true, features = ["rc"] }
@@ -33,10 +32,6 @@ thiserror = { workspace = true }
 tracing = { workspace = true }
 utf8-chars = { workspace = true }
 winnow = { workspace = true, optional = true }
-
-[target.wasm32-unknown-unknown.dependencies]
-getrandom = { workspace = true }
-uuid = { workspace = true, features = ["js"] }
 
 [dev-dependencies]
 anyhow = { workspace = true }

--- a/clash/Cargo.toml
+++ b/clash/Cargo.toml
@@ -16,17 +16,14 @@ serde_json = { workspace = true }
 serde = { workspace = true }
 dirs = { workspace = true }
 fs2 = { workspace = true }
-figment = { workspace = true }
 tracing = { workspace = true }
 regex = { workspace = true }
-serde_regex = { workspace = true }
 toml = { workspace = true }
 tracing-subscriber = { workspace = true }
 serde_yaml = { workspace = true }
 thiserror = { workspace = true }
 bitflags = { workspace = true }
 libc = { workspace = true }
-uuid = { workspace = true }
 hotln = { workspace = true }
 ureq = { workspace = true }
 tokio = { workspace = true }
@@ -36,8 +33,6 @@ http-body-util = { workspace = true }
 bytes = { workspace = true }
 base64 = { workspace = true }
 console = { workspace = true }
-nu-ansi-term = { workspace = true }
-reedline = { workspace = true }
 dialoguer = { workspace = true }
 semver = { workspace = true }
 which = { workspace = true }
@@ -55,7 +50,6 @@ similar = { workspace = true }
 clash_notify = { workspace = true }
 clash_starlark = { workspace = true }
 claude_settings = { workspace = true }
-clash-brush-parser = { workspace = true }
 clash-brush-builtins = { workspace = true }
 clash-brush-core = { workspace = true }
 clash-brush-interactive = { workspace = true }

--- a/clash_starlark/Cargo.toml
+++ b/clash_starlark/Cargo.toml
@@ -20,7 +20,6 @@ include_dir = { workspace = true }
 thiserror = { workspace = true }
 tree-sitter = { workspace = true }
 tree-sitter-starlark = { workspace = true }
-itertools = {workspace = true}
 indoc = {workspace = true}
 
 [dev-dependencies]

--- a/claude_settings/Cargo.toml
+++ b/claude_settings/Cargo.toml
@@ -12,13 +12,11 @@ authors = ["Empathic Team"]
 
 [dependencies]
 anyhow = { workspace = true }
-dirs = { workspace = true }
 figment = { workspace = true }
 regex = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
-toml = { workspace = true }
 tracing = { workspace = true }
 
 [dev-dependencies]

--- a/claude_settings/fuzz/Cargo.lock
+++ b/claude_settings/fuzz/Cargo.lock
@@ -39,15 +39,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 
 [[package]]
-name = "block-buffer"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
 name = "bytemuck"
 version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -73,18 +64,14 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "claude_settings"
-version = "0.1.0"
+version = "0.6.2"
 dependencies = [
  "anyhow",
- "bitflags",
  "dirs",
  "figment",
- "pest",
- "pest_derive",
  "regex",
  "serde",
  "serde_json",
- "serde_yaml",
  "thiserror",
  "toml",
  "tracing",
@@ -96,35 +83,6 @@ version = "0.0.0"
 dependencies = [
  "claude_settings",
  "libfuzzer-sys",
-]
-
-[[package]]
-name = "cpufeatures"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "crypto-common"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
-dependencies = [
- "generic-array",
- "typenum",
-]
-
-[[package]]
-name = "digest"
-version = "0.10.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
-dependencies = [
- "block-buffer",
- "crypto-common",
 ]
 
 [[package]]
@@ -174,16 +132,6 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
-
-[[package]]
-name = "generic-array"
-version = "0.14.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
-dependencies = [
- "typenum",
- "version_check",
-]
 
 [[package]]
 name = "getrandom"
@@ -283,49 +231,6 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
-
-[[package]]
-name = "pest"
-version = "2.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c9eb05c21a464ea704b53158d358a31e6425db2f63a1a7312268b05fe2b75f7"
-dependencies = [
- "memchr",
- "ucd-trie",
-]
-
-[[package]]
-name = "pest_derive"
-version = "2.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68f9dbced329c441fa79d80472764b1a2c7e57123553b8519b36663a2fb234ed"
-dependencies = [
- "pest",
- "pest_generator",
-]
-
-[[package]]
-name = "pest_generator"
-version = "2.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bb96d5051a78f44f43c8f712d8e810adb0ebf923fc9ed2655a7f66f63ba8ee5"
-dependencies = [
- "pest",
- "pest_meta",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "pest_meta"
-version = "2.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "602113b5b5e8621770cfd490cfd90b9f84ab29bd2b0e49ad83eb6d186cef2365"
-dependencies = [
- "pest",
- "sha2",
-]
 
 [[package]]
 name = "pin-project-lite"
@@ -469,17 +374,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha2"
-version = "0.10.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest",
-]
-
-[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -587,18 +481,6 @@ checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
 ]
-
-[[package]]
-name = "typenum"
-version = "1.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
-
-[[package]]
-name = "ucd-trie"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "uncased"


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Remove 14 unused dependency declarations across 5 crates (clash, claude_settings, clash_starlark, clash-brush-core, clash-brush-parser)
- Remove 4 orphaned workspace-level deps (pest, pest_derive, serde_regex, uuid, getrandom)
- Move `insta` from regular to dev-only dependency in clash-brush-parser

Identified via `cargo-machete` with manual verification of each finding to filter false positives.

## Test plan

- [x] `cargo check` passes
- [ ] CI passes
EOF
)