### PR TITLE
feat: add gh CLI support to git sandboxes (#430)

### DIFF
--- a/clash_starlark/src/lib.rs
+++ b/clash_starlark/src/lib.rs
@@ -1160,4 +1160,58 @@ policy("test",
         let sb = &sandboxes["local_only"];
         assert_eq!(sb["network"], json!("localhost"));
     }
+
+    #[test]
+    fn test_git_safe_has_gh_config() {
+        let doc = eval_to_doc(
+            r#"
+load("@clash//sandboxes.star", "git_safe")
+load("@clash//std.star", "allow", "deny", "when", "policy", "settings")
+
+settings(default = deny())
+policy("test",
+    rules = when({"Bash": {"git": allow(sandbox=git_safe)}}),
+)
+"#,
+        );
+        let sandboxes = doc["sandboxes"].as_object().unwrap();
+        let sb = &sandboxes["git_safe"];
+        let rules = sb["rules"].as_array().unwrap();
+        let gh_rule = rules.iter().find(|r| {
+            r["path"]
+                .as_str()
+                .map_or(false, |p| p.contains(".config/gh"))
+        });
+        assert!(
+            gh_rule.is_some(),
+            "git_safe sandbox should include .config/gh/** rule, got: {rules:?}"
+        );
+    }
+
+    #[test]
+    fn test_git_full_has_gh_config() {
+        let doc = eval_to_doc(
+            r#"
+load("@clash//sandboxes.star", "git_full")
+load("@clash//std.star", "allow", "deny", "when", "policy", "settings")
+
+settings(default = deny())
+policy("test",
+    rules = when({"Bash": {"git": allow(sandbox=git_full)}}),
+)
+"#,
+        );
+        let sandboxes = doc["sandboxes"].as_object().unwrap();
+        let sb = &sandboxes["git_full"];
+        let rules = sb["rules"].as_array().unwrap();
+        let gh_rule = rules.iter().find(|r| {
+            r["path"]
+                .as_str()
+                .map_or(false, |p| p.contains(".config/gh"))
+        });
+        assert!(
+            gh_rule.is_some(),
+            "git_full sandbox should include .config/gh/** rule, got: {rules:?}"
+        );
+    }
 }

--- a/clash_starlark/stdlib/sandboxes.star
+++ b/clash_starlark/stdlib/sandboxes.star
@@ -42,12 +42,13 @@ git_safe = sandbox(
         "$HOME": {
             ".gitconfig": allow("r"),
             glob(".config/git/**"): allow("r"),
+            glob(".config/gh/**"): allow("r"),
             glob(".ssh/**"): allow("rx"),
         },
         glob("$TMPDIR/**"): allow(),
     },
     net = allow(),
-    doc = "Git safe: fetch, pull, log, diff. Worktree-aware, network + SSH enabled.",
+    doc = "Git safe: fetch, pull, log, diff, gh. Worktree-aware, network + SSH + gh CLI enabled.",
 )
 
 git_full = sandbox(
@@ -58,12 +59,13 @@ git_full = sandbox(
         "$HOME": {
             ".gitconfig": allow("r"),
             glob(".config/git/**"): allow("r"),
+            glob(".config/gh/**"): allow("r"),
             glob(".ssh/**"): allow("rx"),
         },
         glob("$TMPDIR/**"): allow(),
     },
     net = allow(),
-    doc = "Git full: commit, push, checkout, merge. Worktree-aware, network + SSH enabled.",
+    doc = "Git full: commit, push, checkout, merge, gh. Worktree-aware, network + SSH + gh CLI enabled.",
 )
 
 workspace = sandbox(

--- a/docs/superpowers/specs/2026-04-03-ecosystem-sandboxes-design.md
+++ b/docs/superpowers/specs/2026-04-03-ecosystem-sandboxes-design.md
@@ -31,16 +31,16 @@ Each ecosystem gets a `.star` file in `clash_starlark/stdlib/` exporting sandbox
 
 ### Git (`sandboxes.star`)
 
-**`git_safe`**: fetch, pull, log, diff, status, branch --list
+**`git_safe`**: fetch, pull, log, diff, status, branch --list, gh
 - `rx` on `$PWD` with `follow_worktrees=True`
-- Read `~/.gitconfig`, `~/.config/git/**`
+- Read `~/.gitconfig`, `~/.config/git/**`, `~/.config/gh/**`
 - Read+execute `~/.ssh/**`
 - Full `$TMPDIR`
 - Network: allow
 
-**`git_full`**: + commit, push, checkout, merge, rebase, stash
+**`git_full`**: + commit, push, checkout, merge, rebase, stash, gh
 - `FULL` on `$PWD` with `follow_worktrees=True`
-- Same config/SSH/tmpdir access as `git_safe`
+- Same config/SSH/tmpdir/gh access as `git_safe`
 - Network: allow
 
 ### Rust (`rust.star`)


### PR DESCRIPTION
## Summary
- Add glob(".config/gh/**"): allow("r") to both git_safe and git_full sandboxes in sandboxes.star, enabling the GitHub CLI to access its auth tokens and config files under ~/.config/gh/
- Update sandbox doc strings to mention gh CLI support
- Update ecosystem sandboxes design spec to reflect gh access
- Add tests verifying both sandboxes include the .config/gh/** rule

## Why
The gh CLI stores authentication tokens and configuration in ~/.config/gh/. Without read access to this directory, gh commands (e.g., gh pr create, gh issue list) fail inside git sandboxes. Since these sandboxes already grant network + SSH access for git operations, adding read-only gh config access is a natural extension.

Closes #430

## Test plan
- [x] cargo test -p clash_starlark — all 135 tests pass, including 2 new tests (test_git_safe_has_gh_config, test_git_full_has_gh_config)