### PR TITLE
feat(starlark): unify policy() and sandbox() to (name, tree) shape with typed root keys

### DIFF
--- a/clash-lsp/src/analysis/mod.rs
+++ b/clash-lsp/src/analysis/mod.rs
@@ -88,7 +88,7 @@ mod tests {
     #[test]
     fn parses_valid_policy_with_no_diagnostics() {
         let src = indoc! {r#"
-            policy("test", {"Bash": allow()})
+            policy("test", {tool("Bash"): allow()})
         "#};
         let parsed = parse("test.star", src);
         assert!(

--- a/clash-lsp/src/documents.rs
+++ b/clash-lsp/src/documents.rs
@@ -60,7 +60,10 @@ mod tests {
     fn open_then_get_returns_parsed() {
         let store = DocumentStore::new();
         let uri: Url = "file:///x.star".parse().unwrap();
-        let _ = store.open(uri.clone(), r#"policy("test", {"Bash": allow()})"#.into());
+        let _ = store.open(
+            uri.clone(),
+            r#"policy("test", {tool("Bash"): allow()})"#.into(),
+        );
         assert!(store.get(&uri).is_some());
     }
 
@@ -68,7 +71,10 @@ mod tests {
     fn close_removes_entry() {
         let store = DocumentStore::new();
         let uri: Url = "file:///x.star".parse().unwrap();
-        store.open(uri.clone(), r#"policy("test", {"Bash": allow()})"#.into());
+        store.open(
+            uri.clone(),
+            r#"policy("test", {tool("Bash"): allow()})"#.into(),
+        );
         store.close(&uri);
         assert!(store.get(&uri).is_none());
     }

--- a/clash/src/cmd/from_trace.rs
+++ b/clash/src/cmd/from_trace.rs
@@ -516,11 +516,11 @@ mod tests {
         assert!(policy.contains("load(\"@clash//sandboxes.star\""));
 
         // Should contain tool rules
-        assert!(policy.contains("(\"Read\", \"Grep\"): allow(sandbox = project_files)"));
-        assert!(policy.contains("\"Write\": allow(sandbox = project_files)"));
+        assert!(policy.contains("tool((\"Read\", \"Grep\")): allow(sandbox = project_files)"));
+        assert!(policy.contains("tool(\"Write\"): allow(sandbox = project_files)"));
 
         // Should contain when rules for binaries
-        assert!(policy.contains("\"Bash\":"));
+        assert!(policy.contains("tool(\"Bash\")"));
         assert!(policy.contains("allow(sandbox = project)"));
 
         // Should contain git safety rules
@@ -544,8 +544,8 @@ mod tests {
         };
 
         let policy = generate_starlark(&analysis);
-        assert!(policy.contains("\"Read\": allow(sandbox = project_files)"));
-        assert!(policy.contains("\"Edit\": allow(sandbox = project_files)"));
+        assert!(policy.contains("tool(\"Read\"): allow(sandbox = project_files)"));
+        assert!(policy.contains("tool(\"Edit\"): allow(sandbox = project_files)"));
         // No binary-specific rules (no "git", "cargo" etc.)
         assert!(!policy.contains("# Observed binaries"));
     }
@@ -563,7 +563,7 @@ mod tests {
         // Should generate a generic Bash when rule since we know bash was used
         // but total_invocations > tools count
         assert!(
-            policy.contains("{\"Bash\": allow(sandbox = project)}"),
+            policy.contains("{tool(\"Bash\"): allow(sandbox = project)}"),
             "expected dict syntax in:\n{policy}"
         );
     }
@@ -610,6 +610,6 @@ mod tests {
 
         let policy = generate_starlark(&analysis);
         // Network tools should use ask(), not allow()
-        assert!(policy.contains("(\"WebFetch\", \"WebSearch\"): ask()"));
+        assert!(policy.contains("tool((\"WebFetch\", \"WebSearch\")): ask()"));
     }
 }

--- a/clash/src/cmd/import_settings.rs
+++ b/clash/src/cmd/import_settings.rs
@@ -586,11 +586,11 @@ mod tests {
 
         // The other-allows rule should be just WebFetch, not a tuple with Bash.
         assert!(
-            rules_section.contains("\"WebFetch\": allow()"),
+            rules_section.contains("tool(\"WebFetch\"): allow()"),
             "expected WebFetch as sole other-allowed tool, got:\n{rules_section}"
         );
         assert!(
-            !rules_section.contains("(\"Bash\""),
+            !rules_section.contains("tool((\"Bash\""),
             "Bash should not appear in tool tuple:\n{rules_section}"
         );
 

--- a/clash/src/cmd/init.rs
+++ b/clash/src/cmd/init.rs
@@ -636,8 +636,6 @@ fn remove_clash_from_vec(opt: &mut Option<Vec<claude_settings::HookMatcher>>) ->
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-
     #[test]
     fn detected_policy_compiles() {
         let ecosystems: Vec<&crate::ecosystem::EcosystemDef> = crate::ecosystem::ECOSYSTEMS

--- a/clash/src/cmd/init.rs
+++ b/clash/src/cmd/init.rs
@@ -661,7 +661,7 @@ mod tests {
 
     #[test]
     fn rust_sandbox_compiles() {
-        let source = "load(\"@clash//rust.star\", \"rust_safe\", \"rust_full\")\n\npolicy(\"test\", {Tool(\"Bash\"): {(\"cargo\", \"rustc\", \"rustup\"): {glob(\"**\"): allow(sandbox=rust_safe)}}})";
+        let source = "load(\"@clash//rust.star\", \"rust_safe\", \"rust_full\")\n\npolicy(\"test\", {tool(\"Bash\"): {(\"cargo\", \"rustc\", \"rustup\"): {glob(\"**\"): allow(sandbox=rust_safe)}}})";
         let output = clash_starlark::evaluate(source, "<test>", std::path::Path::new("."))
             .expect("rust sandbox starlark evaluation");
         crate::policy::compile::compile_to_tree(&output.json).expect("rust sandbox must compile");
@@ -669,7 +669,7 @@ mod tests {
 
     #[test]
     fn python_sandbox_compiles() {
-        let source = "load(\"@clash//python.star\", \"python_full\")\n\npolicy(\"test\", {Tool(\"Bash\"): {(\"python\", \"python3\"): {glob(\"**\"): allow(sandbox=python_full)}}})";
+        let source = "load(\"@clash//python.star\", \"python_full\")\n\npolicy(\"test\", {tool(\"Bash\"): {(\"python\", \"python3\"): {glob(\"**\"): allow(sandbox=python_full)}}})";
         let output = clash_starlark::evaluate(source, "<test>", std::path::Path::new("."))
             .expect("python sandbox starlark evaluation");
         crate::policy::compile::compile_to_tree(&output.json).expect("python sandbox must compile");
@@ -677,7 +677,7 @@ mod tests {
 
     #[test]
     fn node_sandbox_compiles() {
-        let source = "load(\"@clash//node.star\", \"node_full\")\n\npolicy(\"test\", {Tool(\"Bash\"): {(\"node\", \"npm\"): {glob(\"**\"): allow(sandbox=node_full)}}})";
+        let source = "load(\"@clash//node.star\", \"node_full\")\n\npolicy(\"test\", {tool(\"Bash\"): {(\"node\", \"npm\"): {glob(\"**\"): allow(sandbox=node_full)}}})";
         let output = clash_starlark::evaluate(source, "<test>", std::path::Path::new("."))
             .expect("node sandbox starlark evaluation");
         crate::policy::compile::compile_to_tree(&output.json).expect("node sandbox must compile");
@@ -685,7 +685,7 @@ mod tests {
 
     #[test]
     fn go_sandbox_compiles() {
-        let source = "load(\"@clash//go.star\", \"go_safe\", \"go_full\")\n\npolicy(\"test\", {Tool(\"Bash\"): {\"go\": {glob(\"**\"): allow(sandbox=go_safe)}}})";
+        let source = "load(\"@clash//go.star\", \"go_safe\", \"go_full\")\n\npolicy(\"test\", {tool(\"Bash\"): {\"go\": {glob(\"**\"): allow(sandbox=go_safe)}}})";
         let output = clash_starlark::evaluate(source, "<test>", std::path::Path::new("."))
             .expect("go sandbox starlark evaluation");
         crate::policy::compile::compile_to_tree(&output.json).expect("go sandbox must compile");
@@ -693,7 +693,7 @@ mod tests {
 
     #[test]
     fn java_sandbox_compiles() {
-        let source = "load(\"@clash//java.star\", \"java_full\")\n\npolicy(\"test\", {Tool(\"Bash\"): {(\"gradle\", \"mvn\"): {glob(\"**\"): allow(sandbox=java_full)}}})";
+        let source = "load(\"@clash//java.star\", \"java_full\")\n\npolicy(\"test\", {tool(\"Bash\"): {(\"gradle\", \"mvn\"): {glob(\"**\"): allow(sandbox=java_full)}}})";
         let output = clash_starlark::evaluate(source, "<test>", std::path::Path::new("."))
             .expect("java sandbox starlark evaluation");
         crate::policy::compile::compile_to_tree(&output.json).expect("java sandbox must compile");
@@ -701,7 +701,7 @@ mod tests {
 
     #[test]
     fn ruby_sandbox_compiles() {
-        let source = "load(\"@clash//ruby.star\", \"ruby_full\")\n\npolicy(\"test\", {Tool(\"Bash\"): {(\"ruby\", \"gem\", \"bundle\"): {glob(\"**\"): allow(sandbox=ruby_full)}}})";
+        let source = "load(\"@clash//ruby.star\", \"ruby_full\")\n\npolicy(\"test\", {tool(\"Bash\"): {(\"ruby\", \"gem\", \"bundle\"): {glob(\"**\"): allow(sandbox=ruby_full)}}})";
         let output = clash_starlark::evaluate(source, "<test>", std::path::Path::new("."))
             .expect("ruby sandbox starlark evaluation");
         crate::policy::compile::compile_to_tree(&output.json).expect("ruby sandbox must compile");
@@ -709,7 +709,7 @@ mod tests {
 
     #[test]
     fn docker_sandbox_compiles() {
-        let source = "load(\"@clash//docker.star\", \"docker_safe\", \"docker_full\")\n\npolicy(\"test\", {Tool(\"Bash\"): {(\"docker\", \"podman\"): {glob(\"**\"): allow(sandbox=docker_safe)}}})";
+        let source = "load(\"@clash//docker.star\", \"docker_safe\", \"docker_full\")\n\npolicy(\"test\", {tool(\"Bash\"): {(\"docker\", \"podman\"): {glob(\"**\"): allow(sandbox=docker_safe)}}})";
         let output = clash_starlark::evaluate(source, "<test>", std::path::Path::new("."))
             .expect("docker sandbox starlark evaluation");
         crate::policy::compile::compile_to_tree(&output.json).expect("docker sandbox must compile");
@@ -717,7 +717,7 @@ mod tests {
 
     #[test]
     fn swift_sandbox_compiles() {
-        let source = "load(\"@clash//swift.star\", \"swift_full\")\n\npolicy(\"test\", {Tool(\"Bash\"): {(\"swift\", \"xcodebuild\"): {glob(\"**\"): allow(sandbox=swift_full)}}})";
+        let source = "load(\"@clash//swift.star\", \"swift_full\")\n\npolicy(\"test\", {tool(\"Bash\"): {(\"swift\", \"xcodebuild\"): {glob(\"**\"): allow(sandbox=swift_full)}}})";
         let output = clash_starlark::evaluate(source, "<test>", std::path::Path::new("."))
             .expect("swift sandbox starlark evaluation");
         crate::policy::compile::compile_to_tree(&output.json).expect("swift sandbox must compile");
@@ -725,7 +725,7 @@ mod tests {
 
     #[test]
     fn dotnet_sandbox_compiles() {
-        let source = "load(\"@clash//dotnet.star\", \"dotnet_full\")\n\npolicy(\"test\", {Tool(\"Bash\"): {(\"dotnet\", \"msbuild\"): {glob(\"**\"): allow(sandbox=dotnet_full)}}})";
+        let source = "load(\"@clash//dotnet.star\", \"dotnet_full\")\n\npolicy(\"test\", {tool(\"Bash\"): {(\"dotnet\", \"msbuild\"): {glob(\"**\"): allow(sandbox=dotnet_full)}}})";
         let output = clash_starlark::evaluate(source, "<test>", std::path::Path::new("."))
             .expect("dotnet sandbox starlark evaluation");
         crate::policy::compile::compile_to_tree(&output.json).expect("dotnet sandbox must compile");
@@ -733,7 +733,7 @@ mod tests {
 
     #[test]
     fn make_sandbox_compiles() {
-        let source = "load(\"@clash//make.star\", \"make_full\")\n\npolicy(\"test\", {Tool(\"Bash\"): {(\"make\", \"cmake\", \"just\"): {glob(\"**\"): allow(sandbox=make_full)}}})";
+        let source = "load(\"@clash//make.star\", \"make_full\")\n\npolicy(\"test\", {tool(\"Bash\"): {(\"make\", \"cmake\", \"just\"): {glob(\"**\"): allow(sandbox=make_full)}}})";
         let output = clash_starlark::evaluate(source, "<test>", std::path::Path::new("."))
             .expect("make sandbox starlark evaluation");
         crate::policy::compile::compile_to_tree(&output.json).expect("make sandbox must compile");

--- a/clash/src/default_policy.star
+++ b/clash/src/default_policy.star
@@ -15,21 +15,21 @@ policy("default", merge(
     {
         mode("plan"): {
             glob("**"): allow(sandbox=readonly),
-            Tool("Bash"): {
+            tool("Bash"): {
                 "git": {
-                    glob("**"): allow(sandbox=git_safe)
-                }
-            }
+                    glob("**"): allow(sandbox=git_safe),
+                },
+            },
         },
         (mode("edit"), mode("default")): {
-            Tool("Bash"): {
+            tool("Bash"): {
                 "git": {
-                    glob("**"): allow(sandbox=git_full)
-                }
-            }
+                    glob("**"): allow(sandbox=git_full),
+                },
+            },
         },
         mode("unrestricted"): {
             glob("**"): allow(sandbox=workspace),
         },
     },
-))
+), doc="Default clash policy: mode-aware sandboxes for plan/edit/unrestricted modes.")

--- a/clash/src/policy_gen/spec.rs
+++ b/clash/src/policy_gen/spec.rs
@@ -409,7 +409,7 @@ impl PolicySpec {
         )];
         if !plan_bash.is_empty() {
             plan_inner.push(DictEntry::new(
-                Expr::call("Tool", vec![Expr::string("Bash")]),
+                Expr::call("tool", vec![Expr::string("Bash")]),
                 Expr::dict(plan_bash),
             ));
         }
@@ -426,7 +426,7 @@ impl PolicySpec {
         )];
         if !edit_bash.is_empty() {
             edit_inner.push(DictEntry::new(
-                Expr::call("Tool", vec![Expr::string("Bash")]),
+                Expr::call("tool", vec![Expr::string("Bash")]),
                 Expr::dict(edit_bash),
             ));
         }

--- a/clash/src/policy_loader.rs
+++ b/clash/src/policy_loader.rs
@@ -452,7 +452,7 @@ mod tests {
                 r#"
 load("@clash//std.star", "policy", "settings", "deny")
 settings(default = deny())
-policy("include", {"Read": allow()})
+policy("include", {tool("Read"): allow()})
 "#,
             )
             .unwrap();

--- a/clash_starlark/src/builders/match_tree.rs
+++ b/clash_starlark/src/builders/match_tree.rs
@@ -114,7 +114,28 @@ pub fn pattern_to_json<'v>(value: Value<'v>, heap: &'v Heap) -> anyhow::Result<J
     {
         return Ok(json!({"regex": s}));
     }
-    // Check for glob struct
+    // Check for new typed-key glob struct: struct(_match_key="glob", _match_value="...")
+    if value.get_type() == "struct"
+        && let Ok(Some(mk_val)) = value.get_attr("_match_key", heap)
+        && mk_val.unpack_str() == Some("glob")
+        && let Ok(Some(mv_val)) = value.get_attr("_match_value", heap)
+        && let Some(pat) = mv_val.unpack_str()
+    {
+        if pat == "*" || pat == "**" {
+            return Ok(json!("wildcard"));
+        }
+        if let Some(stripped) = pat.strip_suffix("/**/*") {
+            return Ok(json!({"prefix": {"literal": stripped}}));
+        }
+        if let Some(stripped) = pat.strip_suffix("/**") {
+            return Ok(json!({"prefix": {"literal": stripped}}));
+        }
+        if let Some(stripped) = pat.strip_suffix("/*") {
+            return Ok(json!({"child_of": {"literal": stripped}}));
+        }
+        return Ok(json!({"prefix": {"literal": pat}}));
+    }
+    // Check for legacy glob struct
     if value.get_type() == "struct"
         && let Ok(Some(glob_val)) = value.get_attr("_glob", heap)
         && let Some(s) = glob_val.unpack_str()

--- a/clash_starlark/src/codegen/builder.rs
+++ b/clash_starlark/src/codegen/builder.rs
@@ -127,7 +127,7 @@ fn match_dict(entries: Vec<(MatchKey, MatchValue)>) -> Expr {
                     Expr::tuple(items.into_iter().map(Expr::string).collect())
                 }
                 MatchKey::Mode(name) => Expr::call("Mode", vec![Expr::string(name)]),
-                MatchKey::Tool(name) => Expr::call("Tool", vec![Expr::string(name)]),
+                MatchKey::Tool(name) => Expr::call("tool", vec![Expr::string(name)]),
             };
             let value = match v {
                 MatchValue::Effect(e) => e,

--- a/clash_starlark/src/codegen/builder.rs
+++ b/clash_starlark/src/codegen/builder.rs
@@ -103,11 +103,11 @@ pub enum MatchValue {
 /// removed.  The returned expression is now a plain dict suitable for passing
 /// directly to `policy()` or `merge()`.
 pub fn match_rule(entries: Vec<(MatchKey, MatchValue)>) -> Expr {
-    match_dict(entries)
+    match_dict(entries, true)
 }
 
-/// Build a simple tool match rule: `{"Name": effect()}` or
-/// `{("A", "B"): effect()}` for multiple tool names.
+/// Build a simple tool match rule: `{tool("Name"): effect()}` or
+/// `{tool(("A", "B")): effect()}` for multiple tool names.
 pub fn tool_match(names: &[&str], effect: Expr) -> Expr {
     let key: MatchKey = if names.len() == 1 {
         MatchKey::Single(names[0].to_owned())
@@ -117,21 +117,32 @@ pub fn tool_match(names: &[&str], effect: Expr) -> Expr {
     match_rule(vec![(key, MatchValue::Effect(effect))])
 }
 
-fn match_dict(entries: Vec<(MatchKey, MatchValue)>) -> Expr {
+fn match_dict(entries: Vec<(MatchKey, MatchValue)>, is_root: bool) -> Expr {
     let dict_entries = entries
         .into_iter()
         .map(|(k, v)| {
             let key = match k {
-                MatchKey::Single(s) => Expr::string(s),
+                MatchKey::Single(s) => {
+                    if is_root {
+                        Expr::call("tool", vec![Expr::string(s)])
+                    } else {
+                        Expr::string(s)
+                    }
+                }
                 MatchKey::Tuple(items) => {
-                    Expr::tuple(items.into_iter().map(Expr::string).collect())
+                    let tup = Expr::tuple(items.into_iter().map(Expr::string).collect());
+                    if is_root {
+                        Expr::call("tool", vec![tup])
+                    } else {
+                        tup
+                    }
                 }
                 MatchKey::Mode(name) => Expr::call("Mode", vec![Expr::string(name)]),
                 MatchKey::Tool(name) => Expr::call("tool", vec![Expr::string(name)]),
             };
             let value = match v {
                 MatchValue::Effect(e) => e,
-                MatchValue::Nested(inner) => match_dict(inner),
+                MatchValue::Nested(inner) => match_dict(inner, false),
             };
             DictEntry::new(key, value)
         })
@@ -220,7 +231,7 @@ mod tests {
         let expr = tool_match(&["Read"], allow());
         let stmts = vec![Stmt::Expr(expr)];
         let src = serialize(&stmts);
-        assert_eq!(src, "{\"Read\": allow()}\n");
+        assert_eq!(src, "{tool(\"Read\"): allow()}\n");
     }
 
     #[test]
@@ -232,7 +243,7 @@ mod tests {
         let stmts = vec![Stmt::Expr(expr)];
         let src = serialize(&stmts);
         assert!(
-            src.contains("(\"Read\", \"Glob\", \"Grep\"): allow(sandbox = _fs_box)"),
+            src.contains("tool((\"Read\", \"Glob\", \"Grep\")): allow(sandbox = _fs_box)"),
             "got:\n{src}"
         );
     }
@@ -273,7 +284,7 @@ mod tests {
         assert!(src.contains("load(\"@clash//std.star\""));
         assert!(src.contains("settings("));
         assert!(src.contains("policy(\"default\""));
-        assert!(src.contains("{\"Read\": allow()}"), "got:\n{src}");
+        assert!(src.contains("{tool(\"Read\"): allow()}"), "got:\n{src}");
     }
 
     #[test]

--- a/clash_starlark/src/codegen/document.rs
+++ b/clash_starlark/src/codegen/document.rs
@@ -118,7 +118,7 @@ policy("test", default = ask(), rules = [tool(["Read"]).allow()])
 
 settings(default = ask())
 
-policy("test", {"Read": allow()}, default = ask())
+policy("test", {tool("Read"): allow()}, default = ask())
 "#;
         let doc = doc_from_str(src);
         let json = doc.evaluate_to_json().unwrap();

--- a/clash_starlark/src/codegen/macros.rs
+++ b/clash_starlark/src/codegen/macros.rs
@@ -151,7 +151,7 @@ mod tests {
             "Bash" => allow(),
         };
         let src = serialize(&[Stmt::Expr(expr)]);
-        assert_eq!(src, "{\"Bash\": allow()}\n");
+        assert_eq!(src, "{tool(\"Bash\"): allow()}\n");
     }
 
     #[test]
@@ -256,7 +256,7 @@ mod tests {
         ];
         let src = serialize(&stmts);
         assert!(src.contains("(\"git\", \"cargo\"): allow()"));
-        assert!(src.contains("\"Read\": allow()"));
+        assert!(src.contains("tool(\"Read\"): allow()"));
     }
 
     #[test]

--- a/clash_starlark/src/codegen/macros.rs
+++ b/clash_starlark/src/codegen/macros.rs
@@ -269,8 +269,8 @@ mod tests {
         };
         let src = serialize(&[Stmt::Expr(expr)]);
         assert!(src.contains("Mode(\"plan\")"));
-        assert!(src.contains("Tool(\"Read\"): allow()"));
-        assert!(src.contains("Tool(\"ExitPlanMode\"): allow()"));
+        assert!(src.contains("tool(\"Read\"): allow()"));
+        assert!(src.contains("tool(\"ExitPlanMode\"): allow()"));
     }
 
     #[test]

--- a/clash_starlark/src/codegen/managed.rs
+++ b/clash_starlark/src/codegen/managed.rs
@@ -296,7 +296,7 @@ mod tests {
 
 policy("test", merge(
     from_claude_settings(),
-    {"Read": allow()},
+    {tool("Read"): allow()},
 ))
 "#,
         )

--- a/clash_starlark/src/codegen/managed.rs
+++ b/clash_starlark/src/codegen/managed.rs
@@ -67,7 +67,7 @@ pub fn upsert_tool_rule(
 ) -> Result<ManagedUpsertResult, String> {
     let effect_expr = build_effect_expr(effect, sandbox);
     let new_expr = Expr::dict(vec![DictEntry::new(
-        Expr::call("Tool", vec![Expr::string(tool_name)]),
+        Expr::call("tool", vec![Expr::string(tool_name)]),
         effect_expr,
     )]);
 
@@ -268,7 +268,7 @@ fn build_exec_dict_expr(
         value = Expr::dict(vec![DictEntry::new(Expr::string(*arg), value)]);
     }
     Expr::dict(vec![DictEntry::new(
-        Expr::call("Tool", vec![Expr::string("Bash")]),
+        Expr::call("tool", vec![Expr::string("Bash")]),
         Expr::dict(vec![DictEntry::new(Expr::string(binary), value)]),
     )])
 }
@@ -334,7 +334,7 @@ policy("test", merge(
         let result = upsert_tool_rule(&mut stmts, "Write", mutate::Effect::Allow, None).unwrap();
         assert_eq!(result, ManagedUpsertResult::Inserted);
         let src = serialize(&stmts);
-        assert!(src.contains("Tool(\"Write\"): allow()"), "got:\n{src}");
+        assert!(src.contains("tool(\"Write\"): allow()"), "got:\n{src}");
     }
 
     #[test]

--- a/clash_starlark/src/codegen/mutate.rs
+++ b/clash_starlark/src/codegen/mutate.rs
@@ -497,7 +497,7 @@ policy("test", default = deny(), rules = [when({"Read": allow()})])
         let mut stmts = policy_stmts();
         add_tool_rule(&mut stmts, &["Write"], Effect::Allow, None).unwrap();
         let src = serialize(&stmts);
-        assert!(src.contains("\"Write\": allow()"), "got:\n{src}");
+        assert!(src.contains("tool(\"Write\"): allow()"), "got:\n{src}");
         // Original rule still there
         assert!(src.contains("\"Read\": allow()"), "got:\n{src}");
     }
@@ -508,7 +508,7 @@ policy("test", default = deny(), rules = [when({"Read": allow()})])
         add_tool_rule(&mut stmts, &["Bash"], Effect::Allow, Some("_box")).unwrap();
         let src = serialize(&stmts);
         assert!(
-            src.contains("\"Bash\": allow(sandbox = _box)"),
+            src.contains("tool(\"Bash\"): allow(sandbox = _box)"),
             "got:\n{src}"
         );
     }
@@ -556,7 +556,7 @@ policy("test", default = deny(), rules = [when({"Read": allow()})])
         replace_rule(&mut stmts, 0, new_rule).unwrap();
         let src = serialize(&stmts);
         assert!(!src.contains("Read"), "got:\n{src}");
-        assert!(src.contains("\"Write\": deny()"), "got:\n{src}");
+        assert!(src.contains("tool(\"Write\"): deny()"), "got:\n{src}");
     }
 
     #[test]

--- a/clash_starlark/src/codegen/mutate.rs
+++ b/clash_starlark/src/codegen/mutate.rs
@@ -755,7 +755,7 @@ policy("test", default = deny(), rules = [])
 
 policy("test", merge(
     from_claude_settings(),
-    {"Read": allow()},
+    {tool("Read"): allow()},
 ))
 "#,
         )

--- a/clash_starlark/src/codegen/serialize.rs
+++ b/clash_starlark/src/codegen/serialize.rs
@@ -506,7 +506,11 @@ load(\"@clash//std.star\",
 
                 policy(
                     "test",
-                    merge({"Bash": {("git", "cargo"): allow()}}, {"Read": allow()}, {"Write": allow()}),
+                    merge(
+                        {tool("Bash"): {("git", "cargo"): allow()}},
+                        {tool("Read"): allow()},
+                        {tool("Write"): allow()},
+                    ),
                     default = ask(),
                 )
             "#}

--- a/clash_starlark/src/eval_context.rs
+++ b/clash_starlark/src/eval_context.rs
@@ -118,6 +118,12 @@ impl EvalContext {
                     .or_insert_with(|| sb.clone());
             }
         }
+        // Also include top-level sandbox(name, tree, ...) registrations.
+        for (name, sb) in self.sandboxes.borrow().iter() {
+            sandbox_map
+                .entry(name.clone())
+                .or_insert_with(|| sb.clone());
+        }
 
         let mut doc = serde_json::json!({
             "schema_version": 5,

--- a/clash_starlark/src/eval_context.rs
+++ b/clash_starlark/src/eval_context.rs
@@ -34,6 +34,8 @@ pub struct SettingsValue {
 #[derive(Debug, Clone)]
 pub struct PolicyRegistration {
     pub name: String,
+    /// Per-policy default effect override from a `default()` root key.
+    pub default_effect: Option<String>,
     pub tree_nodes: Vec<JsonValue>,
     pub sandboxes: Vec<JsonValue>,
 }
@@ -101,9 +103,10 @@ impl EvalContext {
             .ok_or_else(|| anyhow::anyhow!("policy file must call policy()"))?;
 
         let settings = self.settings.borrow();
-        let default_effect = settings
-            .as_ref()
-            .map(|s| s.default_effect.clone())
+        let default_effect = policy
+            .default_effect
+            .clone()
+            .or_else(|| settings.as_ref().map(|s| s.default_effect.clone()))
             .unwrap_or_else(|| "deny".to_string());
 
         // Collect sandboxes from policy rules (allow(sandbox=box) references)

--- a/clash_starlark/src/eval_context.rs
+++ b/clash_starlark/src/eval_context.rs
@@ -5,6 +5,7 @@
 //! after module eval completes.
 
 use std::cell::RefCell;
+use std::collections::BTreeMap;
 
 use serde_json::Value as JsonValue;
 use starlark::values::ProvidesStaticType;
@@ -44,6 +45,8 @@ pub struct PolicyRegistration {
 pub struct EvalContext {
     pub policy: RefCell<Option<PolicyRegistration>>,
     pub settings: RefCell<Option<SettingsValue>>,
+    /// Sandboxes registered via top-level `sandbox(name, tree, ...)` calls.
+    pub sandboxes: RefCell<BTreeMap<String, JsonValue>>,
     /// Leaf conflicts recorded by merge().
     pub shadows: RefCell<Vec<ShadowedRule>>,
 }
@@ -53,8 +56,20 @@ impl EvalContext {
         EvalContext {
             policy: RefCell::new(None),
             settings: RefCell::new(None),
+            sandboxes: RefCell::new(BTreeMap::new()),
             shadows: RefCell::new(Vec::new()),
         }
+    }
+
+    /// Register a sandbox by name. Bails if a sandbox with the same name
+    /// has already been registered.
+    pub fn register_sandbox(&self, name: &str, sb_json: JsonValue) -> anyhow::Result<()> {
+        let mut map = self.sandboxes.borrow_mut();
+        if map.contains_key(name) {
+            anyhow::bail!("sandbox `{name}` is already registered");
+        }
+        map.insert(name.to_string(), sb_json);
+        Ok(())
     }
 
     /// Register settings.

--- a/clash_starlark/src/globals.rs
+++ b/clash_starlark/src/globals.rs
@@ -233,14 +233,14 @@ fn register_globals(builder: &mut GlobalsBuilder) {
     /// Accepts dict form only: `policy("name", {mode("plan"): allow(), ...})`
     fn _policy_impl<'v>(
         #[starlark(require = pos)] name: &str,
-        #[starlark(require = pos, default = starlark::values::none::NoneType)] rules_or_dict: Value<
-            'v,
-        >,
-        #[starlark(require = named, default = starlark::values::none::NoneType)] default: Value<'v>,
+        #[starlark(require = pos)] tree: Value<'v>,
+        #[starlark(require = named, default = "deny")] default: &str,
         #[starlark(require = named, default = starlark::values::none::NoneType)]
         default_sandbox: Value<'v>,
+        #[starlark(require = named, default = starlark::values::none::NoneType)] doc: Value<'v>,
         eval: &mut Evaluator<'v, '_, '_>,
     ) -> anyhow::Result<NoneType> {
+        let _ = doc; // accepted but currently unused in registration
         let heap = eval.heap();
         let ctx = eval
             .extra
@@ -251,37 +251,31 @@ fn register_globals(builder: &mut GlobalsBuilder) {
                 )
             })?;
 
-        // Reject non-dict, non-None values with a helpful error
-        if !rules_or_dict.is_none() && DictRef::from_value(rules_or_dict).is_none() {
+        // Reject non-dict values with a helpful error
+        if DictRef::from_value(tree).is_none() {
             anyhow::bail!(
-                "policy() requires a dict argument, got {}. The when()/rules= syntax has been removed — use dict syntax instead. Run 'clash policy migrate' to convert.",
-                rules_or_dict.get_type()
+                "policy() requires a dict tree argument, got {}. \
+                 Use the unified shape: policy(\"name\", {{ default(): deny(), mode(\"plan\"): allow(), tool(\"Bash\"): {{...}} }}). \
+                 Run 'clash policy migrate' to convert legacy files.",
+                tree.get_type()
             );
         }
 
-        // Unwrap default effect (reserved for future use in policy registration)
-        let _default_effect = if default.is_none() {
-            "deny".to_string()
-        } else if let Some(s) = default.unpack_str() {
-            s.to_string()
-        } else if default.get_type() == "struct" {
-            // Effect struct — extract _effect
-            default
-                .get_attr("_effect", heap)
-                .ok()
-                .flatten()
-                .and_then(|v| v.unpack_str().map(|s| s.to_string()))
-                .unwrap_or_else(|| "deny".to_string())
-        } else {
-            "deny".to_string()
-        };
-
         let source = caller_source_location(eval);
-        let (flat_nodes, sandboxes) =
-            crate::when::policy_impl(name, rules_or_dict, default_sandbox, heap, source)?;
+        let (default_override, flat_nodes, sandboxes) =
+            crate::when::policy_impl(name, tree, default_sandbox, heap, source)?;
+
+        let default_effect = default_override.or_else(|| {
+            if default.is_empty() {
+                None
+            } else {
+                Some(default.to_string())
+            }
+        });
 
         ctx.register_policy(PolicyRegistration {
             name: name.to_string(),
+            default_effect,
             tree_nodes: flat_nodes,
             sandboxes,
         })?;

--- a/clash_starlark/src/globals.rs
+++ b/clash_starlark/src/globals.rs
@@ -287,4 +287,30 @@ fn register_globals(builder: &mut GlobalsBuilder) {
         })?;
         Ok(NoneType)
     }
+
+    // -- Rust-native sandbox() (tree form) --
+
+    /// Register a named sandbox from a decision-tree dict.
+    fn _sandbox_impl<'v>(
+        #[starlark(require = pos)] name: &str,
+        #[starlark(require = pos)] tree: Value<'v>,
+        #[starlark(require = named, default = "deny")] default: &str,
+        #[starlark(require = named, default = starlark::values::none::NoneType)] doc: Value<'v>,
+        eval: &mut Evaluator<'v, '_, '_>,
+    ) -> anyhow::Result<NoneType> {
+        let heap = eval.heap();
+        let ctx = eval
+            .extra
+            .and_then(|e| e.downcast_ref::<EvalContext>())
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "sandbox() can only be called in a policy file, not in loaded modules"
+                )
+            })?;
+        let doc_str = doc.unpack_str().map(|s| s.to_string());
+        let source = caller_source_location(eval);
+        let sb_json = crate::when::sandbox_tree_impl(name, tree, default, doc_str, heap, source)?;
+        ctx.register_sandbox(name, sb_json)?;
+        Ok(NoneType)
+    }
 }

--- a/clash_starlark/src/lib.rs
+++ b/clash_starlark/src/lib.rs
@@ -11,6 +11,8 @@ mod globals;
 mod loader;
 pub mod settings_compat;
 pub mod stdlib;
+pub mod test_support;
+pub use test_support::{TestModule, load_starlark_source_for_test};
 mod when;
 
 use std::path::Path;
@@ -527,12 +529,10 @@ policy("test", {"Bash": {"test": allow(sandbox=_box)}})
     fn test_path_static() {
         let doc = eval_to_doc(
             r#"
-load("@clash//std.star", "allow", "deny", "policy", "settings", "sandbox", "path")
-
 _box = sandbox(
     name = "test",
     default = deny(),
-    fs = [path("/usr/local/bin").allow(read = True, execute = True)],
+    fs = {path("/usr/local/bin"): allow("rx")},
 )
 
 settings(default = deny())
@@ -547,12 +547,10 @@ policy("test", {"Bash": {"test": allow(sandbox=_box)}})
     fn test_path_env() {
         let doc = eval_to_doc(
             r#"
-load("@clash//std.star", "allow", "deny", "policy", "settings", "sandbox", "path")
-
 _box = sandbox(
     name = "test",
     default = deny(),
-    fs = [path(env = "CARGO_HOME").allow(read = True, write = True)],
+    fs = {path("$CARGO_HOME"): allow("rwc")},
 )
 
 settings(default = deny())
@@ -1358,8 +1356,8 @@ policy("test", {"Bash": {"git": allow(sandbox=git_full)}})
         let doc = eval_to_doc(
             r#"
 settings(default = deny())
-a = {Tool("Bash"): allow()}
-b = {Tool("Read"): allow()}
+a = {tool("Bash"): allow()}
+b = {tool("Read"): allow()}
 policy("test", merge(a, b))
 "#,
         );
@@ -1372,8 +1370,8 @@ policy("test", merge(a, b))
         let doc = eval_to_doc(
             r#"
 settings(default = deny())
-a = {Tool("Bash"): deny()}
-b = {Tool("Bash"): allow()}
+a = {tool("Bash"): deny()}
+b = {tool("Bash"): allow()}
 policy("test", merge(a, b))
 "#,
         );
@@ -1389,13 +1387,13 @@ policy("test", merge(a, b))
         let doc = eval_to_doc(
             r#"
 settings(default = deny())
-a = {Tool("Bash"): {"git": deny()}}
-b = {Tool("Bash"): {"npm": allow()}}
+a = {tool("Bash"): {"git": deny()}}
+b = {tool("Bash"): {"npm": allow()}}
 policy("test", merge(a, b))
 "#,
         );
         let tree = doc["tree"].as_array().unwrap();
-        // One Tool("Bash") node with two children (git + npm).
+        // One tool("Bash") node with two children (git + npm).
         assert_eq!(
             tree.len(),
             1,
@@ -1415,9 +1413,9 @@ policy("test", merge(a, b))
         let doc = eval_to_doc(
             r#"
 settings(default = deny())
-a = {Tool("Bash"): deny()}
-b = {Tool("Bash"): ask()}
-c = {Tool("Bash"): allow()}
+a = {tool("Bash"): deny()}
+b = {tool("Bash"): ask()}
+c = {tool("Bash"): allow()}
 policy("test", merge(a, b, c))
 "#,
         );
@@ -1432,7 +1430,7 @@ policy("test", merge(a, b, c))
     fn merge_rejects_single_arg() {
         let source = r#"
 settings(default = deny())
-policy("test", merge({Tool("Bash"): allow()}))
+policy("test", merge({tool("Bash"): allow()}))
 "#;
         let result = evaluate(source, "test.star", &PathBuf::from("."));
         assert!(result.is_err());
@@ -1442,7 +1440,7 @@ policy("test", merge({Tool("Bash"): allow()}))
     fn merge_rejects_non_dict() {
         let source = r#"
 settings(default = deny())
-policy("test", merge("not a dict", {Tool("Bash"): allow()}))
+policy("test", merge("not a dict", {tool("Bash"): allow()}))
 "#;
         let result = evaluate(source, "test.star", &PathBuf::from("."));
         assert!(result.is_err());
@@ -1452,8 +1450,8 @@ policy("test", merge("not a dict", {Tool("Bash"): allow()}))
     fn merge_records_shadows() {
         let source = r#"
 settings(default = deny())
-a = {Tool("Bash"): deny()}
-b = {Tool("Bash"): allow()}
+a = {tool("Bash"): deny()}
+b = {tool("Bash"): allow()}
 policy("test", merge(a, b))
 "#;
         let result = evaluate(source, "test.star", &PathBuf::from(".")).unwrap();
@@ -1463,7 +1461,7 @@ policy("test", merge(a, b))
         );
         let shadow = &result.shadows[0];
         assert_eq!(shadow.path.len(), 1);
-        // The key path should contain the Tool("Bash") representation.
+        // The key path should contain the tool("Bash") representation.
         assert!(
             shadow.path[0].contains("Bash"),
             "path should mention Bash: {:?}",

--- a/clash_starlark/src/lib.rs
+++ b/clash_starlark/src/lib.rs
@@ -12,7 +12,7 @@ mod loader;
 pub mod settings_compat;
 pub mod stdlib;
 pub mod test_support;
-pub use test_support::{TestModule, load_starlark_source_for_test};
+pub use test_support::{TestModule, eval_policy_source_for_test, load_starlark_source_for_test};
 mod when;
 
 use std::path::Path;
@@ -172,7 +172,7 @@ mod tests {
 load("@clash//std.star", "deny", "policy", "settings")
 
 settings(default = deny())
-policy("test", {None: allow()})
+policy("test", {tool(None): allow()})
 "#,
         );
         assert_eq!(doc["schema_version"], 5);
@@ -189,7 +189,7 @@ policy("test", {None: allow()})
         let doc = eval_to_doc(
             r#"
 settings(default = deny())
-policy("test", {None: allow()})
+policy("test", {tool(None): allow()})
 "#,
         );
         assert_eq!(doc["schema_version"], 5);
@@ -322,8 +322,8 @@ _box = sandbox(
 settings(default = deny())
 
 policy("test", merge(
-    {"Bash": {"git": allow(sandbox=_box)}},
-    {None: allow()},
+    {tool("Bash"): {"git": allow(sandbox=_box)}},
+    {tool(None): allow()},
 ))
 "#;
         let doc = eval_to_doc(source);
@@ -352,7 +352,7 @@ policy("test", merge(
 load("@clash//std.star", "deny", "policy", "settings")
 
 settings(default = deny())
-policy("test", {"WebSearch": allow(), "Bash": deny()})
+policy("test", {tool("WebSearch"): allow(), tool("Bash"): deny()})
 "#,
         );
         assert_eq!(doc["schema_version"], 5);
@@ -378,7 +378,7 @@ load("@clash//std.star", "allow", "deny", "policy", "settings", "sandbox", "cwd"
 _box = sandbox(name = "test", default = deny(), fs = [cwd().allow(read = True)])
 
 settings(default = deny())
-policy("test", {"Bash": {("rustc", "cargo", "cargo-clippy"): allow(sandbox=_box)}})
+policy("test", {tool("Bash"): {("rustc", "cargo", "cargo-clippy"): allow(sandbox=_box)}})
 "#,
         );
         assert_eq!(doc["schema_version"], 5);
@@ -408,7 +408,7 @@ _box = sandbox(
 )
 
 settings(default = deny())
-policy("test", {"Bash": {"cargo": allow(sandbox=_box)}})
+policy("test", {tool("Bash"): {"cargo": allow(sandbox=_box)}})
 "#,
         );
         assert_eq!(doc["schema_version"], 5);
@@ -430,7 +430,7 @@ _box = sandbox(
 )
 
 settings(default = deny())
-policy("test", {"Bash": {"git": allow(sandbox=_box)}})
+policy("test", {tool("Bash"): {"git": allow(sandbox=_box)}})
 "#,
         );
         assert_eq!(doc["schema_version"], 5);
@@ -452,7 +452,7 @@ _box = sandbox(
 )
 
 settings(default = deny())
-policy("test", {"Bash": {"npm": allow(sandbox=_box)}})
+policy("test", {tool("Bash"): {"npm": allow(sandbox=_box)}})
 "#,
         );
         assert_eq!(doc["schema_version"], 5);
@@ -472,7 +472,7 @@ _box = sandbox(
 )
 
 settings(default = deny())
-policy("test", {"Bash": {"git": allow(sandbox=_box)}})
+policy("test", {tool("Bash"): {"git": allow(sandbox=_box)}})
 "#,
         );
         assert_eq!(doc["schema_version"], 5);
@@ -499,7 +499,7 @@ _box = sandbox(
 )
 
 settings(default = deny())
-policy("test", {"Bash": {"git": allow(sandbox=_box)}})
+policy("test", {tool("Bash"): {"git": allow(sandbox=_box)}})
 "#,
         );
         let sandboxes = doc["sandboxes"].as_object().unwrap();
@@ -518,7 +518,7 @@ load("@clash//std.star", "allow", "deny", "policy", "settings", "sandbox", "temp
 _box = sandbox(name = "test", default = deny(), fs = [tempdir().allow()])
 
 settings(default = deny())
-policy("test", {"Bash": {"test": allow(sandbox=_box)}})
+policy("test", {tool("Bash"): {"test": allow(sandbox=_box)}})
 "#,
         );
         assert_eq!(doc["schema_version"], 5);
@@ -536,7 +536,7 @@ _box = sandbox(
 )
 
 settings(default = deny())
-policy("test", {"Bash": {"test": allow(sandbox=_box)}})
+policy("test", {tool("Bash"): {"test": allow(sandbox=_box)}})
 "#,
         );
         assert_eq!(doc["schema_version"], 5);
@@ -554,7 +554,7 @@ _box = sandbox(
 )
 
 settings(default = deny())
-policy("test", {"Bash": {"cargo": allow(sandbox=_box)}})
+policy("test", {tool("Bash"): {"cargo": allow(sandbox=_box)}})
 "#,
         );
         assert_eq!(doc["schema_version"], 5);
@@ -568,7 +568,7 @@ load("@clash//std.star", "allow", "deny", "policy", "settings", "sandbox", "cwd"
 
 _box = sandbox(name = "test", default = deny(), fs = [cwd()])
 settings(default = deny())
-policy("test", {"Bash": {"test": allow(sandbox=_box)}})
+policy("test", {tool("Bash"): {"test": allow(sandbox=_box)}})
 "#;
         let result = evaluate(source, "test.star", &PathBuf::from("."));
         assert!(result.is_err());
@@ -582,7 +582,7 @@ load("@clash//rust.star", "rust_full")
 load("@clash//std.star", "allow", "deny", "policy", "settings")
 
 settings(default = deny())
-policy("test", {"Bash": {("rustc", "cargo"): allow(sandbox=rust_full)}})
+policy("test", {tool("Bash"): {("rustc", "cargo"): allow(sandbox=rust_full)}})
 "#,
         );
         assert_eq!(doc["schema_version"], 5);
@@ -603,7 +603,7 @@ policy("test", {"Bash": {("rustc", "cargo"): allow(sandbox=rust_full)}})
 load("@clash//std.star", "allow", "deny", "policy", "settings")
 
 settings(default = deny())
-policy("test", {{"Bash": {{"test": allow(sandbox={sandbox_name})}}}})
+policy("test", {{tool("Bash"): {{"test": allow(sandbox={sandbox_name})}}}})
 "#
             );
             let result = evaluate(&source, "test.star", &PathBuf::from("."))
@@ -632,7 +632,7 @@ load("helpers.star", "my_sandbox")
 load("@clash//std.star", "allow", "deny", "policy", "settings")
 
 settings(default = deny())
-policy("test", {"Bash": {"test": allow(sandbox=my_sandbox)}})
+policy("test", {tool("Bash"): {"test": allow(sandbox=my_sandbox)}})
 "#;
         let result = evaluate(source, "policy.star", dir.path()).unwrap();
         let doc: serde_json::Value = serde_json::from_str(&result.json).unwrap();
@@ -661,11 +661,11 @@ _box = sandbox(
 settings(default = deny())
 
 policy("test", merge(
-    {"Bash": {
+    {tool("Bash"): {
         "git": allow(sandbox=_box),
         ("rustc", "cargo"): allow(sandbox=rust_full),
     }},
-    {None: allow()},
+    {tool(None): allow()},
 ))
 "#,
         );
@@ -687,7 +687,7 @@ load("@clash//std.star", "allow", "deny", "regex", "policy", "settings")
 
 settings(default = deny())
 policy("test", {
-    "Bash": {regex("cargo.*"): allow()},
+    tool("Bash"): {regex("cargo.*"): allow()},
 })
 "#,
         );
@@ -707,7 +707,7 @@ load("@clash//std.star", "deny", "policy", "settings")
 
 settings(default = deny())
 policy("test", {
-    "Bash": deny(),
+    tool("Bash"): deny(),
 })
 "#,
         );
@@ -730,7 +730,7 @@ load("@clash//std.star", "deny", "regex", "policy", "settings")
 
 settings(default = deny())
 policy("test", {
-    regex("mcp__.*"): ask(),
+    tool(regex("mcp__.*")): ask(),
 })
 "#,
         );
@@ -754,7 +754,7 @@ load("@clash//std.star", "allow", "deny", "regex", "policy", "settings")
 
 settings(default = deny())
 policy("test", {
-    "Bash": {("git", regex("gh.*")): allow()},
+    tool("Bash"): {("git", regex("gh.*")): allow()},
 })
 "#,
         );
@@ -776,8 +776,8 @@ load("@clash//std.star", "allow", "deny", "policy", "settings")
 
 settings(default = deny())
 policy("test", {
-    "Bash": {"git": {"push": deny()}},
-    "Read": allow(),
+    tool("Bash"): {"git": {"push": deny()}},
+    tool("Read"): allow(),
 })
 "#,
         );
@@ -810,7 +810,7 @@ _box = sandbox(
 )
 
 settings(default = deny())
-policy("test", {None: allow()}, default_sandbox = _box)
+policy("test", {tool(None): allow()}, default_sandbox = _box)
 "#,
         );
         assert_eq!(doc["schema_version"], 5);
@@ -843,7 +843,7 @@ _box = sandbox(
 )
 
 settings(default = deny())
-policy("test", {"Bash": {"test": allow(sandbox=_box)}})
+policy("test", {tool("Bash"): {"test": allow(sandbox=_box)}})
 "#,
         );
         assert_eq!(doc["schema_version"], 5);
@@ -867,7 +867,7 @@ _box = sandbox(
 )
 
 settings(default = deny())
-policy("test", {"Glob": allow(sandbox=_box)})
+policy("test", {tool("Glob"): allow(sandbox=_box)})
 "#,
         );
         assert_eq!(doc["schema_version"], 5);
@@ -896,7 +896,7 @@ _box = sandbox(
 )
 
 settings(default = deny())
-policy("test", {"Read": allow()}, default_sandbox = _box)
+policy("test", {tool("Read"): allow()}, default_sandbox = _box)
 "#,
         );
         assert_eq!(doc["schema_version"], 5);
@@ -923,7 +923,7 @@ _box = sandbox(
 )
 
 settings(default = deny())
-policy("test", {None: allow()}, default_sandbox = _box)
+policy("test", {tool(None): allow()}, default_sandbox = _box)
 "#,
         );
         assert_eq!(doc["schema_version"], 5);
@@ -955,7 +955,7 @@ _box = sandbox(
 
 settings(default = deny(), default_sandbox = _box)
 policy("test", {
-    "WebSearch": deny(),
+    tool("WebSearch"): deny(),
 }, default_sandbox = _box)
 "#,
         );
@@ -1013,7 +1013,7 @@ extra_fs = sandbox(
 merged = fs_box.update(net_box).update(extra_fs)
 
 settings(default = deny())
-policy("test", {"Bash": {"cargo": allow(sandbox=merged)}})
+policy("test", {tool("Bash"): {"cargo": allow(sandbox=merged)}})
 "#,
         );
         assert_eq!(doc["schema_version"], 5);
@@ -1053,7 +1053,7 @@ def _check():
 _check()
 
 settings(default = deny())
-policy("test", {None: allow()})
+policy("test", {tool(None): allow()})
 "#,
         );
         assert_eq!(doc["schema_version"], 5);
@@ -1073,7 +1073,7 @@ _box = sandbox(
 )
 
 settings(default = deny())
-policy("test", {"Bash": {"test": allow(sandbox=_box)}})
+policy("test", {tool("Bash"): {"test": allow(sandbox=_box)}})
 "#,
         );
         let sandbox = &doc["sandboxes"]["test"];
@@ -1097,7 +1097,7 @@ _box = sandbox(
 )
 
 settings(default = deny())
-policy("test", {"Bash": {"test": allow(sandbox=_box)}})
+policy("test", {tool("Bash"): {"test": allow(sandbox=_box)}})
 "#,
         );
         let sandbox = &doc["sandboxes"]["test"];
@@ -1140,7 +1140,7 @@ load("@clash//std.star", "allow", "deny", "policy", "settings", "sandbox")
 
 _box = sandbox(name="box", default=deny())
 settings(default=deny(), on_sandbox_violation="workaround")
-policy("test", {"Bash": allow(sandbox=_box)})
+policy("test", {tool("Bash"): allow(sandbox=_box)})
 "#,
         );
         assert_eq!(doc["on_sandbox_violation"], "workaround");
@@ -1153,7 +1153,7 @@ policy("test", {"Bash": allow(sandbox=_box)})
 load("@clash//std.star", "deny", "policy", "settings")
 
 settings(default=deny())
-policy("test", {"Bash": deny()})
+policy("test", {tool("Bash"): deny()})
 "#,
         );
         assert!(doc.get("on_sandbox_violation").is_none());
@@ -1165,7 +1165,7 @@ policy("test", {"Bash": deny()})
 load("@clash//std.star", "deny", "policy", "settings")
 
 settings(default=deny(), on_sandbox_violation="invalid")
-policy("test", {"Bash": deny()})
+policy("test", {tool("Bash"): deny()})
 "#;
         let result = evaluate(source, "test.star", &PathBuf::from("."));
         assert!(result.is_err());
@@ -1214,7 +1214,7 @@ _box = sandbox(
 )
 
 settings(default = deny())
-policy("test", {"Bash": {"curl": allow(sandbox = _box)}})
+policy("test", {tool("Bash"): {"curl": allow(sandbox = _box)}})
 "#,
         );
         let sandboxes = doc["sandboxes"].as_object().unwrap();
@@ -1236,7 +1236,7 @@ _box = sandbox(
 )
 
 settings(default = deny())
-policy("test", {"Bash": {"curl": allow(sandbox = _box)}})
+policy("test", {tool("Bash"): {"curl": allow(sandbox = _box)}})
 "#,
         );
         let sandboxes = doc["sandboxes"].as_object().unwrap();
@@ -1254,7 +1254,7 @@ load("@clash//claude_compat.star", "from_claude_settings")
 
 settings(default = deny())
 policy("test", merge(
-    {None: allow()},
+    {tool(None): allow()},
     from_claude_settings(user = False, project = False),
 ))
 "#,
@@ -1274,7 +1274,7 @@ load("@clash//claude_compat.star", "from_claude_settings")
 
 settings(default = deny())
 policy("test", merge(
-    {None: deny()},
+    {tool(None): deny()},
     from_claude_settings(),
 ))
 "#,
@@ -1289,7 +1289,7 @@ policy("test", merge(
             r#"
 settings(default = deny())
 policy("test", merge(
-    {None: allow()},
+    {tool(None): allow()},
     _from_claude_settings(user = False, project = False),
 ))
 "#,
@@ -1305,7 +1305,7 @@ load("@clash//sandboxes.star", "git_safe")
 load("@clash//std.star", "allow", "deny", "policy", "settings")
 
 settings(default = deny())
-policy("test", {"Bash": {"git": allow(sandbox=git_safe)}})
+policy("test", {tool("Bash"): {"git": allow(sandbox=git_safe)}})
 "#,
         );
         let sandboxes = doc["sandboxes"].as_object().unwrap();
@@ -1330,7 +1330,7 @@ load("@clash//sandboxes.star", "git_full")
 load("@clash//std.star", "allow", "deny", "policy", "settings")
 
 settings(default = deny())
-policy("test", {"Bash": {"git": allow(sandbox=git_full)}})
+policy("test", {tool("Bash"): {"git": allow(sandbox=git_full)}})
 "#,
         );
         let sandboxes = doc["sandboxes"].as_object().unwrap();

--- a/clash_starlark/src/test_support.rs
+++ b/clash_starlark/src/test_support.rs
@@ -1,0 +1,86 @@
+//! Test helpers for evaluating Starlark sources outside the full
+//! `policy()`/`sandbox()` registration pipeline.
+//!
+//! Used by integration tests under `clash_starlark/tests/` to verify
+//! stdlib constructors and individual evaluator pieces.
+
+use std::collections::HashMap;
+
+use anyhow::{Result, anyhow};
+use starlark::environment::Module;
+use starlark::eval::Evaluator;
+use starlark::syntax::{AstModule, Dialect};
+use starlark::values::list::ListRef;
+
+use crate::eval_context::EvalContext;
+use crate::globals::clash_globals;
+use crate::loader::ClashLoader;
+
+/// Handle returned from [`load_starlark_source_for_test`].
+///
+/// Holds snapshots of named globals captured immediately after evaluation,
+/// so the underlying Starlark heap does not have to outlive the call.
+pub struct TestModule {
+    string_lists: HashMap<String, Vec<String>>,
+}
+
+impl TestModule {
+    /// Read a previously snapshot-captured global as a list of strings.
+    pub fn get_global_strings(&self, name: &str) -> Result<Vec<String>> {
+        self.string_lists
+            .get(name)
+            .cloned()
+            .ok_or_else(|| anyhow!("global `{name}` was not captured as a string list"))
+    }
+}
+
+/// Evaluate a Starlark source string against `clash_globals()` with the
+/// stdlib pre-injected, and return a handle to read named globals.
+///
+/// The source must be self-contained — it should not call `policy()` or
+/// `sandbox()`. Use this to unit-test stdlib constructors.
+///
+/// This eagerly snapshots every top-level binding whose value is a list of
+/// strings, so callers can read them after the underlying Starlark module
+/// has been dropped.
+pub fn load_starlark_source_for_test(source: &str) -> Result<TestModule> {
+    let ast = AstModule::parse("test.star", source.to_owned(), &Dialect::Standard)
+        .map_err(|e| anyhow!("{e}"))?;
+
+    let loader = ClashLoader::new(std::path::PathBuf::from("."));
+    let globals = clash_globals();
+    let ctx = EvalContext::new();
+    let module = Module::new();
+    loader
+        .inject_std(&module)
+        .map_err(|e| anyhow!("failed to load stdlib: {e}"))?;
+
+    let mut string_lists: HashMap<String, Vec<String>> = HashMap::new();
+    {
+        let mut eval = Evaluator::new(&module);
+        eval.set_loader(&loader);
+        eval.extra = Some(&ctx);
+        eval.eval_module(ast, &globals).map_err(|e| anyhow!("{e}"))?;
+    }
+    for name in module.names() {
+        let n = name.as_str();
+        if let Some(value) = module.get(n) {
+            if let Some(list) = ListRef::from_value(value) {
+                let mut out = Vec::with_capacity(list.len());
+                let mut all_strings = true;
+                for v in list.iter() {
+                    if let Some(s) = v.unpack_str() {
+                        out.push(s.to_string());
+                    } else {
+                        all_strings = false;
+                        break;
+                    }
+                }
+                if all_strings {
+                    string_lists.insert(n.to_string(), out);
+                }
+            }
+        }
+    }
+    Ok(TestModule { string_lists })
+}

--- a/clash_starlark/src/test_support.rs
+++ b/clash_starlark/src/test_support.rs
@@ -84,3 +84,30 @@ pub fn load_starlark_source_for_test(source: &str) -> Result<TestModule> {
     }
     Ok(TestModule { string_lists })
 }
+
+/// Evaluate a Starlark source string as a policy file with a fresh
+/// `EvalContext`. Top-level `policy()` / `sandbox()` / `settings()` calls
+/// register into the returned context.
+///
+/// Used by integration tests that need to verify that the evaluator
+/// accepts/rejects particular root-level constructs.
+pub fn eval_policy_source_for_test(source: &str) -> Result<EvalContext> {
+    let ast = AstModule::parse("test.star", source.to_owned(), &Dialect::Standard)
+        .map_err(|e| anyhow!("{e}"))?;
+
+    let loader = ClashLoader::new(std::path::PathBuf::from("."));
+    let globals = clash_globals();
+    let ctx = EvalContext::new();
+    let module = Module::new();
+    loader
+        .inject_std(&module)
+        .map_err(|e| anyhow!("failed to load stdlib: {e}"))?;
+
+    {
+        let mut eval = Evaluator::new(&module);
+        eval.set_loader(&loader);
+        eval.extra = Some(&ctx);
+        eval.eval_module(ast, &globals).map_err(|e| anyhow!("{e}"))?;
+    }
+    Ok(ctx)
+}

--- a/clash_starlark/src/test_support.rs
+++ b/clash_starlark/src/test_support.rs
@@ -60,7 +60,8 @@ pub fn load_starlark_source_for_test(source: &str) -> Result<TestModule> {
         let mut eval = Evaluator::new(&module);
         eval.set_loader(&loader);
         eval.extra = Some(&ctx);
-        eval.eval_module(ast, &globals).map_err(|e| anyhow!("{e}"))?;
+        eval.eval_module(ast, &globals)
+            .map_err(|e| anyhow!("{e}"))?;
     }
     for name in module.names() {
         let n = name.as_str();
@@ -107,7 +108,8 @@ pub fn eval_policy_source_for_test(source: &str) -> Result<EvalContext> {
         let mut eval = Evaluator::new(&module);
         eval.set_loader(&loader);
         eval.extra = Some(&ctx);
-        eval.eval_module(ast, &globals).map_err(|e| anyhow!("{e}"))?;
+        eval.eval_module(ast, &globals)
+            .map_err(|e| anyhow!("{e}"))?;
     }
     Ok(ctx)
 }

--- a/clash_starlark/src/when.rs
+++ b/clash_starlark/src/when.rs
@@ -107,7 +107,11 @@ fn expand_keys<'v>(key: Value<'v>) -> Vec<Value<'v>> {
 }
 
 /// Classify what kind of match key a Starlark value represents.
+#[allow(dead_code)]
 enum MatchKeyKind {
+    Default {
+        doc: Option<String>,
+    },
     Mode {
         pattern: JsonValue,
         doc: Option<String>,
@@ -116,9 +120,88 @@ enum MatchKeyKind {
         pattern: JsonValue,
         doc: Option<String>,
     },
+    Path {
+        value: JsonValue,
+        doc: Option<String>,
+    },
+    Glob {
+        value: JsonValue,
+        doc: Option<String>,
+    },
+    Domain {
+        value: JsonValue,
+        doc: Option<String>,
+    },
+    Localhost {
+        ports: JsonValue,
+        doc: Option<String>,
+    },
 }
 
-fn classify_key<'v>(key: Value<'v>, heap: &'v Heap) -> anyhow::Result<MatchKeyKind> {
+/// Classify a **root-level** key in a policy/sandbox tree. Requires a typed
+/// constructor (struct with `_match_key`). Bare strings are rejected.
+fn classify_root_key<'v>(key: Value<'v>, heap: &'v Heap) -> anyhow::Result<MatchKeyKind> {
+    if key.get_type() == "struct"
+        && let Ok(Some(mk_val)) = key.get_attr("_match_key", heap)
+        && let Some(mk) = mk_val.unpack_str()
+    {
+        let doc = key
+            .get_attr("_doc", heap)
+            .ok()
+            .flatten()
+            .filter(|v| !v.is_none())
+            .and_then(|v| v.unpack_str().map(|s| s.to_string()));
+
+        // `default()` has no _match_value.
+        if mk == "default" {
+            return Ok(MatchKeyKind::Default { doc });
+        }
+
+        let mv = key
+            .get_attr("_match_value", heap)
+            .ok()
+            .flatten()
+            .context("match key struct missing _match_value")?;
+
+        return match mk {
+            "mode" => Ok(MatchKeyKind::Mode {
+                pattern: pattern_to_json(mv, heap)?,
+                doc,
+            }),
+            "tool" => Ok(MatchKeyKind::Tool {
+                pattern: pattern_to_json(mv, heap)?,
+                doc,
+            }),
+            "path" => Ok(MatchKeyKind::Path {
+                value: pattern_to_json(mv, heap)?,
+                doc,
+            }),
+            "glob" => Ok(MatchKeyKind::Glob {
+                value: pattern_to_json(mv, heap)?,
+                doc,
+            }),
+            "domain" => Ok(MatchKeyKind::Domain {
+                value: pattern_to_json(mv, heap)?,
+                doc,
+            }),
+            "localhost" => Ok(MatchKeyKind::Localhost {
+                ports: pattern_to_json(mv, heap)?,
+                doc,
+            }),
+            other => bail!("unknown match key type: {other}"),
+        };
+    }
+    bail!(
+        "Root keys in a policy or sandbox tree must use a typed constructor \
+         (default(), mode(), tool(), path(), glob(), domain(), localhost()). \
+         Got a bare {} key. If you meant a filesystem path, use path(\"...\"). \
+         If you meant a tool name, use tool(\"...\").",
+        key.get_type()
+    )
+}
+
+#[allow(dead_code)]
+fn classify_nested_key<'v>(key: Value<'v>, heap: &'v Heap) -> anyhow::Result<MatchKeyKind> {
     // Check for typed match key struct (Mode() / Tool() / mode())
     if key.get_type() == "struct" {
         if let Ok(Some(mk_val)) = key.get_attr("_match_key", heap) {
@@ -330,7 +413,22 @@ fn process_policy_dict<'v>(
 ) -> anyhow::Result<()> {
     for (key, value) in dict.iter() {
         for k in expand_keys(key) {
-            match classify_key(k, heap)? {
+            match classify_root_key(k, heap)? {
+                MatchKeyKind::Default { .. } => {
+                    bail!("sandbox-only key default used in policy root");
+                }
+                MatchKeyKind::Path { .. } => {
+                    bail!("sandbox-only key path used in policy root");
+                }
+                MatchKeyKind::Glob { .. } => {
+                    bail!("sandbox-only key glob used in policy root");
+                }
+                MatchKeyKind::Domain { .. } => {
+                    bail!("sandbox-only key domain used in policy root");
+                }
+                MatchKeyKind::Localhost { .. } => {
+                    bail!("sandbox-only key localhost used in policy root");
+                }
                 MatchKeyKind::Mode { pattern, doc } => {
                     let cond = build_mode_condition(pattern, doc, source.clone());
                     let node = if let Some(inner_dict) = DictRef::from_value(value) {

--- a/clash_starlark/src/when.rs
+++ b/clash_starlark/src/when.rs
@@ -458,6 +458,263 @@ fn process_policy_dict<'v>(
 // Sandbox conversion (replaces _sandbox_to_json / _resolve_path_value)
 // ---------------------------------------------------------------------------
 
+/// Shared assembly: build the sandbox JSON from already-converted parts.
+/// Both the legacy struct path (`sandbox_to_json`) and the new tree path
+/// (`sandbox_tree_impl`) feed this function so the wire format stays in sync.
+fn build_sandbox_json(
+    name: &str,
+    default_effect: &str,
+    rules: Vec<JsonValue>,
+    network: JsonValue,
+    doc: Option<String>,
+) -> JsonValue {
+    let default_caps = if default_effect == "deny" {
+        json!(["execute"])
+    } else {
+        json!(["read", "write", "create", "delete", "execute"])
+    };
+    let mut result = json!({
+        "name": name,
+        "default": default_caps,
+        "rules": rules,
+        "network": network,
+    });
+    if let Some(d) = doc {
+        result
+            .as_object_mut()
+            .unwrap()
+            .insert("doc".to_string(), json!(d));
+    }
+    result
+}
+
+/// Extract the effect string ("allow"/"deny"/"ask") from an effect struct.
+fn effect_to_string<'v>(value: Value<'v>, heap: &'v Heap) -> anyhow::Result<String> {
+    if let Some(s) = value.unpack_str() {
+        return Ok(s.to_string());
+    }
+    if !is_effect(value, heap) {
+        bail!(
+            "expected an effect (allow()/deny()/ask()), got {}",
+            value.get_type()
+        );
+    }
+    let kind = value
+        .get_attr("_effect", heap)
+        .ok()
+        .flatten()
+        .and_then(|v| v.unpack_str().map(|s| s.to_string()))
+        .context("effect struct missing _effect")?;
+    Ok(kind)
+}
+
+/// Compute capability list from an effect struct's `_read`/`_write`/...
+/// flags. Mirrors the logic of stdlib `_caps_from_effect`.
+fn caps_from_effect<'v>(eff: Value<'v>, heap: &'v Heap) -> anyhow::Result<Vec<String>> {
+    let get_bool = |name: &str| -> Option<bool> {
+        eff.get_attr(name, heap)
+            .ok()
+            .flatten()
+            .and_then(|v| v.unpack_bool())
+    };
+    let r = get_bool("_read");
+    let w = get_bool("_write");
+    let c = get_bool("_create");
+    let d = get_bool("_delete");
+    let x = get_bool("_execute");
+    if r.is_none() && w.is_none() && c.is_none() && d.is_none() && x.is_none() {
+        return Ok(vec![
+            "read".into(),
+            "write".into(),
+            "create".into(),
+            "delete".into(),
+            "execute".into(),
+        ]);
+    }
+    let mut caps = Vec::new();
+    if r == Some(true) {
+        caps.push("read".to_string());
+    }
+    if w == Some(true) {
+        caps.push("write".to_string());
+    }
+    if c == Some(true) {
+        caps.push("create".to_string());
+    }
+    if d == Some(true) {
+        caps.push("delete".to_string());
+    }
+    if x == Some(true) {
+        caps.push("execute".to_string());
+    }
+    Ok(caps)
+}
+
+/// Build an fs rule JSON from an effect value at a typed path/glob key.
+fn fs_rule_from<'v>(
+    effect: Value<'v>,
+    path_str: String,
+    doc: Option<String>,
+    match_type: &str,
+    heap: &'v Heap,
+) -> anyhow::Result<JsonValue> {
+    if !is_effect(effect, heap) {
+        bail!(
+            "sandbox tree fs values must be effects (allow/deny/ask), got {}",
+            effect.get_type()
+        );
+    }
+    let eff_str = effect_to_string(effect, heap)?;
+    let caps = caps_from_effect(effect, heap)?;
+    let mut rule = json!({
+        "effect": eff_str,
+        "caps": caps,
+        "path": path_str,
+        "path_match": match_type,
+    });
+    if let Some(d) = doc {
+        rule.as_object_mut()
+            .unwrap()
+            .insert("doc".to_string(), json!(d));
+    }
+    Ok(rule)
+}
+
+/// Inject the system rules that the legacy `sandbox()` builder used to add:
+/// allow `read` on `/` (subpath), deny everything on the user-home root.
+fn append_system_rules(rules: &mut Vec<JsonValue>) {
+    let user_homes = if std::env::consts::OS == "macos" {
+        "/Users"
+    } else {
+        "/home"
+    };
+    rules.push(json!({
+        "effect": "allow",
+        "caps": ["read"],
+        "path": "/",
+        "path_match": "subpath",
+    }));
+    rules.push(json!({
+        "effect": "deny",
+        "caps": ["read", "write", "create", "delete", "execute"],
+        "path": user_homes,
+        "path_match": "subpath",
+    }));
+}
+
+/// Build the JSON `network` field from collected sandbox-tree net pieces.
+fn build_network_json(
+    domains: Vec<String>,
+    localhost: Option<bool>,
+    localhost_ports: Vec<i64>,
+) -> JsonValue {
+    let has_localhost = localhost == Some(true) || !localhost_ports.is_empty();
+    let has_domains = !domains.is_empty();
+    if !has_localhost && !has_domains {
+        return json!("deny");
+    }
+    if has_domains && !has_localhost {
+        return json!({ "allow_domains": domains });
+    }
+    if has_localhost && !has_domains {
+        if localhost_ports.is_empty() {
+            return json!("localhost");
+        }
+        return json!({ "localhost": localhost_ports });
+    }
+    // Both — emit allow_domains plus localhost.
+    let mut obj = serde_json::Map::new();
+    obj.insert("allow_domains".to_string(), json!(domains));
+    if localhost_ports.is_empty() {
+        obj.insert("localhost".to_string(), json!(true));
+    } else {
+        obj.insert("localhost".to_string(), json!(localhost_ports));
+    }
+    JsonValue::Object(obj)
+}
+
+/// Process a unified sandbox-tree dict into a complete sandbox JSON value.
+pub fn sandbox_tree_impl<'v>(
+    name: &str,
+    tree: Value<'v>,
+    default_effect_kwarg: &str,
+    doc: Option<String>,
+    heap: &'v Heap,
+    _source: Option<String>,
+) -> anyhow::Result<JsonValue> {
+    let dict = DictRef::from_value(tree)
+        .ok_or_else(|| anyhow::anyhow!("sandbox() tree must be a dict"))?;
+
+    let mut default_effect = default_effect_kwarg.to_string();
+    let mut fs_rules: Vec<JsonValue> = Vec::new();
+    let mut net_domains: Vec<String> = Vec::new();
+    let mut net_localhost_allow: Option<bool> = None;
+    let mut net_localhost_ports: Vec<i64> = Vec::new();
+
+    for (key, value) in dict.iter() {
+        let raw_mv = key
+            .get_attr("_match_value", heap)
+            .ok()
+            .flatten()
+            .and_then(|v| v.unpack_str().map(|s| s.to_string()));
+        let raw_ports: Vec<i64> = key
+            .get_attr("_match_value", heap)
+            .ok()
+            .flatten()
+            .and_then(|v| {
+                ListRef::from_value(v).map(|list| {
+                    list.iter()
+                        .filter_map(|item| item.unpack_i32().map(|n| n as i64))
+                        .collect()
+                })
+            })
+            .unwrap_or_default();
+        let key_doc = key
+            .get_attr("_doc", heap)
+            .ok()
+            .flatten()
+            .filter(|v| !v.is_none())
+            .and_then(|v| v.unpack_str().map(|s| s.to_string()));
+
+        match classify_root_key(key, heap)? {
+            MatchKeyKind::Default { .. } => {
+                default_effect = effect_to_string(value, heap)?;
+            }
+            MatchKeyKind::Path { .. } => {
+                let pv = raw_mv
+                    .ok_or_else(|| anyhow::anyhow!("path() key missing string value"))?;
+                fs_rules.push(fs_rule_from(value, pv, key_doc, "literal", heap)?);
+            }
+            MatchKeyKind::Glob { .. } => {
+                let pv = raw_mv
+                    .ok_or_else(|| anyhow::anyhow!("glob() key missing string value"))?;
+                fs_rules.push(fs_rule_from(value, pv, key_doc, "glob", heap)?);
+            }
+            MatchKeyKind::Domain { .. } => {
+                let dn = raw_mv
+                    .ok_or_else(|| anyhow::anyhow!("domain() key must be a string"))?;
+                let _eff = effect_to_string(value, heap)?;
+                net_domains.push(dn);
+            }
+            MatchKeyKind::Localhost { .. } => {
+                let eff = effect_to_string(value, heap)?;
+                if eff == "allow" {
+                    net_localhost_allow = Some(true);
+                }
+                net_localhost_ports.extend(raw_ports);
+            }
+            MatchKeyKind::Mode { .. } | MatchKeyKind::Tool { .. } => {
+                bail!("mode()/tool() are policy-only keys; not allowed in a sandbox tree");
+            }
+        }
+    }
+
+    append_system_rules(&mut fs_rules);
+
+    let network = build_network_json(net_domains, net_localhost_allow, net_localhost_ports);
+    Ok(build_sandbox_json(name, &default_effect, fs_rules, network, doc))
+}
+
 /// Convert a sandbox Starlark struct to JSON.
 pub fn sandbox_to_json<'v>(sb: Value<'v>, heap: &'v Heap) -> anyhow::Result<JsonValue> {
     let name = sb
@@ -488,31 +745,13 @@ pub fn sandbox_to_json<'v>(sb: Value<'v>, heap: &'v Heap) -> anyhow::Result<Json
     // Network policy
     let net = convert_net_policy(sb, heap)?;
 
-    // Default caps
-    let default_caps = if default_effect == "deny" {
-        json!(["execute"])
-    } else {
-        json!(["read", "write", "create", "delete", "execute"])
-    };
+    let doc = sb
+        .get_attr("_doc", heap)
+        .ok()
+        .flatten()
+        .and_then(|v| v.unpack_str().map(|s| s.to_string()));
 
-    let mut result = json!({
-        "name": name,
-        "default": default_caps,
-        "rules": rules,
-        "network": net,
-    });
-
-    // Optional doc
-    if let Ok(Some(doc_val)) = sb.get_attr("_doc", heap) {
-        if let Some(doc) = doc_val.unpack_str() {
-            result
-                .as_object_mut()
-                .unwrap()
-                .insert("doc".to_string(), json!(doc));
-        }
-    }
-
-    Ok(result)
+    Ok(build_sandbox_json(&name, &default_effect, rules, net, doc))
 }
 
 fn convert_fs_rule<'v>(rule: Value<'v>, heap: &'v Heap) -> anyhow::Result<JsonValue> {

--- a/clash_starlark/src/when.rs
+++ b/clash_starlark/src/when.rs
@@ -375,14 +375,22 @@ pub fn policy_impl<'v>(
     default_sandbox: Value<'v>,
     heap: &'v Heap,
     source: Option<String>,
-) -> anyhow::Result<(Vec<JsonValue>, Vec<JsonValue>)> {
+) -> anyhow::Result<(Option<String>, Vec<JsonValue>, Vec<JsonValue>)> {
     let mut flat_nodes: Vec<JsonValue> = Vec::new();
     let mut collector = SandboxCollector::new();
+    let mut default_override: Option<String> = None;
 
     // Dict form
     if !rules_or_dict.is_none() {
         if let Some(dict) = DictRef::from_value(rules_or_dict) {
-            process_policy_dict(&dict, heap, &source, &mut flat_nodes, &mut collector)?;
+            process_policy_dict(
+                &dict,
+                heap,
+                &source,
+                &mut flat_nodes,
+                &mut collector,
+                &mut default_override,
+            )?;
         }
     }
 
@@ -400,7 +408,7 @@ pub fn policy_impl<'v>(
         }
     }
 
-    Ok((flat_nodes, collector.sandboxes))
+    Ok((default_override, flat_nodes, collector.sandboxes))
 }
 
 /// Process the dict form of policy().
@@ -410,24 +418,24 @@ fn process_policy_dict<'v>(
     source: &Option<String>,
     flat_nodes: &mut Vec<JsonValue>,
     collector: &mut SandboxCollector,
+    default_override: &mut Option<String>,
 ) -> anyhow::Result<()> {
     for (key, value) in dict.iter() {
         for k in expand_keys(key) {
             match classify_root_key(k, heap)? {
                 MatchKeyKind::Default { .. } => {
-                    bail!("sandbox-only key default used in policy root");
+                    let eff = effect_to_string(value, heap)?;
+                    collector.collect_from_effect(value, heap)?;
+                    *default_override = Some(eff);
                 }
-                MatchKeyKind::Path { .. } => {
-                    bail!("sandbox-only key path used in policy root");
-                }
-                MatchKeyKind::Glob { .. } => {
-                    bail!("sandbox-only key glob used in policy root");
-                }
-                MatchKeyKind::Domain { .. } => {
-                    bail!("sandbox-only key domain used in policy root");
-                }
-                MatchKeyKind::Localhost { .. } => {
-                    bail!("sandbox-only key localhost used in policy root");
+                MatchKeyKind::Path { .. }
+                | MatchKeyKind::Glob { .. }
+                | MatchKeyKind::Domain { .. }
+                | MatchKeyKind::Localhost { .. } => {
+                    bail!(
+                        "path()/glob()/domain()/localhost() are sandbox-only keys; \
+                         policy() trees only accept default(), mode(), and tool() at the root"
+                    );
                 }
                 MatchKeyKind::Mode { pattern, doc } => {
                     let cond = build_mode_condition(pattern, doc, source.clone());

--- a/clash_starlark/src/when.rs
+++ b/clash_starlark/src/when.rs
@@ -123,10 +123,12 @@ enum MatchKeyKind {
     Path {
         value: JsonValue,
         doc: Option<String>,
+        worktree: bool,
     },
     Glob {
         value: JsonValue,
         doc: Option<String>,
+        worktree: bool,
     },
     Domain {
         value: JsonValue,
@@ -134,6 +136,9 @@ enum MatchKeyKind {
     },
     Localhost {
         ports: JsonValue,
+        doc: Option<String>,
+    },
+    Network {
         doc: Option<String>,
     },
 }
@@ -157,6 +162,17 @@ fn classify_root_key<'v>(key: Value<'v>, heap: &'v Heap) -> anyhow::Result<Match
             return Ok(MatchKeyKind::Default { doc });
         }
 
+        let worktree = key
+            .get_attr("_worktree", heap)
+            .ok()
+            .flatten()
+            .and_then(|v| v.unpack_bool())
+            .unwrap_or(false);
+
+        if mk == "network" {
+            return Ok(MatchKeyKind::Network { doc });
+        }
+
         let mv = key
             .get_attr("_match_value", heap)
             .ok()
@@ -175,17 +191,19 @@ fn classify_root_key<'v>(key: Value<'v>, heap: &'v Heap) -> anyhow::Result<Match
             "path" => Ok(MatchKeyKind::Path {
                 value: pattern_to_json(mv, heap)?,
                 doc,
+                worktree,
             }),
             "glob" => Ok(MatchKeyKind::Glob {
                 value: pattern_to_json(mv, heap)?,
                 doc,
+                worktree,
             }),
             "domain" => Ok(MatchKeyKind::Domain {
                 value: pattern_to_json(mv, heap)?,
                 doc,
             }),
             "localhost" => Ok(MatchKeyKind::Localhost {
-                ports: pattern_to_json(mv, heap)?,
+                ports: serde_json::Value::Null,
                 doc,
             }),
             other => bail!("unknown match key type: {other}"),
@@ -431,9 +449,10 @@ fn process_policy_dict<'v>(
                 MatchKeyKind::Path { .. }
                 | MatchKeyKind::Glob { .. }
                 | MatchKeyKind::Domain { .. }
-                | MatchKeyKind::Localhost { .. } => {
+                | MatchKeyKind::Localhost { .. }
+                | MatchKeyKind::Network { .. } => {
                     bail!(
-                        "path()/glob()/domain()/localhost() are sandbox-only keys; \
+                        "path()/glob()/domain()/localhost()/network() are sandbox-only keys; \
                          policy() trees only accept default(), mode(), and tool() at the root"
                     );
                 }
@@ -564,6 +583,7 @@ fn fs_rule_from<'v>(
     path_str: String,
     doc: Option<String>,
     match_type: &str,
+    worktree: bool,
     heap: &'v Heap,
 ) -> anyhow::Result<JsonValue> {
     if !is_effect(effect, heap) {
@@ -580,6 +600,11 @@ fn fs_rule_from<'v>(
         "path": path_str,
         "path_match": match_type,
     });
+    if worktree {
+        rule.as_object_mut()
+            .unwrap()
+            .insert("follow_worktrees".to_string(), json!(true));
+    }
     if let Some(d) = doc {
         rule.as_object_mut()
             .unwrap()
@@ -658,6 +683,7 @@ pub fn sandbox_tree_impl<'v>(
     let mut net_domains: Vec<String> = Vec::new();
     let mut net_localhost_allow: Option<bool> = None;
     let mut net_localhost_ports: Vec<i64> = Vec::new();
+    let mut network_override: Option<String> = None;
 
     for (key, value) in dict.iter() {
         let raw_mv = key
@@ -670,11 +696,21 @@ pub fn sandbox_tree_impl<'v>(
             .ok()
             .flatten()
             .and_then(|v| {
-                ListRef::from_value(v).map(|list| {
-                    list.iter()
-                        .filter_map(|item| item.unpack_i32().map(|n| n as i64))
-                        .collect()
-                })
+                if let Some(list) = ListRef::from_value(v) {
+                    Some(
+                        list.iter()
+                            .filter_map(|item| item.unpack_i32().map(|n| n as i64))
+                            .collect::<Vec<_>>(),
+                    )
+                } else if let Some(tup) = starlark::values::tuple::TupleRef::from_value(v) {
+                    Some(
+                        tup.iter()
+                            .filter_map(|item| item.unpack_i32().map(|n| n as i64))
+                            .collect::<Vec<_>>(),
+                    )
+                } else {
+                    None
+                }
             })
             .unwrap_or_default();
         let key_doc = key
@@ -688,15 +724,38 @@ pub fn sandbox_tree_impl<'v>(
             MatchKeyKind::Default { .. } => {
                 default_effect = effect_to_string(value, heap)?;
             }
-            MatchKeyKind::Path { .. } => {
+            MatchKeyKind::Path { worktree, .. } => {
                 let pv = raw_mv
                     .ok_or_else(|| anyhow::anyhow!("path() key missing string value"))?;
-                fs_rules.push(fs_rule_from(value, pv, key_doc, "literal", heap)?);
+                fs_rules.push(fs_rule_from(
+                    value,
+                    pv,
+                    key_doc,
+                    if worktree { "subpath" } else { "literal" },
+                    worktree,
+                    heap,
+                )?);
             }
-            MatchKeyKind::Glob { .. } => {
+            MatchKeyKind::Glob { worktree, .. } => {
                 let pv = raw_mv
                     .ok_or_else(|| anyhow::anyhow!("glob() key missing string value"))?;
-                fs_rules.push(fs_rule_from(value, pv, key_doc, "glob", heap)?);
+                // Translate glob suffix to the IR's path_match enum.
+                let (final_path, mt) = if pv == "*" || pv == "**" {
+                    ("/".to_string(), "subpath")
+                } else if let Some(stripped) = pv.strip_suffix("/**/*") {
+                    (stripped.to_string(), "subpath")
+                } else if let Some(stripped) = pv.strip_suffix("/**") {
+                    (stripped.to_string(), "subpath")
+                } else if let Some(stripped) = pv.strip_suffix("/*") {
+                    (stripped.to_string(), "child_of")
+                } else {
+                    (pv, "literal")
+                };
+                fs_rules.push(fs_rule_from(value, final_path, key_doc, mt, worktree, heap)?);
+            }
+            MatchKeyKind::Network { .. } => {
+                let eff = effect_to_string(value, heap)?;
+                network_override = Some(eff);
             }
             MatchKeyKind::Domain { .. } => {
                 let dn = raw_mv
@@ -719,7 +778,11 @@ pub fn sandbox_tree_impl<'v>(
 
     append_system_rules(&mut fs_rules);
 
-    let network = build_network_json(net_domains, net_localhost_allow, net_localhost_ports);
+    let network = if let Some(ov) = network_override {
+        json!(ov)
+    } else {
+        build_network_json(net_domains, net_localhost_allow, net_localhost_ports)
+    };
     Ok(build_sandbox_json(name, &default_effect, fs_rules, network, doc))
 }
 
@@ -835,11 +898,26 @@ fn convert_net_policy<'v>(sb: Value<'v>, heap: &'v Heap) -> anyhow::Result<JsonV
             let dict = DictRef::from_value(v).unwrap();
             let key = heap.alloc_str("_localhost_ports");
             if let Ok(Some(ports_val)) = dict.get(key.to_value()) {
-                if let Some(ports_list) = ListRef::from_value(ports_val) {
-                    let ports: Vec<u16> = ports_list
-                        .iter()
-                        .filter_map(|item| item.unpack_i32().map(|n| n as u16))
-                        .collect();
+                let ports_iter: Option<Vec<u16>> = if let Some(list) =
+                    ListRef::from_value(ports_val)
+                {
+                    Some(
+                        list.iter()
+                            .filter_map(|item| item.unpack_i32().map(|n| n as u16))
+                            .collect(),
+                    )
+                } else if let Some(tup) =
+                    starlark::values::tuple::TupleRef::from_value(ports_val)
+                {
+                    Some(
+                        tup.iter()
+                            .filter_map(|item| item.unpack_i32().map(|n| n as u16))
+                            .collect(),
+                    )
+                } else {
+                    None
+                };
+                if let Some(ports) = ports_iter {
                     if ports.is_empty() {
                         return Ok(json!("localhost"));
                     }

--- a/clash_starlark/src/when.rs
+++ b/clash_starlark/src/when.rs
@@ -725,8 +725,8 @@ pub fn sandbox_tree_impl<'v>(
                 default_effect = effect_to_string(value, heap)?;
             }
             MatchKeyKind::Path { worktree, .. } => {
-                let pv = raw_mv
-                    .ok_or_else(|| anyhow::anyhow!("path() key missing string value"))?;
+                let pv =
+                    raw_mv.ok_or_else(|| anyhow::anyhow!("path() key missing string value"))?;
                 fs_rules.push(fs_rule_from(
                     value,
                     pv,
@@ -737,8 +737,8 @@ pub fn sandbox_tree_impl<'v>(
                 )?);
             }
             MatchKeyKind::Glob { worktree, .. } => {
-                let pv = raw_mv
-                    .ok_or_else(|| anyhow::anyhow!("glob() key missing string value"))?;
+                let pv =
+                    raw_mv.ok_or_else(|| anyhow::anyhow!("glob() key missing string value"))?;
                 // Translate glob suffix to the IR's path_match enum.
                 let (final_path, mt) = if pv == "*" || pv == "**" {
                     ("/".to_string(), "subpath")
@@ -751,15 +751,16 @@ pub fn sandbox_tree_impl<'v>(
                 } else {
                     (pv, "literal")
                 };
-                fs_rules.push(fs_rule_from(value, final_path, key_doc, mt, worktree, heap)?);
+                fs_rules.push(fs_rule_from(
+                    value, final_path, key_doc, mt, worktree, heap,
+                )?);
             }
             MatchKeyKind::Network { .. } => {
                 let eff = effect_to_string(value, heap)?;
                 network_override = Some(eff);
             }
             MatchKeyKind::Domain { .. } => {
-                let dn = raw_mv
-                    .ok_or_else(|| anyhow::anyhow!("domain() key must be a string"))?;
+                let dn = raw_mv.ok_or_else(|| anyhow::anyhow!("domain() key must be a string"))?;
                 let _eff = effect_to_string(value, heap)?;
                 net_domains.push(dn);
             }
@@ -783,7 +784,13 @@ pub fn sandbox_tree_impl<'v>(
     } else {
         build_network_json(net_domains, net_localhost_allow, net_localhost_ports)
     };
-    Ok(build_sandbox_json(name, &default_effect, fs_rules, network, doc))
+    Ok(build_sandbox_json(
+        name,
+        &default_effect,
+        fs_rules,
+        network,
+        doc,
+    ))
 }
 
 /// Convert a sandbox Starlark struct to JSON.
@@ -906,9 +913,7 @@ fn convert_net_policy<'v>(sb: Value<'v>, heap: &'v Heap) -> anyhow::Result<JsonV
                             .filter_map(|item| item.unpack_i32().map(|n| n as u16))
                             .collect(),
                     )
-                } else if let Some(tup) =
-                    starlark::values::tuple::TupleRef::from_value(ports_val)
-                {
+                } else if let Some(tup) = starlark::values::tuple::TupleRef::from_value(ports_val) {
                     Some(
                         tup.iter()
                             .filter_map(|item| item.unpack_i32().map(|n| n as u16))

--- a/clash_starlark/stdlib/builtin.star
+++ b/clash_starlark/stdlib/builtin.star
@@ -10,7 +10,7 @@ clashbox = sandbox(
 )
 
 clash = {
-    "Bash": {
+    tool("Bash"): {
         "clash": {
             ("bug", "status"): allow(sandbox=clashbox),
             "policy": {
@@ -31,7 +31,7 @@ _claude_fs = sandbox(
 )
 
 claude = {
-    (
+    tool((
         "Agent",
         "AskUserQuestion",
         "EnterPlanMode",
@@ -45,7 +45,7 @@ claude = {
         "TaskOutput",
         "TaskStop",
         "TaskUpdate",
-    ): allow(sandbox=_claude_fs),
+    )): allow(sandbox=_claude_fs),
 }
 
 # Merged dict of all builtin rules

--- a/clash_starlark/stdlib/docker.star
+++ b/clash_starlark/stdlib/docker.star
@@ -26,4 +26,4 @@ docker_full = sandbox(
     doc = "Docker full: build, run, compose, push. Full project access, network enabled.",
 )
 
-docker = {"Bash": {("docker", "docker-compose", "podman"): allow(sandbox = docker_full)}}
+docker = {tool("Bash"): {("docker", "docker-compose", "podman"): allow(sandbox = docker_full)}}

--- a/clash_starlark/stdlib/dotnet.star
+++ b/clash_starlark/stdlib/dotnet.star
@@ -13,4 +13,4 @@ dotnet_full = sandbox(
     doc = ".NET full: build, test, restore. Full project + NuGet cache access.",
 )
 
-dotnet = {"Bash": {("dotnet", "msbuild"): allow(sandbox = dotnet_full)}}
+dotnet = {tool("Bash"): {("dotnet", "msbuild"): allow(sandbox = dotnet_full)}}

--- a/clash_starlark/stdlib/go.star
+++ b/clash_starlark/stdlib/go.star
@@ -24,4 +24,4 @@ go_full = sandbox(
     doc = "Go full: get, mod tidy, install. Full project access, network enabled.",
 )
 
-go = {"Bash": {"go": allow(sandbox = go_full)}}
+go = {tool("Bash"): {"go": allow(sandbox = go_full)}}

--- a/clash_starlark/stdlib/java.star
+++ b/clash_starlark/stdlib/java.star
@@ -13,4 +13,4 @@ java_full = sandbox(
     doc = "Java/JVM full: gradle, maven builds. Full project + dependency cache access.",
 )
 
-java = {"Bash": {("gradle", "gradlew", "mvn", "mvnw", "java", "javac"): allow(sandbox = java_full)}}
+java = {tool("Bash"): {("gradle", "gradlew", "mvn", "mvnw", "java", "javac"): allow(sandbox = java_full)}}

--- a/clash_starlark/stdlib/make.star
+++ b/clash_starlark/stdlib/make.star
@@ -9,4 +9,4 @@ make_full = sandbox(
     doc = "Make/CMake/Just full: build targets. Full project access, no network.",
 )
 
-make = {"Bash": {("make", "cmake", "just"): allow(sandbox = make_full)}}
+make = {tool("Bash"): {("make", "cmake", "just"): allow(sandbox = make_full)}}

--- a/clash_starlark/stdlib/node.star
+++ b/clash_starlark/stdlib/node.star
@@ -16,4 +16,4 @@ node_full = sandbox(
     doc = "Node full: npm/bun/yarn/pnpm install, run scripts. Full project + package access.",
 )
 
-node = {"Bash": {("node", "npm", "npx", "bun", "deno", "yarn", "pnpm"): allow(sandbox = node_full)}}
+node = {tool("Bash"): {("node", "npm", "npx", "bun", "deno", "yarn", "pnpm"): allow(sandbox = node_full)}}

--- a/clash_starlark/stdlib/python.star
+++ b/clash_starlark/stdlib/python.star
@@ -15,4 +15,4 @@ python_full = sandbox(
     doc = "Python full: pip install, run scripts, virtualenvs. Full project + package access.",
 )
 
-python = {"Bash": {("python", "python3", "pip", "pip3", "uv", "poetry"): allow(sandbox = python_full)}}
+python = {tool("Bash"): {("python", "python3", "pip", "pip3", "uv", "poetry"): allow(sandbox = python_full)}}

--- a/clash_starlark/stdlib/ruby.star
+++ b/clash_starlark/stdlib/ruby.star
@@ -14,4 +14,4 @@ ruby_full = sandbox(
     doc = "Ruby full: gem install, bundle, rails. Full project + gem access.",
 )
 
-ruby = {"Bash": {("ruby", "gem", "bundle", "rails"): allow(sandbox = ruby_full)}}
+ruby = {tool("Bash"): {("ruby", "gem", "bundle", "rails"): allow(sandbox = ruby_full)}}

--- a/clash_starlark/stdlib/rust.star
+++ b/clash_starlark/stdlib/rust.star
@@ -29,4 +29,4 @@ rust_full = sandbox(
     doc = "Rust full: add, install, update. Full project + toolchain access, network enabled.",
 )
 
-rust = {"Bash": {("cargo", "rustc", "rustup"): allow(sandbox = rust_full)}}
+rust = {tool("Bash"): {("cargo", "rustc", "rustup"): allow(sandbox = rust_full)}}

--- a/clash_starlark/stdlib/sandboxes.star
+++ b/clash_starlark/stdlib/sandboxes.star
@@ -22,6 +22,7 @@ readonly = sandbox(
         glob("$HOME/.claude/**"): allow("r"),
     },
     net = allow(),
+    doc = "Read-only project access with network allowed.",
 )
 
 project = sandbox(
@@ -31,7 +32,8 @@ project = sandbox(
         glob("$PWD/**"): allow(FULL),
         glob("$HOME/.claude/**"): allow("rwcd"),
         glob("$TMPDIR/**"): allow(FULL),
-    }
+    },
+    doc = "Build tools: read+write project and TMPDIR, no network.",
 )
 
 git_safe = sandbox(
@@ -76,9 +78,11 @@ workspace = sandbox(
         } | {
         glob("$HOME/{}/**".format(d)): deny() for d in UNSAFE_IN_HOME
     },
+    doc = "Full home directory access, deny sensitive subdirs (.ssh, .gpg, .config, .aws, .gh, .git).",
 )
 
 unrestricted = sandbox(
     name = "unrestricted",
     default=allow(),
+    doc = "Fully trusted: all filesystem + network access.",
 )

--- a/clash_starlark/stdlib/std.star
+++ b/clash_starlark/stdlib/std.star
@@ -72,7 +72,7 @@ def regex(pattern):
     return struct(_regex=pattern)
 
 
-def glob(pattern, doc=None):
+def glob(pattern, doc=None, worktree=False):
     """Filesystem glob-path key.
 
     Usage:
@@ -84,7 +84,7 @@ def glob(pattern, doc=None):
         pattern.endswith("/*") or pattern.endswith("/**") or pattern.endswith("/**/*")
     ):
         fail("glob() pattern must end with /*, /**, or /**/* (got: " + pattern + ")")
-    return struct(_match_key="glob", _match_value=pattern, _doc=doc)
+    return struct(_match_key="glob", _match_value=pattern, _doc=doc, _worktree=worktree)
 
 
 def _legacy_glob(pattern):
@@ -440,15 +440,29 @@ def tempdir():
     return _path_match(struct(_env="TMPDIR"), False)
 
 
-def path(path_str, doc=None):
+def path(path_str, doc=None, worktree=False):
     """Filesystem literal-path key.
+
+    When `worktree=True`, the path is treated as a recursive subpath match and
+    follows git worktrees.
 
     Usage:
         sandbox("x", {path("$PWD"): allow("rwc")})
+        sandbox("x", {path("$PWD", worktree=True): allow("rwc")})
     """
     if type(path_str) != "string":
         fail("path() takes a string; got " + type(path_str))
-    return struct(_match_key="path", _match_value=path_str, _doc=doc)
+    return struct(_match_key="path", _match_value=path_str, _doc=doc, _worktree=worktree)
+
+
+def network(doc=None):
+    """Top-level network effect key.
+
+    Usage:
+        sandbox("x", {network(): allow()})   # allow all network
+        sandbox("x", {network(): deny()})    # deny all network (default)
+    """
+    return struct(_match_key="network", _match_value=None, _doc=doc)
 
 
 def _legacy_path_match(path_str=None, env=None):
@@ -499,6 +513,7 @@ def localhost(ports=None, doc=None):
                 fail("localhost() ports must be integers; got " + type(p))
             if p < 1 or p > 65535:
                 fail("localhost() port out of range (1-65535): " + str(p))
+        ports = tuple(ports)
     return struct(_match_key="localhost", _match_value=ports, _doc=doc)
 
 

--- a/clash_starlark/stdlib/std.star
+++ b/clash_starlark/stdlib/std.star
@@ -538,8 +538,30 @@ def _make_sandbox(name, default, fs_rules, net_policy, net_domain_names=None, do
     )
 
 
-def sandbox(name=None, default="deny", fs=None, net=None, doc=None):
-    """Build a sandbox definition.
+def sandbox(name=None, tree=None, default="deny", fs=None, net=None, doc=None):
+    """Register a sandbox from a decision-tree dict, or (legacy) build one.
+
+    New form:
+        sandbox("rust-dev", {
+            default(): deny(),
+            path("$PWD"): allow("rwc"),
+            domain("crates.io"): allow(),
+        })
+
+    Legacy form (still supported until Task A6):
+        sandbox("name", default=deny(), fs={...}, net=allow())
+    """
+    # New tree form: positional dict tree, no fs=/net= kwargs.
+    if tree != None and type(tree) == "dict" and fs == None and net == None:
+        if type(name) != "string":
+            fail("sandbox() name must be a string")
+        _sandbox_impl(name, tree, default=_unwrap_effect(default), doc=doc)
+        return name
+    return _legacy_sandbox(name, default, fs, net, doc)
+
+
+def _legacy_sandbox(name=None, default="deny", fs=None, net=None, doc=None):
+    """Legacy builder-based sandbox(). Removed in Task A6.
 
     Usage:
         sandbox("example", default=deny(),

--- a/clash_starlark/stdlib/std.star
+++ b/clash_starlark/stdlib/std.star
@@ -72,14 +72,23 @@ def regex(pattern):
     return struct(_regex=pattern)
 
 
-def glob(pattern):
-    """Create a glob pattern for matching.
+def glob(pattern, doc=None):
+    """Filesystem glob-path key.
 
-    - glob("*")            → wildcard (match anything)
-    - glob("$HOME/*")      → direct children of $HOME
-    - glob("$HOME/**/*")   → $HOME and all descendants (recursive)
-    - glob("$HOME/**")     → same as /**/*
+    Usage:
+        sandbox("x", {glob("$HOME/**"): allow("r")})
     """
+    if type(pattern) != "string":
+        fail("glob() takes a string; got " + type(pattern))
+    if pattern not in ("*", "**") and not (
+        pattern.endswith("/*") or pattern.endswith("/**") or pattern.endswith("/**/*")
+    ):
+        fail("glob() pattern must end with /*, /**, or /**/* (got: " + pattern + ")")
+    return struct(_match_key="glob", _match_value=pattern, _doc=doc)
+
+
+def _legacy_glob(pattern):
+    """Legacy glob builder used by the sandbox migration emitter only."""
     if pattern in ("*", "**"):
         return struct(_glob="*", _glob_type="wildcard")
     if pattern.endswith("/**/*"):
@@ -124,13 +133,26 @@ def Mode(name):
     return struct(_match_key="mode", _match_value=name)
 
 
-def Tool(name):
-    """Typed key for policy dicts — matches tool name (explicit alternative to raw strings).
+def tool(name, doc=None):
+    """Tool selector root key (policy trees).
 
     Usage:
-        policy("name", {Tool("Bash"): {"git": allow()}})
+        policy("x", {mode("plan"): {tool("Bash"): {"git push": deny()}}})
     """
-    return struct(_match_key="tool", _match_value=name)
+    return struct(_match_key="tool", _match_value=name, _doc=doc)
+
+
+def Tool(name):
+    fail("Tool() has been renamed to tool(). See docs/superpowers/specs/2026-04-06-unify-policy-and-sandbox-design.md")
+
+
+def default(doc=None):
+    """Sentinel root key representing the fallback effect for a tree.
+
+    Usage:
+        policy("x", {default(): deny(), mode("plan"): allow()})
+    """
+    return struct(_match_key="default", _match_value=None, _doc=doc)
 
 
 # ---------------------------------------------------------------------------
@@ -242,7 +264,28 @@ def _process_fs_dict(fs_dict, parent_path=None):
     rules = []
     for key, value in fs_dict.items():
         # Determine path, match_type, follow_worktrees from key type
-        if hasattr(key, "_is_sandbox_matcher"):
+        if hasattr(key, "_match_key"):
+            mk = key._match_key
+            if mk == "path":
+                key_path = key._match_value
+                explicit_type = "literal"
+                follow_wt = False
+            elif mk == "glob":
+                key = _legacy_glob(key._match_value)
+                key_path = key._glob
+                if key._glob_type == "wildcard":
+                    key_path = "/"
+                    explicit_type = "subpath"
+                elif key._glob_type == "recursive":
+                    explicit_type = "subpath"
+                elif key._glob_type == "children":
+                    explicit_type = "child_of"
+                else:
+                    fail("unknown glob type: " + key._glob_type)
+                follow_wt = False
+            else:
+                fail("sandbox fs key constructor not supported here: " + mk)
+        elif hasattr(key, "_is_sandbox_matcher"):
             key_path = key._path
             explicit_type = key._matcher_type
             follow_wt = hasattr(key, "_follow_worktrees") and key._follow_worktrees
@@ -397,13 +440,19 @@ def tempdir():
     return _path_match(struct(_env="TMPDIR"), False)
 
 
-def path(path_str=None, env=None):
-    """Build a path match for an arbitrary path or env var.
+def path(path_str, doc=None):
+    """Filesystem literal-path key.
 
     Usage:
-        path("/usr/local/bin").allow(read=True, execute=True)
-        path(env="CARGO_HOME").allow(read=True, write=True)
+        sandbox("x", {path("$PWD"): allow("rwc")})
     """
+    if type(path_str) != "string":
+        fail("path() takes a string; got " + type(path_str))
+    return struct(_match_key="path", _match_value=path_str, _doc=doc)
+
+
+def _legacy_path_match(path_str=None, env=None):
+    """Legacy builder-style path() — used internally by sandbox migration until Task A6."""
     if path_str != None and env != None:
         fail("path() takes either a path string or env=, not both")
     if path_str == None and env == None:
@@ -429,30 +478,28 @@ def domains(mapping):
     return entries
 
 
-def domain(name, effect):
-    """Build a single net rule.
+def domain(name, doc=None):
+    """Network domain key.
 
     Usage:
-        domain("github.com", allow)
+        sandbox("x", {domain("github.com"): allow()})
     """
-    return [struct(_domain_name=name)]
+    return struct(_match_key="domain", _match_value=name, _doc=doc)
 
 
-def localhost(ports = None):
-    """Build a localhost network specifier, optionally restricted to specific ports.
+def localhost(ports=None, doc=None):
+    """Localhost network key. Optionally restricted to specific ports.
 
     Usage:
-        net = localhost()              # all ports (same as net = "localhost")
-        net = localhost(ports=[8080])  # only port 8080
+        sandbox("x", {localhost(): allow(), localhost(ports=[8080]): allow()})
     """
-    if ports == None or len(ports) == 0:
-        return struct(_is_localhost=True, _ports=[])
-    for p in ports:
-        if type(p) != "int":
-            fail("localhost() ports must be integers, got: " + type(p))
-        if p < 1 or p > 65535:
-            fail("localhost() port out of range (1-65535): " + str(p))
-    return struct(_is_localhost=True, _ports=ports)
+    if ports != None:
+        for p in ports:
+            if type(p) != "int":
+                fail("localhost() ports must be integers; got " + type(p))
+            if p < 1 or p > 65535:
+                fail("localhost() port out of range (1-65535): " + str(p))
+    return struct(_match_key="localhost", _match_value=ports, _doc=doc)
 
 
 # ---------------------------------------------------------------------------
@@ -524,7 +571,7 @@ def sandbox(name=None, default="deny", fs=None, net=None, doc=None):
         fs_rules = _process_fs_dict(fs) + _system_rules
     elif type(fs) == "list":
         # Legacy builder-based API
-        fs += [path("/").recurse().allow(read=True), path(_user_homes).recurse().deny()]
+        fs += [_legacy_path_match("/").recurse().allow(read=True), _legacy_path_match(_user_homes).recurse().deny()]
         for entry in fs:
             if hasattr(entry, "_is_path"):
                 if hasattr(entry, "_sandbox_rules"):
@@ -537,7 +584,16 @@ def sandbox(name=None, default="deny", fs=None, net=None, doc=None):
     net_policy = None
     net_domain_names = []
     if net != None:
-        if hasattr(net, "_is_localhost"):
+        if hasattr(net, "_match_key") and net._match_key == "localhost":
+            ports = net._match_value
+            if ports != None and len(ports) > 0:
+                net_policy = {"_localhost_ports": ports}
+            else:
+                net_policy = "localhost"
+        elif hasattr(net, "_match_key") and net._match_key == "domain":
+            net_domain_names.append(net._match_value)
+            net_policy = net_domain_names
+        elif hasattr(net, "_is_localhost"):
             if len(net._ports) > 0:
                 net_policy = {"_localhost_ports": net._ports}
             else:

--- a/clash_starlark/stdlib/std.star
+++ b/clash_starlark/stdlib/std.star
@@ -165,21 +165,21 @@ def merge(*dicts):
     return _merge(*dicts)
 
 
-def policy(name, rules_or_dict=None, default="deny", default_sandbox=None):
-    """Register a named policy.
+def policy(name, tree, default="deny", default_sandbox=None, doc=None):
+    """Register a named policy from a decision-tree dict.
 
     Usage:
         policy("default", {
+            default(): deny(sandbox=plan_box),
             mode("plan"): allow(sandbox=plan_box),
-            mode("edit"): allow(sandbox=edit_box),
+            tool("Bash"): {"git push": deny()},
         })
-
-        policy("default", merge(
-            {mode("plan"): allow(sandbox=plan_box)},
-            from_claude_settings(),
-        ))
     """
-    _policy_impl(name, rules_or_dict, default=_unwrap_effect(default), default_sandbox=default_sandbox)
+    if type(name) != "string":
+        fail("policy() name must be a string")
+    if type(tree) != "dict":
+        fail("policy() tree must be a dict. Run `clash policy migrate` to convert legacy files.")
+    _policy_impl(name, tree, default=_unwrap_effect(default), default_sandbox=default_sandbox, doc=doc)
 
 
 # ---------------------------------------------------------------------------

--- a/clash_starlark/stdlib/std.star
+++ b/clash_starlark/stdlib/std.star
@@ -165,8 +165,11 @@ def merge(*dicts):
     return _merge(*dicts)
 
 
-def policy(name, tree, default="deny", default_sandbox=None, doc=None):
+def policy(name, tree, default=None, default_sandbox=None, doc=None):
     """Register a named policy from a decision-tree dict.
+
+    When `default` is omitted the policy inherits the default effect from
+    settings().  Pass an explicit `default=deny()` to override.
 
     Usage:
         policy("default", {
@@ -179,7 +182,7 @@ def policy(name, tree, default="deny", default_sandbox=None, doc=None):
         fail("policy() name must be a string")
     if type(tree) != "dict":
         fail("policy() tree must be a dict. Run `clash policy migrate` to convert legacy files.")
-    _policy_impl(name, tree, default=_unwrap_effect(default), default_sandbox=default_sandbox, doc=doc)
+    _policy_impl(name, tree, default=_unwrap_effect(default) if default != None else "", default_sandbox=default_sandbox, doc=doc)
 
 
 # ---------------------------------------------------------------------------

--- a/clash_starlark/stdlib/swift.star
+++ b/clash_starlark/stdlib/swift.star
@@ -13,4 +13,4 @@ swift_full = sandbox(
     doc = "Swift full: build, test, package resolve. Full project + SPM cache access.",
 )
 
-swift = {"Bash": {("swift", "swiftc", "xcodebuild"): allow(sandbox = swift_full)}}
+swift = {tool("Bash"): {("swift", "swiftc", "xcodebuild"): allow(sandbox = swift_full)}}

--- a/clash_starlark/tests/dsl_keys.rs
+++ b/clash_starlark/tests/dsl_keys.rs
@@ -18,6 +18,14 @@ result = [
     .unwrap();
     assert_eq!(
         out.get_global_strings("result").unwrap(),
-        vec!["default", "tool", "path", "glob", "domain", "localhost", "mode"],
+        vec![
+            "default",
+            "tool",
+            "path",
+            "glob",
+            "domain",
+            "localhost",
+            "mode"
+        ],
     );
 }

--- a/clash_starlark/tests/dsl_keys.rs
+++ b/clash_starlark/tests/dsl_keys.rs
@@ -1,0 +1,23 @@
+use clash_starlark::load_starlark_source_for_test;
+
+#[test]
+fn typed_constructors_produce_match_keys() {
+    let out = load_starlark_source_for_test(
+        r#"
+result = [
+    default()._match_key,
+    tool("Bash")._match_key,
+    path("$PWD")._match_key,
+    glob("/tmp/**")._match_key,
+    domain("github.com")._match_key,
+    localhost()._match_key,
+    mode("plan")._match_key,
+]
+"#,
+    )
+    .unwrap();
+    assert_eq!(
+        out.get_global_strings("result").unwrap(),
+        vec!["default", "tool", "path", "glob", "domain", "localhost", "mode"],
+    );
+}

--- a/clash_starlark/tests/policy_tree.rs
+++ b/clash_starlark/tests/policy_tree.rs
@@ -1,0 +1,33 @@
+use clash_starlark::eval_policy_source_for_test;
+
+#[test]
+fn policy_default_key_sets_fallback() {
+    let ctx = eval_policy_source_for_test(
+        r#"
+policy("x", {
+    default(): deny(),
+    mode("plan"): allow(),
+    tool("Bash"): {"git push": deny()},
+})
+"#,
+    )
+    .unwrap();
+    let pol = ctx.policy.borrow();
+    let pol = pol.as_ref().expect("policy registered");
+    assert_eq!(pol.name, "x");
+    assert_eq!(pol.default_effect.as_deref(), Some("deny"));
+    // Tree has 2 non-default root nodes (mode + tool)
+    assert_eq!(pol.tree_nodes.len(), 2);
+}
+
+#[test]
+fn policy_unified_signature_accepts_tree_and_doc() {
+    eval_policy_source_for_test(
+        r#"
+policy("x", {
+    mode("plan"): allow(),
+}, default="deny", doc="demo")
+"#,
+    )
+    .unwrap();
+}

--- a/clash_starlark/tests/root_key_rule.rs
+++ b/clash_starlark/tests/root_key_rule.rs
@@ -1,0 +1,26 @@
+use clash_starlark::eval_policy_source_for_test;
+
+#[test]
+fn bare_string_at_policy_root_is_rejected() {
+    let err = eval_policy_source_for_test(
+        r#"
+policy("x", {"Bash": allow()})
+"#,
+    )
+    .unwrap_err();
+    let msg = format!("{err:#}");
+    assert!(
+        msg.contains("typed constructor"),
+        "expected typed-constructor error, got: {msg}"
+    );
+}
+
+#[test]
+fn typed_root_key_is_accepted() {
+    eval_policy_source_for_test(
+        r#"
+policy("x", {tool("Bash"): allow()})
+"#,
+    )
+    .unwrap();
+}

--- a/clash_starlark/tests/sandbox_tree.rs
+++ b/clash_starlark/tests/sandbox_tree.rs
@@ -32,9 +32,7 @@ sandbox("rust-dev", {
     assert!(
         rules
             .iter()
-            .any(|r| r["path"] == "/tmp"
-                && r["effect"] == "allow"
-                && r["path_match"] == "subpath"),
+            .any(|r| r["path"] == "/tmp" && r["effect"] == "allow" && r["path_match"] == "subpath"),
         "expected /tmp subpath allow rule (from /tmp/** glob), got: {rules:#?}"
     );
 

--- a/clash_starlark/tests/sandbox_tree.rs
+++ b/clash_starlark/tests/sandbox_tree.rs
@@ -32,8 +32,10 @@ sandbox("rust-dev", {
     assert!(
         rules
             .iter()
-            .any(|r| r["path"] == "/tmp/**" && r["effect"] == "allow" && r["path_match"] == "glob"),
-        "expected /tmp/** glob allow rule, got: {rules:#?}"
+            .any(|r| r["path"] == "/tmp"
+                && r["effect"] == "allow"
+                && r["path_match"] == "subpath"),
+        "expected /tmp subpath allow rule (from /tmp/** glob), got: {rules:#?}"
     );
 
     // Network: domain + localhost present → represented somehow.

--- a/clash_starlark/tests/sandbox_tree.rs
+++ b/clash_starlark/tests/sandbox_tree.rs
@@ -1,0 +1,46 @@
+use clash_starlark::eval_policy_source_for_test;
+
+#[test]
+fn sandbox_tree_fs_and_net_round_trip() {
+    let ctx = eval_policy_source_for_test(
+        r#"
+sandbox("rust-dev", {
+    default(): deny(),
+    path("$PWD"): allow("rwc"),
+    glob("/tmp/**"): allow("rwc"),
+    domain("crates.io"): allow(),
+    localhost(): allow(),
+})
+"#,
+    )
+    .unwrap();
+    let sandboxes = ctx.sandboxes.borrow();
+    let sb = sandboxes
+        .get("rust-dev")
+        .expect("sandbox registered under name");
+
+    // default: deny → default caps = ["execute"]
+    assert_eq!(sb["default"], serde_json::json!(["execute"]));
+
+    let rules = sb["rules"].as_array().unwrap();
+    assert!(
+        rules
+            .iter()
+            .any(|r| r["path"] == "$PWD" && r["effect"] == "allow" && r["path_match"] == "literal"),
+        "expected $PWD literal allow rule, got: {rules:#?}"
+    );
+    assert!(
+        rules
+            .iter()
+            .any(|r| r["path"] == "/tmp/**" && r["effect"] == "allow" && r["path_match"] == "glob"),
+        "expected /tmp/** glob allow rule, got: {rules:#?}"
+    );
+
+    // Network: domain + localhost present → represented somehow.
+    let net = &sb["network"];
+    let net_str = serde_json::to_string(net).unwrap();
+    assert!(
+        net_str.contains("crates.io"),
+        "expected crates.io in network, got: {net_str}"
+    );
+}

--- a/clester/tests/scripts/assertion_combinators.yaml
+++ b/clester/tests/scripts/assertion_combinators.yaml
@@ -4,9 +4,9 @@ meta:
 
 clash:
   policy_star: |
-    load("@clash//std.star", "policy", "settings", "allow", "deny")
+    load("@clash//std.star", "policy", "settings", "tool", "allow", "deny")
     settings(default=deny())
-    policy("test", {"Bash": {"git": allow()}})
+    policy("test", {tool("Bash"): {"git": allow()}})
 
 steps:
   - name: all_of — decision and reason both match

--- a/clester/tests/scripts/assertion_files.yaml
+++ b/clester/tests/scripts/assertion_files.yaml
@@ -4,9 +4,9 @@ meta:
 
 clash:
   policy_star: |
-    load("@clash//std.star", "policy", "settings", "allow", "deny")
+    load("@clash//std.star", "policy", "settings", "tool", "allow", "deny")
     settings(default=deny())
-    policy("test", {"Bash": {"git": allow()}})
+    policy("test", {tool("Bash"): {"git": allow()}})
 
 steps:
   - name: create test file via shell

--- a/clester/tests/scripts/assertion_regex.yaml
+++ b/clester/tests/scripts/assertion_regex.yaml
@@ -4,9 +4,9 @@ meta:
 
 clash:
   policy_star: |
-    load("@clash//std.star", "policy", "settings", "allow", "deny")
+    load("@clash//std.star", "policy", "settings", "tool", "allow", "deny")
     settings(default=deny())
-    policy("test", {"Bash": {"git": allow()}})
+    policy("test", {tool("Bash"): {"git": allow()}})
 
 steps:
   - name: git status allowed — reason matches regex

--- a/clester/tests/scripts/ecosystem_sandboxes.yaml
+++ b/clester/tests/scripts/ecosystem_sandboxes.yaml
@@ -19,7 +19,7 @@ clash:
 
     policy("test",
         {
-            Tool("Bash"): {
+            tool("Bash"): {
                 "git": { glob("**"): allow(sandbox=git_safe) },
                 ("cargo", "rustc"): { glob("**"): allow(sandbox=rust_safe) },
                 "go": { glob("**"): allow(sandbox=go_safe) },

--- a/clester/tests/scripts/error/error_conflicting_policies.yaml
+++ b/clester/tests/scripts/error/error_conflicting_policies.yaml
@@ -4,13 +4,13 @@ meta:
 
 clash:
   policy_star: |
-    load("@clash//std.star", "policy", "settings", "allow", "deny")
+    load("@clash//std.star", "policy", "settings", "tool", "allow", "deny")
     settings(default=allow())
-    policy("user-policy", {"Bash": allow()})
+    policy("user-policy", {tool("Bash"): allow()})
   project_policy_star: |
-    load("@clash//std.star", "policy", "settings", "allow", "deny")
+    load("@clash//std.star", "policy", "settings", "tool", "allow", "deny")
     settings(default=deny())
-    policy("project-policy", {"Bash": deny()})
+    policy("project-policy", {tool("Bash"): deny()})
 
 steps:
   - name: project deny overrides user allow

--- a/clester/tests/scripts/harness_defaults_user_deny.yaml
+++ b/clester/tests/scripts/harness_defaults_user_deny.yaml
@@ -7,9 +7,9 @@ meta:
 
 clash:
   policy_star: |
-    load("@clash//std.star", "allow", "deny", "policy", "settings")
+    load("@clash//std.star", "allow", "deny", "policy", "settings", "tool")
     settings(default=deny())
-    policy("test", {"Read": deny()})
+    policy("test", {tool("Read"): deny()})
 
 steps:
   - name: read from $HOME/.claude/ is denied by explicit user rule

--- a/clester/tests/scripts/star_basic_exec.yaml
+++ b/clester/tests/scripts/star_basic_exec.yaml
@@ -4,16 +4,16 @@ meta:
 
 clash:
   policy_star: |
-    load("@clash//std.star", "policy", "settings", "allow", "deny", "glob")
+    load("@clash//std.star", "policy", "settings", "tool", "allow", "deny", "glob")
     settings(default=deny())
     policy("test", {
-        "Bash": {
+        tool("Bash"): {
             "git": {
                 "push": deny(),
                 glob("**"): allow(),
             },
         },
-        "Read": allow(),
+        tool("Read"): allow(),
     })
 
 steps:

--- a/clester/tests/scripts/star_canonical_names.yaml
+++ b/clester/tests/scripts/star_canonical_names.yaml
@@ -6,7 +6,7 @@ clash:
   policy_star: |
     settings(default=deny())
     policy("test", {
-        ("shell", "read", "write", "edit", "glob", "grep", "web_fetch", "web_search"): allow(),
+        tool(("shell", "read", "write", "edit", "glob", "grep", "web_fetch", "web_search")): allow(),
     })
 
 steps:

--- a/clester/tests/scripts/star_case_insensitive.yaml
+++ b/clester/tests/scripts/star_case_insensitive.yaml
@@ -6,8 +6,8 @@ clash:
   policy_star: |
     settings(default=deny())
     policy("test", {
-        "bash": allow(),
-        "READ": allow(),
+        tool("bash"): allow(),
+        tool("READ"): allow(),
     })
 
 steps:

--- a/clester/tests/scripts/star_default_deny.yaml
+++ b/clester/tests/scripts/star_default_deny.yaml
@@ -4,9 +4,9 @@ meta:
 
 clash:
   policy_star: |
-    load("@clash//std.star", "policy", "settings", "allow", "deny")
+    load("@clash//std.star", "policy", "settings", "tool", "allow", "deny")
     settings(default=deny())
-    policy("test", {"Bash": {"git": allow()}})
+    policy("test", {tool("Bash"): {"git": allow()}})
 
 steps:
   - name: git allowed

--- a/clester/tests/scripts/star_env_vars.yaml
+++ b/clester/tests/scripts/star_env_vars.yaml
@@ -6,10 +6,10 @@ meta:
 
 clash:
   policy_star: |
-    load("@clash//std.star", "policy", "settings", "allow", "deny")
+    load("@clash//std.star", "policy", "settings", "tool", "allow", "deny")
     settings(default=deny())
     policy("test", {
-        "Bash": {
+        tool("Bash"): {
             "git": {"push": deny()},
             "cargo": allow(),
         },

--- a/clester/tests/scripts/star_layer_precedence.yaml
+++ b/clester/tests/scripts/star_layer_precedence.yaml
@@ -4,13 +4,13 @@ meta:
 
 clash:
   policy_star: |
-    load("@clash//std.star", "policy", "settings", "ask", "allow")
+    load("@clash//std.star", "policy", "settings", "tool", "ask", "allow")
     settings(default=ask())
-    policy("test", {"Bash": {("git", "cargo"): allow()}})
+    policy("test", {tool("Bash"): {("git", "cargo"): allow()}})
   project_policy_star: |
-    load("@clash//std.star", "policy", "settings", "deny")
+    load("@clash//std.star", "policy", "settings", "tool", "deny")
     settings(default=deny())
-    policy("test", {"Bash": {"git": {"push": deny()}}})
+    policy("test", {tool("Bash"): {"git": {"push": deny()}}})
 
 steps:
   - name: git status allowed by user rule (not overridden by project)

--- a/clester/tests/scripts/star_net_localhost.yaml
+++ b/clester/tests/scripts/star_net_localhost.yaml
@@ -4,9 +4,9 @@ meta:
 
 clash:
   policy_star: |
-    load("@clash//std.star", "policy", "settings", "allow", "deny")
+    load("@clash//std.star", "policy", "settings", "tool", "allow", "deny")
     settings(default=deny())
-    policy("test", {"WebFetch": {"localhost": allow()}})
+    policy("test", {tool("WebFetch"): {"localhost": allow()}})
 
 steps:
   - name: webfetch localhost allowed

--- a/clester/tests/scripts/star_net_rules.yaml
+++ b/clester/tests/scripts/star_net_rules.yaml
@@ -4,10 +4,10 @@ meta:
 
 clash:
   policy_star: |
-    load("@clash//std.star", "policy", "settings", "allow", "deny")
+    load("@clash//std.star", "policy", "settings", "tool", "allow", "deny")
     settings(default=deny())
     policy("test", {
-        "WebFetch": {
+        tool("WebFetch"): {
             "github.com": allow(),
             "api.github.com": allow(),
         },

--- a/clester/tests/scripts/star_sandbox_dict.yaml
+++ b/clester/tests/scripts/star_sandbox_dict.yaml
@@ -4,14 +4,14 @@ meta:
 
 clash:
   policy_star: |
-    load("@clash//std.star", "policy", "settings", "sandbox", "allow", "deny", "subpath", "glob")
+    load("@clash//std.star", "policy", "settings", "sandbox", "tool", "path", "allow", "deny", "subpath", "glob")
     dev_box = sandbox(
         name = "dev",
         default = deny(),
         fs = {
             subpath("$PWD", follow_worktrees = True): allow("rwc"),
             glob("$TMPDIR/**"): allow(),
-            "$HOME": {
+            path("$HOME"): {
                 glob(".cargo/**"): allow("rwc"),
                 glob(".rustup/**"): allow("r"),
                 glob(".ssh/**"): deny(),
@@ -21,11 +21,11 @@ clash:
 
     settings(default=deny())
     policy("test", {
-        "Bash": {
+        tool("Bash"): {
             "cargo": allow(sandbox = dev_box),
             "git": allow(sandbox = dev_box),
         },
-        "Read": allow(sandbox = dev_box),
+        tool("Read"): allow(sandbox = dev_box),
     })
 
 steps:

--- a/clester/tests/scripts/star_sandbox_merge.yaml
+++ b/clester/tests/scripts/star_sandbox_merge.yaml
@@ -4,13 +4,13 @@ meta:
 
 clash:
   policy_star: |
-    load("@clash//std.star", "policy", "settings", "sandbox", "allow", "deny")
+    load("@clash//std.star", "policy", "settings", "sandbox", "tool", "path", "allow", "deny")
 
     fs_box = sandbox(
         name = "fs",
         default = deny(),
         fs = {
-            "$PWD": allow("rwc"),
+            path("$PWD"): allow("rwc"),
         },
     )
 
@@ -18,8 +18,8 @@ clash:
         name = "home",
         default = deny(),
         fs = {
-            "$HOME/.cargo": allow("r"),
-            "$TMPDIR": allow(),
+            path("$HOME/.cargo"): allow("r"),
+            path("$TMPDIR"): allow(),
         },
     )
 
@@ -27,11 +27,11 @@ clash:
 
     settings(default=deny())
     policy("test", {
-        "Bash": {
+        tool("Bash"): {
             "cargo": allow(sandbox = merged),
             "git": allow(sandbox = fs_box),
         },
-        "Read": allow(sandbox = fs_box),
+        tool("Read"): allow(sandbox = fs_box),
     })
 
 steps:

--- a/clester/tests/scripts/star_sandbox_presets.yaml
+++ b/clester/tests/scripts/star_sandbox_presets.yaml
@@ -10,7 +10,7 @@ clash:
     policy("test", {
         tool("Bash"): {"git": {glob("**"): allow(sandbox=project)}},
         tool(("Read", "Glob", "Grep")): allow(),
-    })
+    }, default=ask())
 
 steps:
   - name: git status allowed with project sandbox

--- a/clester/tests/scripts/star_sandbox_presets.yaml
+++ b/clester/tests/scripts/star_sandbox_presets.yaml
@@ -4,12 +4,12 @@ meta:
 
 clash:
   policy_star: |
-    load("@clash//std.star", "policy", "settings", "allow", "deny", "ask", "glob")
+    load("@clash//std.star", "policy", "settings", "tool", "allow", "deny", "ask", "glob")
     load("@clash//sandboxes.star", "readonly", "project", "workspace", "unrestricted")
     settings(default=ask(), default_sandbox=project)
     policy("test", {
-        "Bash": {"git": {glob("**"): allow(sandbox=project)}},
-        ("Read", "Glob", "Grep"): allow(),
+        tool("Bash"): {"git": {glob("**"): allow(sandbox=project)}},
+        tool(("Read", "Glob", "Grep")): allow(),
     })
 
 steps:

--- a/clester/tests/scripts/star_tool_rules.yaml
+++ b/clester/tests/scripts/star_tool_rules.yaml
@@ -4,12 +4,12 @@ meta:
 
 clash:
   policy_star: |
-    load("@clash//std.star", "policy", "settings", "allow", "deny")
+    load("@clash//std.star", "policy", "settings", "tool", "allow", "deny")
     settings(default=deny())
     policy("test", {
-        ("Read", "Glob", "Grep"): allow(),
-        "WebSearch": deny(),
-        "Skill": allow(),
+        tool(("Read", "Glob", "Grep")): allow(),
+        tool("WebSearch"): deny(),
+        tool("Skill"): allow(),
     })
 
 steps:

--- a/docs/superpowers/specs/2026-04-06-unify-policy-and-sandbox-design.md
+++ b/docs/superpowers/specs/2026-04-06-unify-policy-and-sandbox-design.md
@@ -220,3 +220,33 @@ Two parse-time errors matter most. Both should be instructive, not punitive:
   the new root-key rule and the unified sandbox tree shape.
 - Any change to how sandboxes are *executed* — this is purely a source-format
   and parse-time change.
+
+## Known follow-ups
+
+The initial implementation pass (tasks A1–A6) left a few items as deferred
+tech debt rather than blocking the unify-policy-and-sandbox PR:
+
+1. **`_legacy_sandbox` / `_make_sandbox` shim retained.** The bundled stdlib
+   ecosystem files (`stdlib/rust.star`, `python.star`, `node.star`, `go.star`,
+   `java.star`, `ruby.star`, `swift.star`, `dotnet.star`, `make.star`,
+   `docker.star`, `sandboxes.star`) still call legacy `sandbox(fs=..., net=...)`
+   at module load time. The dispatch in `sandbox()` that routes legacy
+   `fs=`/`net=` kwargs to `_legacy_sandbox` is therefore still required, along
+   with the supporting `cwd()`, `home()`, `tempdir()`, `domains()`,
+   `_legacy_path_match`, `_legacy_glob`, and `_path_match` helpers.
+
+2. **Loader refactor needed to migrate stdlib ecosystems.** The reason these
+   files can't be mechanically migrated to the unified tree shape is that
+   module-level `sandbox()` calls during `load(...)` evaluation cannot
+   currently access `EvalContext` to register against the active policy.
+   Migrating them to the new DSL requires a loader refactor that gives
+   module-level constructors access to the registration context. That refactor
+   is out of scope for this PR but is the prerequisite for finally deleting
+   the legacy shim and its supporting helpers.
+
+3. **`network()` root constructor.** A5 added a `network()` root constructor
+   to the unified DSL because expressing "allow all network" in the new tree
+   shape required a typed constructor at the root that wasn't otherwise
+   reachable. This was a mechanical addition discovered during migration; it
+   should be reviewed for naming/ergonomics alongside any future revisions to
+   the network grammar.

--- a/examples/curl-localhost-only.star
+++ b/examples/curl-localhost-only.star
@@ -2,21 +2,18 @@
 # Allow curl, but only to your local dev server on port 8080.
 # Everything else is denied network access at the OS level.
 
-sandbox(
-    name = "localhost_only",
-    default = deny(),
-    fs = {
-        subpath("$PWD"): allow("r"),
-        glob("$TMPDIR/**"): allow(),
-    },
-    net = localhost(ports = [8080]),
-)
+sandbox("localhost_only", {
+    default(): deny(),
+    path("$PWD"): allow("r"),
+    glob("$TMPDIR/**"): allow(),
+    localhost(ports = [8080]): allow(),
+}, doc = "Localhost-only network access on port 8080; project read-only.")
 
 settings(default = deny())
 
 policy("curl-localhost-only", {
-    "Bash": {
+    tool("Bash"): {
         "curl": allow(sandbox = "localhost_only"),
     },
-    ("Read", "Glob", "Grep"): allow(),
-})
+    tool(("Read", "Glob", "Grep")): allow(),
+}, doc = "Allow curl to reach localhost:8080 only; everything else denied.")

--- a/examples/git-ssh-protected.star
+++ b/examples/git-ssh-protected.star
@@ -2,29 +2,25 @@
 # git can reach GitHub and read your SSH keys for auth.
 # Nothing else can see ~/.ssh or access the network.
 
-sandbox(
-    name = "git_github",
-    default = deny(),
-    fs = {
-        subpath("$PWD", follow_worktrees = True): allow("rwc"),
-        "$HOME": {
-            glob(".ssh/**"): allow("rx"),
-            ".gitconfig": allow("r"),
-            glob(".config/git/**"): allow("r"),
-        },
-        glob("$TMPDIR/**"): allow(),
-    },
-    net = [domains({"github.com": allow(), "*.github.com": allow()})],
-)
+sandbox("git_github", {
+    default(): deny(),
+    path("$PWD", worktree = True): allow("rwc"),
+    glob("$HOME/.ssh/**"): allow("rx"),
+    path("$HOME/.gitconfig"): allow("r"),
+    glob("$HOME/.config/git/**"): allow("r"),
+    glob("$TMPDIR/**"): allow(),
+    domain("github.com"): allow(),
+    domain("*.github.com"): allow(),
+}, doc = "Git sandbox: project read/write, SSH keys readable, network limited to github.com.")
 
 settings(default = deny())
 
 policy("git-ssh-protected", {
-    "Bash": {
+    tool("Bash"): {
         "git": {
             "push": deny(),
             glob("**"): allow(sandbox = "git_github"),
         },
     },
-    ("Read", "Glob", "Grep"): allow(),
-})
+    tool(("Read", "Glob", "Grep")): allow(),
+}, doc = "git can reach github.com and read SSH keys for auth; nothing else has network or ~/.ssh.")

--- a/examples/node-dev.star
+++ b/examples/node-dev.star
@@ -1,23 +1,22 @@
 # Node.js Development Policy
 # Allows npm/bun/node with sandboxed filesystem access.
 
-sandbox(
-    name = "node",
-    default = deny(),
-    fs = {
-        subpath("$PWD", follow_worktrees = True): allow("rwc"),
-        glob("$TMPDIR/**"): allow(),
-    },
-    net = allow(),
-)
+sandbox("node", {
+    default(): deny(),
+    path("$PWD", worktree = True): allow("rwc"),
+    glob("$TMPDIR/**"): allow(),
+    network(): allow(),
+}, doc = "Node toolchain sandbox: project read/write, network allowed.")
 
 settings(default = ask())
 
 policy("node-dev", {
-    "Bash": {
-        "git": {"push": {"--force": deny()}},
+    tool("Bash"): {
+        "git": {
+            "push": {"--force": deny()},
+            glob("**"): allow(),
+        },
         ("npm", "npx", "node", "bun"): allow(sandbox = "node"),
-        "git": allow(),
     },
-    ("Read", "Glob", "Grep"): allow(),
-})
+    tool(("Read", "Glob", "Grep")): allow(),
+}, doc = "Node.js development: npm/npx/node/bun sandboxed; git push --force denied.")

--- a/examples/paranoid.star
+++ b/examples/paranoid.star
@@ -5,8 +5,8 @@
 settings(default = deny())
 
 policy("paranoid", {
-    "Bash": {
+    tool("Bash"): {
         "git": {("status", "diff", "log"): allow()},
     },
-    ("Read", "Glob", "Grep"): allow(),
-})
+    tool(("Read", "Glob", "Grep")): allow(),
+}, doc = "Maximum security: deny-all default, only read-only git and file reading tools allowed.")

--- a/examples/permissive.star
+++ b/examples/permissive.star
@@ -5,9 +5,9 @@
 settings(default = ask())
 
 policy("permissive", {
-    "Bash": {
+    tool("Bash"): {
         "git": {"push": {"--force": deny()}},
         ("git", "cargo", "npm", "npx", "node", "bun", "python", "pip", "uv", "make", "just"): allow(),
     },
-    ("Read", "Write", "Edit", "Glob", "Grep"): allow(),
-})
+    tool(("Read", "Write", "Edit", "Glob", "Grep")): allow(),
+}, doc = "Permissive: ask-all default with common dev tools auto-allowed; denies only force-push.")

--- a/examples/python-dev.star
+++ b/examples/python-dev.star
@@ -1,23 +1,22 @@
 # Python Development Policy
 # Allows python/pip/uv/pytest with sandboxed filesystem access.
 
-sandbox(
-    name = "python",
-    default = deny(),
-    fs = {
-        subpath("$PWD", follow_worktrees = True): allow("rwc"),
-        glob("$TMPDIR/**"): allow(),
-    },
-    net = allow(),
-)
+sandbox("python", {
+    default(): deny(),
+    path("$PWD", worktree = True): allow("rwc"),
+    glob("$TMPDIR/**"): allow(),
+    network(): allow(),
+}, doc = "Python toolchain sandbox: project read/write, network allowed.")
 
 settings(default = ask())
 
 policy("python-dev", {
-    "Bash": {
-        "git": {"push": {"--force": deny()}},
+    tool("Bash"): {
+        "git": {
+            "push": {"--force": deny()},
+            glob("**"): allow(),
+        },
         ("python", "python3", "pip", "uv", "pytest"): allow(sandbox = "python"),
-        "git": allow(),
     },
-    ("Read", "Glob", "Grep"): allow(),
-})
+    tool(("Read", "Glob", "Grep")): allow(),
+}, doc = "Python development: python/pip/uv/pytest sandboxed; git push --force denied.")

--- a/examples/read-only-repo.star
+++ b/examples/read-only-repo.star
@@ -2,17 +2,14 @@
 # Any bash command can read your project directory.
 # Nothing else on the filesystem is visible.
 
-sandbox(
-    name = "repo_readonly",
-    default = deny(),
-    fs = {
-        subpath("$PWD"): allow("r"),
-    },
-)
+sandbox("repo_readonly", {
+    default(): deny(),
+    path("$PWD", worktree = True): allow("r"),
+}, doc = "Read-only access to the current project directory.")
 
 settings(default = deny())
 
 policy("read-only-repo", {
-    "Bash": allow(sandbox = "repo_readonly"),
-    ("Read", "Glob", "Grep"): allow(),
-})
+    tool("Bash"): allow(sandbox = "repo_readonly"),
+    tool(("Read", "Glob", "Grep")): allow(),
+}, doc = "Bash commands run sandboxed with read-only access to the project directory.")

--- a/examples/rust-dev.star
+++ b/examples/rust-dev.star
@@ -2,28 +2,25 @@
 # Allows common Rust toolchain commands with filesystem sandboxing.
 # Default: ask for anything not explicitly allowed.
 
-sandbox(
-    name = "rust",
-    default = deny(),
-    fs = {
-        subpath("$PWD", follow_worktrees = True): allow("rwc"),
-        glob("$TMPDIR/**"): allow(),
-        "$HOME": {
-            glob(".cargo/**"): allow("rwc"),
-            glob(".rustup/**"): allow("r"),
-        },
-    },
-    net = allow(),
-)
+sandbox("rust", {
+    default(): deny(),
+    path("$PWD", worktree = True): allow("rwc"),
+    glob("$TMPDIR/**"): allow(),
+    glob("$HOME/.cargo/**"): allow("rwc"),
+    glob("$HOME/.rustup/**"): allow("r"),
+    network(): allow(),
+}, doc = "Rust toolchain sandbox: project + cargo + rustup, network allowed.")
 
 settings(default = ask())
 
 policy("rust-dev", {
-    "Bash": {
-        "git": {"push": {"--force": deny()}},
+    tool("Bash"): {
+        "git": {
+            "push": {"--force": deny()},
+            glob("**"): allow(),
+        },
         ("cargo", "rustc", "rustfmt"): allow(sandbox = "rust"),
         "rustup": allow(),
-        "git": allow(),
     },
-    ("Read", "Glob", "Grep"): allow(),
-})
+    tool(("Read", "Glob", "Grep")): allow(),
+}, doc = "Rust development: cargo/rustc/rustfmt sandboxed; git push --force denied.")


### PR DESCRIPTION
## Summary

Unifies the `policy()` and `sandbox()` Starlark APIs so both take `(name, tree, *, ...optional kwargs)`. The `tree` argument is a decision-tree dict whose **root keys must be typed constructors** — `default()`, `mode()`, `tool()`, `path()`, `glob()`, `domain()`, `localhost()`, `network()`. Bare strings as root keys are now a parse-time error with a friendly message pointing to the right constructor.

Spec: `docs/superpowers/specs/2026-04-06-unify-policy-and-sandbox-design.md`
Plan: `docs/superpowers/plans/2026-04-06-unify-policy-and-sandbox.md`

### Before

```starlark
sandbox("rust-dev", default=deny(),
    fs={"$PWD": allow("rwc"), "$HOME": {".cargo": allow("rwc")}},
    net=allow(),
)
policy("default", {"Bash": {"git push": deny()}, mode("plan"): allow()})
```

### After

```starlark
sandbox("rust-dev", {
    path("$PWD"): allow("rwc"),
    path("$HOME/.cargo"): allow("rwc"),
    network(): allow(),
}, doc="Build and test Rust projects.")

policy("default", {
    default(): deny(),
    mode("plan"): allow(),
    tool("Bash"): {"git push": deny()},
}, doc="Default clash policy.")
```

## What's in this PR

- **A1** typed-constructor stdlib functions (`default()`, `tool()`, `path()`, `glob()`, `domain()`, `localhost()`, `network()`).
- **A2** `classify_root_key` in `when.rs` enforces the typed-root-key rule with a friendly error.
- **A3** `sandbox_tree_impl` parses the unified sandbox tree; shared `build_sandbox_json` feeds both legacy and tree paths.
- **A4** Unified `policy()` signature; `default()` root key wires through to `PolicyRegistration::default_effect`.
- **A5** Migrated `default_policy.star`, all `examples/*.star`, and the policy half of bundled `stdlib/*.star` ecosystem files. Several mechanically-required Rust extensions: `network()` constructor, `path(worktree=True)`, glob IR translation, `localhost(ports=...)` tuple-keying, top-level sandbox merge into the document.
- **A6** Spec updated with "Known follow-ups" section documenting deferred items.

## Known follow-ups (not in this PR)

The bundled `stdlib/*.star` ecosystem files (`rust.star`, `python.star`, `sandboxes.star`, etc.) still call legacy `sandbox(fs=, net=)` because module-level `sandbox()` calls during `load(...)` evaluation cannot currently access `EvalContext`. The `_legacy_sandbox` shim and its supporting helpers (`cwd()`, `home()`, `tempdir()`, `_path_match`, etc.) are intentionally retained until a follow-up loader refactor enables their migration. See spec §"Known follow-ups".

The `network()` root constructor was added as a mechanically-required addition during A5 to express "allow all network" — it should be reviewed for naming/ergonomics in a future pass.

## Test plan

- [x] `cargo test -p clash_starlark` green (171 tests)
- [x] `cargo test -p clash` 606 passing, 1 pre-existing unrelated failure (`resolve_symlinks_follows_real_symlink`, sandbox-env permissions)
- [ ] Reviewer to spot-check migrated `examples/*.star` for semantic equivalence
- [ ] Reviewer to evaluate `network()` naming
