### PR TITLE
feat: gate tui behind feature flag

### DIFF
--- a/clash/Cargo.toml
+++ b/clash/Cargo.toml
@@ -42,8 +42,8 @@ tar = { workspace = true }
 chrono = { workspace = true }
 toolpath = { workspace = true }
 toolpath-claude = { workspace = true }
-ratatui = { workspace = true }
-crossterm = { workspace = true }
+ratatui = { workspace = true, optional = true }
+crossterm = { workspace = true, optional = true }
 similar = { workspace = true }
 tempfile = { workspace = true }
 
@@ -57,6 +57,7 @@ clash-brush-interactive = { workspace = true }
 
 [features]
 default = []
+tui = ["dep:ratatui", "dep:crossterm"]
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/clash/src/cli.rs
+++ b/clash/src/cli.rs
@@ -73,12 +73,6 @@ pub enum PolicyCmd {
         /// Policy scope to edit: "user" or "project" (default: auto-detect)
         #[arg(long)]
         scope: Option<String>,
-        /// Open in $EDITOR instead of the interactive TUI
-        #[arg(long)]
-        raw: bool,
-        /// Open with the test console panel visible
-        #[arg(long)]
-        test: bool,
     },
     /// Add an allow rule for a tool or binary
     ///

--- a/clash/src/cmd/doctor.rs
+++ b/clash/src/cmd/doctor.rs
@@ -253,21 +253,28 @@ fn run_onboard() -> Result<()> {
     match &policy_check {
         CheckResult::Fail(_) => {
             if offer_fix(OnboardFix::CreatePolicy)? {
-                ui::progress("Launching policy editor...");
+                ui::progress("Creating starter policy...");
                 match crate::cmd::init::ensure_starter_policy() {
-                    Ok((path, created_new)) => {
-                        match crate::tui::run_with_options(&path, false, true) {
-                            Ok(crate::tui::TuiOutcome::Completed) => fixed += 1,
-                            Ok(crate::tui::TuiOutcome::Aborted) => {
-                                if created_new {
-                                    let _ = std::fs::remove_file(&path);
+                    Ok((_path, _created_new)) => {
+                        #[cfg(feature = "tui")]
+                        {
+                            match crate::tui::run_with_options(&_path, false, true) {
+                                Ok(crate::tui::TuiOutcome::Completed) => fixed += 1,
+                                Ok(crate::tui::TuiOutcome::Aborted) => {
+                                    if _created_new {
+                                        let _ = std::fs::remove_file(&_path);
+                                    }
+                                    ui::warn("Policy setup cancelled.");
                                 }
-                                ui::warn("Policy setup cancelled.");
+                                Err(e) => {
+                                    warn!(error = %e, "Policy editor failed during onboard");
+                                    ui::fail(&format!("Policy creation failed: {e}"));
+                                }
                             }
-                            Err(e) => {
-                                warn!(error = %e, "Policy editor failed during onboard");
-                                ui::fail(&format!("Policy creation failed: {e}"));
-                            }
+                        }
+                        #[cfg(not(feature = "tui"))]
+                        {
+                            fixed += 1;
                         }
                     }
                     Err(e) => {

--- a/clash/src/cmd/init.rs
+++ b/clash/src/cmd/init.rs
@@ -106,14 +106,21 @@ pub fn run(agent: Option<AgentKind>) -> Result<()> {
         }
         None => ensure_starter_policy()?,
     };
-    let outcome = crate::tui::run_with_options(&policy_path, false, true)?;
-    if outcome == crate::tui::TuiOutcome::Aborted {
-        if created_new {
-            let _ = std::fs::remove_file(&policy_path);
+    #[cfg(feature = "tui")]
+    {
+        let outcome = crate::tui::run_with_options(&policy_path, false, true)?;
+        if outcome == crate::tui::TuiOutcome::Aborted {
+            if created_new {
+                let _ = std::fs::remove_file(&policy_path);
+            }
+            println!();
+            ui::warn("Setup cancelled. Run `clash init` to try again.");
+            return Ok(());
         }
-        println!();
-        ui::warn("Setup cancelled. Run `clash init` to try again.");
-        return Ok(());
+    }
+    #[cfg(not(feature = "tui"))]
+    {
+        let _ = &policy_path;
     }
     actions.policy_created = created_new;
     actions.policy_reviewed = true;

--- a/clash/src/cmd/policy.rs
+++ b/clash/src/cmd/policy.rs
@@ -25,7 +25,7 @@ pub fn run(cmd: PolicyCmd) -> Result<()> {
         PolicyCmd::List { json } => handle_list(json),
         PolicyCmd::Validate { file, json } => handle_validate(file, json),
         PolicyCmd::Show { json } => handle_show(json),
-        PolicyCmd::Edit { scope, raw, test } => handle_edit(scope, raw, test),
+        PolicyCmd::Edit { scope } => handle_edit(scope),
         PolicyCmd::Allow {
             command,
             tool,
@@ -519,8 +519,7 @@ pub fn open_in_editor(path: &Path) -> Result<()> {
 fn validate_policy_source(path: &Path) -> Result<crate::policy::match_tree::CompiledPolicy> {
     let source = crate::settings::evaluate_policy_file(path)
         .with_context(|| format!("failed to evaluate: {}", path.display()))?;
-    crate::policy::compile::compile_to_tree(&source)
-        .with_context(|| "policy validation failed")
+    crate::policy::compile::compile_to_tree(&source).with_context(|| "policy validation failed")
 }
 
 /// Visudo-style edit loop: copy to tempfile, edit, validate, confirm, write.
@@ -625,32 +624,25 @@ fn edit_with_validation(path: &Path) -> Result<()> {
 }
 
 /// Handle `clash policy edit`.
-fn handle_edit(scope: Option<String>, raw: bool, test: bool) -> Result<()> {
-    if raw {
-        // --raw: visudo-style edit with validation
-        let level = match scope.as_deref() {
-            Some("user") => PolicyLevel::User,
-            Some("project") => PolicyLevel::Project,
-            Some(other) => {
-                anyhow::bail!("unknown scope: \"{other}\" (expected \"user\" or \"project\")")
-            }
-            None => ClashSettings::default_scope(),
-        };
-        let path = ClashSettings::policy_file_for_level(level)?;
-        if !path.exists() {
-            anyhow::bail!(
-                "no policy file at {} — run `clash init {}` first",
-                path.display(),
-                level,
-            );
+fn handle_edit(scope: Option<String>) -> Result<()> {
+    // --raw: visudo-style edit with validation
+    let level = match scope.as_deref() {
+        Some("user") => PolicyLevel::User,
+        Some("project") => PolicyLevel::Project,
+        Some(other) => {
+            anyhow::bail!("unknown scope: \"{other}\" (expected \"user\" or \"project\")")
         }
-        return edit_with_validation(&path);
+        None => ClashSettings::default_scope(),
+    };
+    let path = ClashSettings::policy_file_for_level(level)?;
+    if !path.exists() {
+        anyhow::bail!(
+            "no policy file at {} — run `clash init {}` first",
+            path.display(),
+            level,
+        );
     }
-
-    // Interactive TUI editor
-    let path = resolve_manifest_path(scope)?;
-    crate::tui::run_with_options(&path, test, false)?;
-    Ok(())
+    edit_with_validation(&path)
 }
 
 // ---------------------------------------------------------------------------
@@ -731,8 +723,8 @@ fn apply_mutation_star(
     use clash_starlark::codegen::managed::{self, ManagedUpsertResult};
     use clash_starlark::codegen::mutate::Effect as StarEffect;
 
-    let mut doc = StarDocument::open(path)
-        .with_context(|| format!("failed to open {}", path.display()))?;
+    let mut doc =
+        StarDocument::open(path).with_context(|| format!("failed to open {}", path.display()))?;
 
     let star_effect = match &mutation {
         PolicyMutation::Allow { .. } => StarEffect::Allow,
@@ -947,7 +939,9 @@ fn looks_like_hash(s: &str) -> bool {
 }
 
 /// Extract the binary name and args from an audit log entry's tool_input_summary.
-fn extract_command_from_entry(entry: &crate::debug::AuditLogEntry) -> Result<(String, Vec<String>)> {
+fn extract_command_from_entry(
+    entry: &crate::debug::AuditLogEntry,
+) -> Result<(String, Vec<String>)> {
     let summary = &entry.tool_input_summary;
     let clean = summary.trim_end_matches("...");
 
@@ -981,11 +975,7 @@ fn handle_allow(
     yes: bool,
 ) -> Result<()> {
     // Detect hash-based invocation: single positional arg that looks like a hex hash.
-    if command.len() == 1
-        && tool.is_none()
-        && bin.is_none()
-        && looks_like_hash(&command[0])
-    {
+    if command.len() == 1 && tool.is_none() && bin.is_none() && looks_like_hash(&command[0]) {
         return handle_allow_by_hash(&command[0], sandbox, scope, broad, yes);
     }
     apply_mutation(command, tool, bin, scope, PolicyMutation::Allow { sandbox })
@@ -1000,11 +990,7 @@ fn handle_deny(
     yes: bool,
 ) -> Result<()> {
     // Detect hash-based invocation: single positional arg that looks like a hex hash.
-    if command.len() == 1
-        && tool.is_none()
-        && bin.is_none()
-        && looks_like_hash(&command[0])
-    {
+    if command.len() == 1 && tool.is_none() && bin.is_none() && looks_like_hash(&command[0]) {
         return handle_deny_by_hash(&command[0], scope, broad, yes);
     }
     apply_mutation(command, tool, bin, scope, PolicyMutation::Deny)
@@ -1017,8 +1003,7 @@ fn handle_allow_by_hash(
     broad: bool,
     yes: bool,
 ) -> Result<()> {
-    let entry = crate::debug::log::find_by_hash(hash)
-        .context("failed to look up audit entry")?;
+    let entry = crate::debug::log::find_by_hash(hash).context("failed to look up audit entry")?;
 
     let (bin_name, args) = extract_command_from_entry(&entry)?;
 
@@ -1064,7 +1049,12 @@ fn handle_allow_by_hash(
         }
     }
 
-    apply_mutation_by_path(&path, &bin_name, &rule_args, PolicyMutation::Allow { sandbox })
+    apply_mutation_by_path(
+        &path,
+        &bin_name,
+        &rule_args,
+        PolicyMutation::Allow { sandbox },
+    )
 }
 
 /// Write a hash-based rule mutation using an already-resolved path.
@@ -1090,9 +1080,12 @@ fn apply_mutation_by_path(
         match mutation {
             PolicyMutation::Remove => {
                 if clash_starlark::codegen::managed::remove_exec_rule(
-                    &mut doc.stmts, bin_name, &arg_refs,
+                    &mut doc.stmts,
+                    bin_name,
+                    &arg_refs,
                 ) {
-                    doc.save().with_context(|| format!("failed to write {}", path.display()))?;
+                    doc.save()
+                        .with_context(|| format!("failed to write {}", path.display()))?;
                     println!("{} Rule removed", style::green_bold("✓"));
                 } else {
                     println!("No matching managed rule found");
@@ -1100,9 +1093,15 @@ fn apply_mutation_by_path(
             }
             _ => {
                 let result = clash_starlark::codegen::managed::upsert_exec_rule(
-                    &mut doc.stmts, bin_name, &arg_refs, star_effect, sandbox_name,
-                ).map_err(|e| anyhow::anyhow!("{e}"))?;
-                doc.save().with_context(|| format!("failed to write {}", path.display()))?;
+                    &mut doc.stmts,
+                    bin_name,
+                    &arg_refs,
+                    star_effect,
+                    sandbox_name,
+                )
+                .map_err(|e| anyhow::anyhow!("{e}"))?;
+                doc.save()
+                    .with_context(|| format!("failed to write {}", path.display()))?;
                 let result_str = match result {
                     clash_starlark::codegen::managed::ManagedUpsertResult::Inserted => "Rule added",
                     clash_starlark::codegen::managed::ManagedUpsertResult::Replaced => {
@@ -1119,7 +1118,9 @@ fn apply_mutation_by_path(
     let rule_arg_refs: Vec<&str> = rule_args.iter().map(|s| s.as_str()).collect();
     let decision = match &mutation {
         PolicyMutation::Allow { sandbox } => Decision::Allow(
-            sandbox.as_deref().map(|s| crate::policy::match_tree::SandboxRef(s.to_string())),
+            sandbox
+                .as_deref()
+                .map(|s| crate::policy::match_tree::SandboxRef(s.to_string())),
         ),
         PolicyMutation::Deny => Decision::Deny,
         PolicyMutation::Remove => Decision::Deny,
@@ -1149,14 +1150,8 @@ fn apply_mutation_by_path(
     Ok(())
 }
 
-fn handle_deny_by_hash(
-    hash: &str,
-    scope: Option<String>,
-    broad: bool,
-    yes: bool,
-) -> Result<()> {
-    let entry = crate::debug::log::find_by_hash(hash)
-        .context("failed to look up audit entry")?;
+fn handle_deny_by_hash(hash: &str, scope: Option<String>, broad: bool, yes: bool) -> Result<()> {
+    let entry = crate::debug::log::find_by_hash(hash).context("failed to look up audit entry")?;
 
     let (bin_name, args) = extract_command_from_entry(&entry)?;
 
@@ -1343,10 +1338,7 @@ fn handle_convert(file: Option<PathBuf>, replace: bool) -> Result<()> {
 fn handle_migrate(scope: Option<String>, yes: bool) -> Result<()> {
     let path = resolve_manifest_path(scope)?;
 
-    if !path
-        .extension()
-        .is_some_and(|ext| ext == "star")
-    {
+    if !path.extension().is_some_and(|ext| ext == "star") {
         anyhow::bail!(
             "policy file is not .star format: {}\nRun `clash policy convert` first to migrate from JSON.",
             path.display()
@@ -1435,11 +1427,7 @@ fn handle_migrate(scope: Option<String>, yes: bool) -> Result<()> {
 
     std::fs::write(&path, &new_source)
         .with_context(|| format!("failed to write {}", path.display()))?;
-    eprintln!(
-        "{} Migrated {}",
-        style::green_bold("✓"),
-        path.display()
-    );
+    eprintln!("{} Migrated {}", style::green_bold("✓"), path.display());
 
     Ok(())
 }

--- a/clash/src/lib.rs
+++ b/clash/src/lib.rs
@@ -61,6 +61,7 @@ pub mod style;
 pub mod trace;
 pub mod trace_display;
 pub mod tracing_init;
+#[cfg(feature = "tui")]
 pub mod tui;
 pub mod ui;
 pub mod version;


### PR DESCRIPTION
Remove the interactive TUI from `clash policy edit` (now always opens
$EDITOR with visudo-style validation) and put the TUI module on ice
behind a `tui` cargo feature, along with its `ratatui` and `crossterm`
dependencies. Callers in `init` and `doctor` are cfg-gated and skip the
walkthrough when the feature is disabled.
