### PR TITLE
feat: remove policy.json source format; .star is the only supported format

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,7 +51,7 @@
 * Policy source: `clash-policy/src/` — parse, compile, eval, IR (extracted crate; `clash::policy` re-exports it)
 * Rules are JSON objects with an `effect` and a capability matcher, e.g. `{ "rule": { "effect": "deny", "exec": { "bin": { "literal": "git" }, "args": [{ "literal": "push" }, { "any": null }] } } }`
 * The policy speaks in capabilities, not Claude Code tool names — the eval layer maps tools to capabilities
-* Policy files use `.json` or `.star` extension (`.json` preferred when both exist)
+* Policy files use the `.star` extension. Legacy `policy.json` files are converted with `clash policy convert`.
 * The `clash-starlark` crate evaluates `.star` files → JSON using Starlark (a Python-like config language)
 * Starlark policies use top-level `settings()`, `sandbox()`, and `policy()` registration calls (no `main()` function)
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ This builds the binary and launches a one-off Claude Code session with the plugi
 
 Policies are written in **Starlark** (`.star`), a Python-like configuration language that compiles to JSON IR. Clash reads policies on every tool invocation, so edits take effect immediately — no restart needed.
 
-You can also write policies directly in JSON if you prefer — see the [Policy Writing Guide](docs/policy-guide.md) for the JSON schema.
+Legacy `policy.json` files can be migrated with `clash policy convert` — see the [Policy Writing Guide](docs/policy-guide.md).
 
 ### Policy Layers
 
@@ -77,12 +77,12 @@ Clash supports three policy levels, each automatically included and evaluated in
 
 | Level | Location | Purpose |
 |-------|----------|---------|
-| **User** | `~/.clash/policy.json` (or `.star`) | Your personal defaults across all projects |
-| **Project** | `<project>/.clash/policy.json` (or `.star`) | Shared rules for a specific repository |
+| **User** | `~/.clash/policy.star` | Your personal defaults across all projects |
+| **Project** | `<project>/.clash/policy.star` | Shared rules for a specific repository |
 | **Session** | Created via `--scope session` | Temporary overrides for the current session |
 | **Harness** | Injected automatically | Agent infrastructure access (memories, settings, transcripts) |
 
-> **Note:** Both `.json` and `.star` are supported. When both exist at the same level, `.json` takes precedence. CLI commands (`clash policy allow/deny/remove`) operate on `policy.json`.
+> **Note:** Policy files use the `.star` extension. Legacy `policy.json` files are converted with `clash policy convert`.
 
 **Layer precedence:** Session > Project > User > Harness. Harness default rules are injected at the lowest priority — your rules always take precedence. They allow the agent to access its own infrastructure directories (`~/.claude/`, `<project>/.claude/`, transcript dir). Disable with `CLASH_NO_HARNESS_DEFAULTS=1` or `settings(harness_defaults=False)`. Use `clash status --verbose` to see harness rules tagged `[harness]`.
 

--- a/clash-plugin/README.md
+++ b/clash-plugin/README.md
@@ -41,7 +41,7 @@ The plugin registers five hook types via `hooks/hooks.json`:
 
 ## Policy Basics
 
-Policies can be managed via `policy.json` (machine-readable, CLI-friendly) or written in Starlark (`.star` files) for power users. Policy files are read from `~/.clash/policy.json` or `~/.clash/policy.star` (user-level) and `<project>/.clash/policy.json` or `<project>/.clash/policy.star` (project-level). When both exist at the same level, `.json` takes precedence.
+Policies are written in Starlark (`.star` files). Policy files are read from `~/.clash/policy.star` (user-level) and `<project>/.clash/policy.star` (project-level). Legacy `policy.json` files can be migrated with `clash policy convert`.
 
 ### Policy File Structure
 
@@ -106,10 +106,11 @@ policy("default", {
 
 ### Policy File Paths
 
-- User-level: `~/.clash/policy.json` (preferred) or `~/.clash/policy.star`
-- Project-level: `<project>/.clash/policy.json` (preferred) or `<project>/.clash/policy.star`
+- User-level: `~/.clash/policy.star`
+- Project-level: `<project>/.clash/policy.star`
 - Session-scoped rules can be added via `/clash:allow` or `/clash:deny` skills during a session
-- CLI commands (`clash policy allow/deny/remove`) operate on `policy.json` files
+- CLI commands (`clash policy allow/deny/remove`) operate on `policy.star` files
+- Legacy `policy.json` files are migrated with `clash policy convert`
 
 ### Fixing Sandbox Errors
 

--- a/clash-policy/src/lib.rs
+++ b/clash-policy/src/lib.rs
@@ -37,9 +37,9 @@ use serde::{Deserialize, Serialize};
 /// Higher-precedence levels override lower ones: Session > Project > User.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
 pub enum PolicyLevel {
-    /// User-level policy: `~/.clash/policy.json` (or `policy.star`)
+    /// User-level policy: `~/.clash/policy.star`
     User = 0,
-    /// Project-level policy: `<project_root>/.clash/policy.json` (or `policy.star`)
+    /// Project-level policy: `<project_root>/.clash/policy.star`
     Project = 1,
     /// Session-level policy: `/tmp/clash-<session_id>/policy.star`
     /// Temporary rules that last only for the current Claude Code session.

--- a/clash-policy/src/match_tree.rs
+++ b/clash-policy/src/match_tree.rs
@@ -385,11 +385,12 @@ fn default_effect() -> Effect {
 }
 
 // ---------------------------------------------------------------------------
-// PolicyManifest — on-disk policy.json representation
+// PolicyManifest — JSON shape produced by evaluating a policy
 // ---------------------------------------------------------------------------
 
-/// On-disk `policy.json` representation. Parsed at the loader level;
-/// `includes` are resolved and merged before the inner `CompiledPolicy` is used.
+/// JSON shape produced by evaluating a `.star` policy (and by the legacy
+/// `policy.json` migrate path). Parsed at the loader level; `includes` are
+/// resolved and merged before the inner `CompiledPolicy` is used.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PolicyManifest {
     /// Starlark files to include (evaluated and merged at load time).
@@ -400,11 +401,11 @@ pub struct PolicyManifest {
     pub policy: CompiledPolicy,
 }
 
-/// A single include directive in `policy.json`.
+/// A single include directive in a [`PolicyManifest`].
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct IncludeEntry {
     /// Path to a `.star` file. `@clash//` prefix resolves to the embedded stdlib;
-    /// other paths are relative to the directory containing `policy.json`.
+    /// other paths are relative to the directory containing the policy file.
     pub path: String,
 }
 

--- a/clash/src/cmd/fmt.rs
+++ b/clash/src/cmd/fmt.rs
@@ -89,6 +89,9 @@ fn validate_paths(files: &[PathBuf]) -> Result<Vec<PathBuf>> {
         if !path.exists() {
             anyhow::bail!("file not found: {}", path.display());
         }
+        if path.extension().and_then(|e| e.to_str()) == Some("json") {
+            return Err(crate::policy_loader::legacy_json_error(path));
+        }
         if path.extension().and_then(|e| e.to_str()) != Some("star") {
             anyhow::bail!("expected a .star file, got: {}", path.display(),);
         }
@@ -125,7 +128,10 @@ mod tests {
             .unwrap();
 
         let err = validate_paths(&[json_file]).unwrap_err();
-        assert!(err.to_string().contains(".star"), "got: {err}");
+        assert!(
+            err.to_string().contains("Legacy `policy.json`"),
+            "got: {err}"
+        );
     }
 
     #[test]

--- a/clash/src/cmd/policy.rs
+++ b/clash/src/cmd/policy.rs
@@ -4,8 +4,7 @@ use anyhow::{Context, Result};
 use tracing::{Level, info, instrument};
 
 use crate::cli::PolicyCmd;
-use crate::policy::manifest_edit;
-use crate::policy::match_tree::{Decision, PolicyManifest};
+use crate::policy::match_tree::PolicyManifest;
 use crate::settings::{ClashSettings, PolicyLevel};
 use crate::style;
 
@@ -666,49 +665,10 @@ fn apply_mutation(
 ) -> Result<()> {
     let path = resolve_manifest_path(scope)?;
 
-    if path.extension().is_some_and(|ext| ext == "star") {
-        return apply_mutation_star(&path, &command, tool.as_deref(), bin.as_deref(), mutation);
+    if !path.extension().is_some_and(|ext| ext == "star") {
+        return Err(crate::policy_loader::legacy_json_error(&path));
     }
-
-    let mut manifest = crate::policy_loader::read_manifest(&path)?;
-
-    // For Remove we only need the observable chain — Decision::Deny is a dummy.
-    let dummy_decision = Decision::Deny;
-    let decision = match &mutation {
-        PolicyMutation::Allow { sandbox } => Decision::Allow(
-            sandbox
-                .as_deref()
-                .map(|s| crate::policy::match_tree::SandboxRef(s.to_string())),
-        ),
-        PolicyMutation::Deny | PolicyMutation::Remove => dummy_decision,
-    };
-
-    let node = build_rule_node(&command, tool, bin, decision)?;
-
-    let result_str = match mutation {
-        PolicyMutation::Remove => {
-            if manifest_edit::remove_rule(&mut manifest, &node) {
-                crate::policy_loader::write_manifest(&path, &manifest)?;
-                println!("{} Rule removed", style::green_bold("✓"));
-                println!("  {}", style::dim(&path.display().to_string()));
-            } else {
-                println!("No matching rule found");
-            }
-            return Ok(());
-        }
-        _ => {
-            let result = manifest_edit::upsert_rule(&mut manifest, node);
-            crate::policy_loader::write_manifest(&path, &manifest)?;
-            match result {
-                manifest_edit::UpsertResult::Inserted => "Rule added",
-                manifest_edit::UpsertResult::Replaced => "Rule updated (replaced existing)",
-            }
-        }
-    };
-
-    println!("{} {}", style::green_bold("✓"), result_str);
-    println!("  {}", style::dim(&path.display().to_string()));
-    Ok(())
+    apply_mutation_star(&path, &command, tool.as_deref(), bin.as_deref(), mutation)
 }
 
 /// Apply a mutation to a `.star` policy file using the managed section approach.
@@ -841,7 +801,10 @@ fn apply_mutation_star(
     Ok(())
 }
 
-/// Resolve the policy.json path for the given scope, creating it if needed.
+/// Resolve the `policy.star` path for the given scope, creating it if needed.
+///
+/// If a legacy `policy.json` exists at the resolved location, returns the
+/// `legacy_json_error` directing the user to `clash policy migrate`.
 pub(crate) fn resolve_manifest_path(scope: Option<String>) -> Result<PathBuf> {
     let level = match scope.as_deref() {
         Some("user") => PolicyLevel::User,
@@ -858,7 +821,6 @@ pub(crate) fn resolve_manifest_path(scope: Option<String>) -> Result<PathBuf> {
         PolicyLevel::Session => anyhow::bail!("session scope not supported for policy mutation"),
     };
 
-    // Prefer .star over .json — .star is the primary format when both exist.
     let star_path = dir.join("policy.star");
     if star_path.exists() {
         return Ok(star_path);
@@ -866,26 +828,16 @@ pub(crate) fn resolve_manifest_path(scope: Option<String>) -> Result<PathBuf> {
 
     let json_path = dir.join("policy.json");
     if json_path.exists() {
-        return Ok(json_path);
+        return Err(crate::policy_loader::legacy_json_error(&json_path));
     }
 
-    // No policy at all — create a bare manifest.
+    // No policy at all — scaffold a starter .star file.
     std::fs::create_dir_all(&dir).with_context(|| format!("failed to create {}", dir.display()))?;
-    let manifest = PolicyManifest {
-        includes: vec![],
-        policy: crate::policy::match_tree::CompiledPolicy {
-            sandboxes: std::collections::HashMap::new(),
-            tree: vec![],
-            default_effect: crate::policy::Effect::Deny,
-            default_sandbox: None,
-            on_sandbox_violation: Default::default(),
-            harness_defaults: None,
-        },
-    };
-
-    crate::policy_loader::write_manifest(&json_path, &manifest)?;
-    info!(path = %json_path.display(), "Created policy.json");
-    Ok(json_path)
+    let source = include_str!("../default_policy.star");
+    std::fs::write(&star_path, source)
+        .with_context(|| format!("failed to write {}", star_path.display()))?;
+    info!(path = %star_path.display(), "Created policy.star");
+    Ok(star_path)
 }
 
 /// Parse a positional command string into (bin, args).
@@ -903,34 +855,6 @@ fn parse_command(command: &[String]) -> Option<(String, Vec<String>)> {
     let bin = parts[0].to_string();
     let args: Vec<String> = parts[1..].iter().map(|s| s.to_string()).collect();
     Some((bin, args))
-}
-
-/// Build a rule node from CLI arguments.
-///
-/// Priority: positional `command` > `--bin` > `--tool`.
-/// If no flags or command are provided, returns an error.
-fn build_rule_node(
-    command: &[String],
-    tool: Option<String>,
-    bin: Option<String>,
-    decision: Decision,
-) -> Result<crate::policy::match_tree::Node> {
-    // Positional command takes priority.
-    if let Some((bin_name, args)) = parse_command(command) {
-        let arg_refs: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
-        return Ok(manifest_edit::build_exec_rule(
-            &bin_name, &arg_refs, decision,
-        ));
-    }
-    match (tool.as_deref(), bin.as_deref()) {
-        (_, Some(bin_name)) => Ok(manifest_edit::build_exec_rule(bin_name, &[], decision)),
-        (Some(tool_name), None) => {
-            // Resolve canonical/case-insensitive names: "shell" → "Bash", "bash" → "Bash", etc.
-            let resolved = crate::agents::resolve_any_to_internal(tool_name).unwrap_or(tool_name);
-            Ok(manifest_edit::build_tool_rule(resolved, decision))
-        }
-        (None, None) => anyhow::bail!("provide a command, --tool, or --bin"),
-    }
 }
 
 /// Check if a string looks like an audit log hash (3-7 hex chars).
@@ -1064,7 +988,10 @@ fn apply_mutation_by_path(
     rule_args: &[String],
     mutation: PolicyMutation,
 ) -> Result<()> {
-    if path.extension().is_some_and(|ext| ext == "star") {
+    if !path.extension().is_some_and(|ext| ext == "star") {
+        return Err(crate::policy_loader::legacy_json_error(path));
+    }
+    {
         let arg_refs: Vec<&str> = rule_args.iter().map(|s| s.as_str()).collect();
         let star_effect = match &mutation {
             PolicyMutation::Allow { .. } => clash_starlark::codegen::mutate::Effect::Allow,
@@ -1112,42 +1039,8 @@ fn apply_mutation_by_path(
             }
         }
         println!("  {}", style::dim(&path.display().to_string()));
-        return Ok(());
+        Ok(())
     }
-
-    let rule_arg_refs: Vec<&str> = rule_args.iter().map(|s| s.as_str()).collect();
-    let decision = match &mutation {
-        PolicyMutation::Allow { sandbox } => Decision::Allow(
-            sandbox
-                .as_deref()
-                .map(|s| crate::policy::match_tree::SandboxRef(s.to_string())),
-        ),
-        PolicyMutation::Deny => Decision::Deny,
-        PolicyMutation::Remove => Decision::Deny,
-    };
-    let node = manifest_edit::build_exec_rule(bin_name, &rule_arg_refs, decision);
-    let mut manifest = crate::policy_loader::read_manifest(path)?;
-    match mutation {
-        PolicyMutation::Remove => {
-            if manifest_edit::remove_rule(&mut manifest, &node) {
-                crate::policy_loader::write_manifest(path, &manifest)?;
-                println!("{} Rule removed", style::green_bold("✓"));
-            } else {
-                println!("No matching rule found");
-            }
-        }
-        _ => {
-            let result = manifest_edit::upsert_rule(&mut manifest, node);
-            crate::policy_loader::write_manifest(path, &manifest)?;
-            let result_str = match result {
-                manifest_edit::UpsertResult::Inserted => "Rule added",
-                manifest_edit::UpsertResult::Replaced => "Rule updated (replaced existing)",
-            };
-            println!("{} {}", style::green_bold("✓"), result_str);
-        }
-    }
-    println!("  {}", style::dim(&path.display().to_string()));
-    Ok(())
 }
 
 fn handle_deny_by_hash(hash: &str, scope: Option<String>, broad: bool, yes: bool) -> Result<()> {
@@ -1210,7 +1103,19 @@ fn handle_remove(
 fn handle_convert(file: Option<PathBuf>, replace: bool) -> Result<()> {
     let json_path = match file {
         Some(p) => p,
-        None => resolve_manifest_path(None)?,
+        None => {
+            // Look for a policy.json at the default scope without going through
+            // resolve_manifest_path (which now rejects .json).
+            let level = ClashSettings::default_scope();
+            let dir = match level {
+                PolicyLevel::User => ClashSettings::settings_dir()?,
+                PolicyLevel::Project => ClashSettings::project_root()?.join(".clash"),
+                PolicyLevel::Session => {
+                    anyhow::bail!("session scope not supported for policy convert")
+                }
+            };
+            dir.join("policy.json")
+        }
     };
 
     if !json_path.exists() {

--- a/clash/src/policy_loader.rs
+++ b/clash/src/policy_loader.rs
@@ -49,9 +49,18 @@ pub fn evaluate_star_policy(path: &Path) -> Result<clash_starlark::EvalOutput> {
     Ok(output)
 }
 
-/// Load a `policy.json` manifest: parse the JSON, resolve includes, and return
-/// a merged JSON source string suitable for [`compile::compile_to_tree`].
-pub fn load_json_policy(path: &Path) -> Result<String> {
+/// Construct the standard "legacy `policy.json` detected" error for any
+/// non-migrate caller that encounters a `.json` policy file.
+pub fn legacy_json_error(path: &Path) -> anyhow::Error {
+    anyhow::anyhow!(
+        "Legacy `policy.json` detected at `{}`. Run `clash policy migrate` to convert to `.star` (the only supported format).",
+        path.display()
+    )
+}
+
+/// Only call from cmd::policy::migrate. All other JSON loading paths have been removed.
+#[allow(dead_code)]
+pub(crate) fn migrate_load_json_policy(path: &Path) -> Result<String> {
     let raw = std::fs::read_to_string(path)
         .with_context(|| format!("failed to read {}", path.display()))?;
 
@@ -72,6 +81,7 @@ pub fn load_json_policy(path: &Path) -> Result<String> {
 ///
 /// Inline tree nodes come first (first-match wins), followed by included
 /// policies in declaration order.
+#[allow(dead_code)]
 fn merge_manifest_with_includes(manifest: &PolicyManifest, base_dir: &Path) -> Result<String> {
     let mut merged = manifest.policy.clone();
 
@@ -133,7 +143,7 @@ fn evaluate_stdlib_include(include_path: &str) -> Result<String> {
 
 /// Read and parse a `policy.json` file into a [`PolicyManifest`].
 ///
-/// This does NOT resolve includes — call [`load_json_policy`] for full loading.
+/// This does NOT resolve includes — call [`migrate_load_json_policy`] for full loading.
 pub fn read_manifest(path: &Path) -> Result<PolicyManifest> {
     let raw = std::fs::read_to_string(path)
         .with_context(|| format!("failed to read {}", path.display()))?;
@@ -312,14 +322,10 @@ pub fn try_load_policy(
 
     let is_json = path.extension().is_some_and(|ext| ext == "json");
     let (json_source, shadows) = if is_json {
-        match load_json_policy(path) {
-            Ok(json) => (json, Vec::new()),
-            Err(e) => {
-                error!(path = %path.display(), level = %level, error = %e, "Failed to evaluate JSON policy");
-                *policy_error = Some(format!("Failed to evaluate {}: {}", path.display(), e));
-                return None;
-            }
-        }
+        let e = legacy_json_error(path);
+        error!(path = %path.display(), level = %level, error = %e, "Legacy policy.json rejected");
+        *policy_error = Some(e.to_string());
+        return None;
     } else {
         match evaluate_star_policy(path) {
             Ok(output) => (output.json, output.shadows),
@@ -391,7 +397,7 @@ pub fn load_and_compile_single(
 
     let is_json = path.extension().is_some_and(|ext| ext == "json");
     let eval_result = if is_json {
-        load_json_policy(path)
+        Err(legacy_json_error(path))
     } else {
         evaluate_star_policy(path).map(|o| o.json)
     };
@@ -422,6 +428,10 @@ pub fn load_and_compile_single(
 mod tests {
     use super::*;
 
+    /// Legacy JSON parsing is still tested, but only via the migrate code path.
+    mod migrate_tests {
+        use super::*;
+
     #[test]
     fn load_json_policy_without_includes() {
         let dir = tempfile::tempdir().unwrap();
@@ -442,7 +452,7 @@ mod tests {
         )
         .unwrap();
 
-        let source = load_json_policy(&json_path).unwrap();
+        let source = migrate_load_json_policy(&json_path).unwrap();
         let policy: CompiledPolicy = serde_json::from_str(&source).unwrap();
         assert_eq!(policy.tree.len(), 1);
     }
@@ -482,7 +492,7 @@ policy("include", {"Read": allow()})
         )
         .unwrap();
 
-        let source = load_json_policy(&json_path).unwrap();
+        let source = migrate_load_json_policy(&json_path).unwrap();
         let policy: CompiledPolicy = serde_json::from_str(&source).unwrap();
         // Should have inline (Bash) + included (Read) rules.
         assert!(
@@ -507,13 +517,14 @@ policy("include", {"Read": allow()})
         )
         .unwrap();
 
-        let source = load_json_policy(&json_path).unwrap();
+        let source = migrate_load_json_policy(&json_path).unwrap();
         let policy: CompiledPolicy = serde_json::from_str(&source).unwrap();
         // builtin.star exports rules for clash commands + claude tools.
         assert!(
             !policy.tree.is_empty(),
             "builtin.star should contribute rules"
         );
+    }
     }
 
     #[test]

--- a/clash/src/policy_loader.rs
+++ b/clash/src/policy_loader.rs
@@ -432,13 +432,13 @@ mod tests {
     mod migrate_tests {
         use super::*;
 
-    #[test]
-    fn load_json_policy_without_includes() {
-        let dir = tempfile::tempdir().unwrap();
-        let json_path = dir.path().join("policy.json");
-        std::fs::write(
-            &json_path,
-            r#"{
+        #[test]
+        fn load_json_policy_without_includes() {
+            let dir = tempfile::tempdir().unwrap();
+            let json_path = dir.path().join("policy.json");
+            std::fs::write(
+                &json_path,
+                r#"{
                 "default_effect": "deny",
                 "sandboxes": {},
                 "tree": [{
@@ -449,35 +449,35 @@ mod tests {
                     }
                 }]
             }"#,
-        )
-        .unwrap();
+            )
+            .unwrap();
 
-        let source = migrate_load_json_policy(&json_path).unwrap();
-        let policy: CompiledPolicy = serde_json::from_str(&source).unwrap();
-        assert_eq!(policy.tree.len(), 1);
-    }
+            let source = migrate_load_json_policy(&json_path).unwrap();
+            let policy: CompiledPolicy = serde_json::from_str(&source).unwrap();
+            assert_eq!(policy.tree.len(), 1);
+        }
 
-    #[test]
-    fn load_json_policy_with_star_include() {
-        let dir = tempfile::tempdir().unwrap();
+        #[test]
+        fn load_json_policy_with_star_include() {
+            let dir = tempfile::tempdir().unwrap();
 
-        // Write a local .star include file.
-        let star_path = dir.path().join("extra.star");
-        std::fs::write(
-            &star_path,
-            r#"
+            // Write a local .star include file.
+            let star_path = dir.path().join("extra.star");
+            std::fs::write(
+                &star_path,
+                r#"
 load("@clash//std.star", "policy", "settings", "deny")
 settings(default = deny())
 policy("include", {"Read": allow()})
 "#,
-        )
-        .unwrap();
+            )
+            .unwrap();
 
-        // Write policy.json that includes extra.star and has its own inline rule.
-        let json_path = dir.path().join("policy.json");
-        std::fs::write(
-            &json_path,
-            r#"{
+            // Write policy.json that includes extra.star and has its own inline rule.
+            let json_path = dir.path().join("policy.json");
+            std::fs::write(
+                &json_path,
+                r#"{
                 "default_effect": "deny",
                 "sandboxes": {},
                 "includes": [{"path": "extra.star"}],
@@ -489,42 +489,42 @@ policy("include", {"Read": allow()})
                     }
                 }]
             }"#,
-        )
-        .unwrap();
+            )
+            .unwrap();
 
-        let source = migrate_load_json_policy(&json_path).unwrap();
-        let policy: CompiledPolicy = serde_json::from_str(&source).unwrap();
-        // Should have inline (Bash) + included (Read) rules.
-        assert!(
-            policy.tree.len() >= 2,
-            "expected at least 2 rules, got {}",
-            policy.tree.len()
-        );
-    }
+            let source = migrate_load_json_policy(&json_path).unwrap();
+            let policy: CompiledPolicy = serde_json::from_str(&source).unwrap();
+            // Should have inline (Bash) + included (Read) rules.
+            assert!(
+                policy.tree.len() >= 2,
+                "expected at least 2 rules, got {}",
+                policy.tree.len()
+            );
+        }
 
-    #[test]
-    fn load_json_policy_with_stdlib_include() {
-        let dir = tempfile::tempdir().unwrap();
-        let json_path = dir.path().join("policy.json");
-        std::fs::write(
-            &json_path,
-            r#"{
+        #[test]
+        fn load_json_policy_with_stdlib_include() {
+            let dir = tempfile::tempdir().unwrap();
+            let json_path = dir.path().join("policy.json");
+            std::fs::write(
+                &json_path,
+                r#"{
                 "default_effect": "deny",
                 "sandboxes": {},
                 "includes": [{"path": "@clash//builtin.star"}],
                 "tree": []
             }"#,
-        )
-        .unwrap();
+            )
+            .unwrap();
 
-        let source = migrate_load_json_policy(&json_path).unwrap();
-        let policy: CompiledPolicy = serde_json::from_str(&source).unwrap();
-        // builtin.star exports rules for clash commands + claude tools.
-        assert!(
-            !policy.tree.is_empty(),
-            "builtin.star should contribute rules"
-        );
-    }
+            let source = migrate_load_json_policy(&json_path).unwrap();
+            let policy: CompiledPolicy = serde_json::from_str(&source).unwrap();
+            // builtin.star exports rules for clash commands + claude tools.
+            assert!(
+                !policy.tree.is_empty(),
+                "builtin.star should contribute rules"
+            );
+        }
     }
 
     #[test]

--- a/clash/src/policy_loader.rs
+++ b/clash/src/policy_loader.rs
@@ -141,15 +141,6 @@ fn evaluate_stdlib_include(include_path: &str) -> Result<String> {
     Ok(eval_output.json)
 }
 
-/// Read and parse a `policy.json` file into a [`PolicyManifest`].
-///
-/// This does NOT resolve includes — call [`migrate_load_json_policy`] for full loading.
-pub fn read_manifest(path: &Path) -> Result<PolicyManifest> {
-    let raw = std::fs::read_to_string(path)
-        .with_context(|| format!("failed to read {}", path.display()))?;
-    serde_json::from_str(&raw).with_context(|| format!("failed to parse {}", path.display()))
-}
-
 /// Resolve includes and return the combined included policy plus any warnings.
 ///
 /// Evaluates each include entry and merges their rules and sandboxes.
@@ -200,13 +191,6 @@ pub fn resolve_includes(
     }
 
     Ok((merged, warnings))
-}
-
-/// Write a [`PolicyManifest`] to disk as pretty-printed JSON.
-pub fn write_manifest(path: &Path, manifest: &PolicyManifest) -> Result<()> {
-    let json =
-        serde_json::to_string_pretty(manifest).context("failed to serialize policy manifest")?;
-    std::fs::write(path, json).with_context(|| format!("failed to write {}", path.display()))
 }
 
 /// Validate a policy file's metadata (existence, type, size, permissions).
@@ -527,28 +511,4 @@ policy("include", {"Read": allow()})
         }
     }
 
-    #[test]
-    fn manifest_roundtrip() {
-        let dir = tempfile::tempdir().unwrap();
-        let json_path = dir.path().join("policy.json");
-
-        let manifest = PolicyManifest {
-            includes: vec![crate::policy::match_tree::IncludeEntry {
-                path: "@clash//builtin.star".into(),
-            }],
-            policy: CompiledPolicy {
-                sandboxes: std::collections::HashMap::new(),
-                tree: vec![],
-                default_effect: crate::policy::Effect::Deny,
-                default_sandbox: None,
-                on_sandbox_violation: Default::default(),
-                harness_defaults: None,
-            },
-        };
-
-        write_manifest(&json_path, &manifest).unwrap();
-        let loaded = read_manifest(&json_path).unwrap();
-        assert_eq!(loaded.includes.len(), 1);
-        assert_eq!(loaded.includes[0].path, "@clash//builtin.star");
-    }
 }

--- a/clash/src/policy_loader.rs
+++ b/clash/src/policy_loader.rs
@@ -510,5 +510,4 @@ policy("include", {"Read": allow()})
             );
         }
     }
-
 }

--- a/clash/src/settings/discovery.rs
+++ b/clash/src/settings/discovery.rs
@@ -88,22 +88,25 @@ pub fn settings_dir() -> Result<PathBuf> {
 
 /// Returns the user-level policy file path.
 ///
-/// Respects `CLASH_POLICY_FILE` env var for override.
-/// Prefers `policy.json` over `policy.star` when both exist.
+/// Respects `CLASH_POLICY_FILE` env var for override. Returns the path to
+/// `policy.star` (the only supported format). If a legacy `policy.json` is
+/// present without a sibling `policy.star`, returns an error directing the
+/// user to `clash policy migrate`.
 pub fn policy_file() -> Result<PathBuf> {
     if let Ok(p) = std::env::var("CLASH_POLICY_FILE") {
         return Ok(PathBuf::from(p));
     }
     let dir = settings_dir()?;
-    Ok(prefer_json_over_star(&dir))
+    discover_star_in(&dir)
 }
 
 /// Returns the project-level policy file path.
 ///
-/// Prefers `policy.json` over `policy.star` when both exist.
-pub fn project_policy_file(project_root: &std::path::Path) -> PathBuf {
+/// Returns the path to `policy.star`. If only a legacy `policy.json` exists,
+/// returns an error directing the user to `clash policy migrate`.
+pub fn project_policy_file(project_root: &std::path::Path) -> Result<PathBuf> {
     let dir = project_root.join(".clash");
-    prefer_json_over_star(&dir)
+    discover_star_in(&dir)
 }
 
 /// Returns the session-level policy file path for the given session ID.
@@ -111,14 +114,21 @@ pub fn session_policy_file(session_id: &str) -> PathBuf {
     crate::session_dir::SessionDir::new(session_id).policy()
 }
 
-/// Return `policy.json` if it exists in `dir`, otherwise `policy.star`.
-pub(crate) fn prefer_json_over_star(dir: &std::path::Path) -> PathBuf {
+/// Return `policy.star` in `dir` (whether or not it exists). If `policy.star`
+/// is absent but a legacy `policy.json` is present, return an error directing
+/// the user to `clash policy migrate`.
+pub(crate) fn discover_star_in(dir: &std::path::Path) -> Result<PathBuf> {
+    let star_path = dir.join("policy.star");
+    if star_path.exists() {
+        return Ok(star_path);
+    }
     let json_path = dir.join("policy.json");
     if json_path.exists() {
-        json_path
-    } else {
-        dir.join("policy.star")
+        return Err(crate::policy_loader::legacy_json_error(&json_path));
     }
+    // Neither exists — return the `.star` path so callers can report
+    // "not found" against the canonical name.
+    Ok(star_path)
 }
 
 /// Shorten a path by replacing the home directory prefix with `~`.
@@ -164,11 +174,10 @@ pub fn evaluate_star_policy(path: &std::path::Path) -> Result<String> {
     crate::policy_loader::evaluate_star_policy(path).map(|o| o.json)
 }
 
-/// Evaluate a policy file (`.json` or `.star`) and return the compiled JSON source.
+/// Evaluate a policy file and return the compiled JSON source.
 ///
-/// Dispatches based on file extension: `.star` (or anything else) →
-/// [`policy_loader::evaluate_star_policy`]. Legacy `.json` files are rejected
-/// with a friendly error directing the user to `clash policy migrate`.
+/// Only `.star` files are accepted. Legacy `.json` files are rejected with a
+/// friendly error directing the user to `clash policy migrate`.
 pub fn evaluate_policy_file(path: &std::path::Path) -> Result<String> {
     if path.extension().is_some_and(|ext| ext == "json") {
         Err(crate::policy_loader::legacy_json_error(path))
@@ -257,6 +266,27 @@ mod test {
             compile_default_policy_to_json_with_preset(preset.name)?;
         }
         Ok(())
+    }
+
+    #[test]
+    fn discovery_ignores_policy_json() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(tmp.path().join("policy.json"), "{}").unwrap();
+        std::fs::write(tmp.path().join("policy.star"), "# star").unwrap();
+        let path = discover_star_in(tmp.path()).expect("should succeed");
+        assert_eq!(path, tmp.path().join("policy.star"));
+    }
+
+    #[test]
+    fn discovery_errors_on_lone_policy_json() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(tmp.path().join("policy.json"), "{}").unwrap();
+        let err = discover_star_in(tmp.path()).expect_err("should error");
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("policy migrate"),
+            "expected error mentioning `policy migrate`, got: {msg}"
+        );
     }
 
     #[test]

--- a/clash/src/settings/discovery.rs
+++ b/clash/src/settings/discovery.rs
@@ -166,11 +166,12 @@ pub fn evaluate_star_policy(path: &std::path::Path) -> Result<String> {
 
 /// Evaluate a policy file (`.json` or `.star`) and return the compiled JSON source.
 ///
-/// Dispatches based on file extension: `.json` → [`policy_loader::load_json_policy`],
-/// `.star` (or anything else) → [`policy_loader::evaluate_star_policy`].
+/// Dispatches based on file extension: `.star` (or anything else) →
+/// [`policy_loader::evaluate_star_policy`]. Legacy `.json` files are rejected
+/// with a friendly error directing the user to `clash policy migrate`.
 pub fn evaluate_policy_file(path: &std::path::Path) -> Result<String> {
     if path.extension().is_some_and(|ext| ext == "json") {
-        crate::policy_loader::load_json_policy(path)
+        Err(crate::policy_loader::legacy_json_error(path))
     } else {
         crate::policy_loader::evaluate_star_policy(path).map(|o| o.json)
     }

--- a/clash/src/settings/loader.rs
+++ b/clash/src/settings/loader.rs
@@ -10,9 +10,8 @@ use crate::policy::match_tree::CompiledPolicy;
 use crate::policy_loader;
 
 use super::discovery::{
-    self, PolicyLevel, compile_default_policy_to_json, find_ancestor_with, parse_audit_config,
-    discover_star_in, parse_notification_config, session_policy_file, settings_dir,
-    tilde_path,
+    self, PolicyLevel, compile_default_policy_to_json, discover_star_in, find_ancestor_with,
+    parse_audit_config, parse_notification_config, session_policy_file, settings_dir, tilde_path,
 };
 use super::{ClashSettings, HookContext, LoadedPolicy};
 

--- a/clash/src/settings/loader.rs
+++ b/clash/src/settings/loader.rs
@@ -10,8 +10,8 @@ use crate::policy::match_tree::CompiledPolicy;
 use crate::policy_loader;
 
 use super::discovery::{
-    self, PolicyLevel, compile_default_policy_to_json, discover_star_in, find_ancestor_with,
-    parse_audit_config, parse_notification_config, session_policy_file, settings_dir, tilde_path,
+    self, PolicyLevel, discover_star_in, find_ancestor_with, parse_audit_config,
+    parse_notification_config, session_policy_file, settings_dir, tilde_path,
 };
 use super::{ClashSettings, HookContext, LoadedPolicy};
 
@@ -198,18 +198,17 @@ impl ClashSettings {
 
     /// Write the compiled default policy JSON to `path` if no policy exists.
     ///
-    /// The path passed in may point to `policy.star` (from `discover_star_in`
-    /// when no file exists yet). We always write `policy.json` instead, compiling
-    /// the embedded Starlark source to JSON at runtime.
+    /// The path passed in points to `policy.star` (from `discover_star_in`
+    /// when no file exists yet). The embedded `default_policy.star` source is
+    /// written verbatim — no JSON compilation step.
     fn ensure_policy_at(path: PathBuf) -> Result<Option<PathBuf>> {
         if path.exists() {
             return Ok(None);
         }
 
-        // Always write the compiled JSON variant, even if `path` ends in `.star`.
-        let json_path = path.with_extension("json");
+        let star_path = path.with_extension("star");
 
-        if let Some(parent) = json_path.parent() {
+        if let Some(parent) = star_path.parent() {
             std::fs::create_dir_all(parent)
                 .with_context(|| format!("failed to create directory {}", parent.display()))?;
 
@@ -221,21 +220,20 @@ impl ClashSettings {
             }
         }
 
-        let json = compile_default_policy_to_json()
-            .context("compiling embedded default policy (std.star) to JSON")?;
-        std::fs::write(&json_path, &json).with_context(|| {
-            format!("failed to write default policy to {}", json_path.display())
+        let source = include_str!("../default_policy.star");
+        std::fs::write(&star_path, source).with_context(|| {
+            format!("failed to write default policy to {}", star_path.display())
         })?;
 
         // Restrict file permissions on unix (owner-only read/write).
         #[cfg(unix)]
         {
             use std::os::unix::fs::PermissionsExt;
-            let _ = std::fs::set_permissions(&json_path, std::fs::Permissions::from_mode(0o600));
+            let _ = std::fs::set_permissions(&star_path, std::fs::Permissions::from_mode(0o600));
         }
 
-        info!(path = %json_path.display(), "Created default user policy");
-        Ok(Some(json_path))
+        info!(path = %star_path.display(), "Created default user policy");
+        Ok(Some(star_path))
     }
 
     /// Return the policy parse/compile error, if any.
@@ -549,23 +547,19 @@ mod test {
     }
 
     #[test]
-    fn ensure_policy_creates_json_file_when_missing() {
+    fn ensure_policy_creates_star_file_when_missing() {
         let dir = tempfile::tempdir().unwrap();
-        // Pass a .star path — ensure_policy_at should write .json instead.
         let star_path = dir.path().join(".clash").join("policy.star");
-        let json_path = dir.path().join(".clash").join("policy.json");
 
-        let result = ClashSettings::ensure_policy_at(star_path).unwrap();
+        let result = ClashSettings::ensure_policy_at(star_path.clone()).unwrap();
         assert!(result.is_some(), "should have created the file");
-        assert_eq!(result.unwrap(), json_path);
-        assert!(json_path.exists(), "policy.json should exist on disk");
+        assert_eq!(result.unwrap(), star_path);
+        assert!(star_path.exists(), "policy.star should exist on disk");
 
-        let contents = std::fs::read_to_string(&json_path).unwrap();
-        let parsed: serde_json::Value =
-            serde_json::from_str(&contents).expect("written file should be valid JSON");
+        let contents = std::fs::read_to_string(&star_path).unwrap();
         assert!(
-            parsed.get("tree").is_some(),
-            "JSON should contain a tree field"
+            contents.contains("policy("),
+            "default policy.star should contain a policy() call:\n{contents}"
         );
     }
 
@@ -594,10 +588,9 @@ mod test {
 
         let dir = tempfile::tempdir().unwrap();
         let star_path = dir.path().join(".clash").join("policy.star");
-        let json_path = dir.path().join(".clash").join("policy.json");
 
-        ClashSettings::ensure_policy_at(star_path).unwrap();
-        let mode = std::fs::metadata(&json_path).unwrap().permissions().mode() & 0o777;
+        ClashSettings::ensure_policy_at(star_path.clone()).unwrap();
+        let mode = std::fs::metadata(&star_path).unwrap().permissions().mode() & 0o777;
         assert_eq!(mode, 0o600, "policy file should be owner-only read/write");
     }
 

--- a/clash/src/settings/loader.rs
+++ b/clash/src/settings/loader.rs
@@ -11,7 +11,7 @@ use crate::policy_loader;
 
 use super::discovery::{
     self, PolicyLevel, compile_default_policy_to_json, find_ancestor_with, parse_audit_config,
-    parse_notification_config, prefer_json_over_star, session_policy_file, settings_dir,
+    discover_star_in, parse_notification_config, session_policy_file, settings_dir,
     tilde_path,
 };
 use super::{ClashSettings, HookContext, LoadedPolicy};
@@ -27,22 +27,23 @@ impl ClashSettings {
     /// Returns the user-level policy file path.
     ///
     /// Respects `CLASH_POLICY_FILE` env var for override.
-    /// Prefers `policy.json` over `policy.star` when both exist.
+    /// Returns the path to `policy.star`. Errors if a legacy `policy.json`
+    /// is present without a sibling `.star` (use `clash policy migrate`).
     pub fn policy_file() -> Result<PathBuf> {
         discovery::policy_file()
     }
 
     /// Returns the policy file path for a specific level.
     ///
-    /// Prefers `policy.json` over `policy.star` when both exist.
-    /// For `Session`, reads the active session ID from `~/.clash/active_session`.
+    /// Returns the path to `policy.star`. For `Session`, reads the active
+    /// session ID from `~/.clash/active_session`.
     pub fn policy_file_for_level(level: PolicyLevel) -> Result<PathBuf> {
         match level {
             PolicyLevel::User => Self::policy_file(),
             PolicyLevel::Project => {
                 let root = Self::project_root()?;
                 let dir = root.join(".clash");
-                Ok(prefer_json_over_star(&dir))
+                discover_star_in(&dir)
             }
             PolicyLevel::Session => {
                 let session_id = Self::active_session_id()?;
@@ -191,14 +192,14 @@ impl ClashSettings {
     /// The created file uses the embedded `DEFAULT_POLICY` (deny-all with read access to CWD).
     pub fn ensure_user_policy_exists() -> Result<Option<PathBuf>> {
         let path = Self::policy_file().context(
-            "resolving user policy file path (~/.clash/policy.json or CLASH_POLICY_FILE)",
+            "resolving user policy file path (~/.clash/policy.star or CLASH_POLICY_FILE)",
         )?;
         Self::ensure_policy_at(path)
     }
 
     /// Write the compiled default policy JSON to `path` if no policy exists.
     ///
-    /// The path passed in may point to `policy.star` (from `prefer_json_over_star`
+    /// The path passed in may point to `policy.star` (from `discover_star_in`
     /// when no file exists yet). We always write `policy.json` instead, compiling
     /// the embedded Starlark source to JSON at runtime.
     fn ensure_policy_at(path: PathBuf) -> Result<Option<PathBuf>> {

--- a/clash/src/tui/app.rs
+++ b/clash/src/tui/app.rs
@@ -685,9 +685,7 @@ impl App {
                         let save_result = if let Some(ref mut doc) = self.star_doc {
                             doc.save()
                         } else {
-                            Err(anyhow::anyhow!(
-                                "TUI save requires a `.star` document"
-                            ))
+                            Err(anyhow::anyhow!("TUI save requires a `.star` document"))
                         };
                         match save_result {
                             Ok(()) => {

--- a/clash/src/tui/app.rs
+++ b/clash/src/tui/app.rs
@@ -685,7 +685,9 @@ impl App {
                         let save_result = if let Some(ref mut doc) = self.star_doc {
                             doc.save()
                         } else {
-                            policy_loader::write_manifest(&self.path, &self.manifest)
+                            Err(anyhow::anyhow!(
+                                "TUI save requires a `.star` document"
+                            ))
                         };
                         match save_result {
                             Ok(()) => {

--- a/clash/src/tui/mod.rs
+++ b/clash/src/tui/mod.rs
@@ -77,8 +77,8 @@ pub fn run_with_options(
         ));
     }
 
-    let doc = StarDocument::open(path)
-        .with_context(|| format!("failed to parse {}", path.display()))?;
+    let doc =
+        StarDocument::open(path).with_context(|| format!("failed to parse {}", path.display()))?;
     let mut app = app::App::new_star(doc)?;
     if show_test_panel {
         app.show_test_panel();

--- a/clash/src/tui/mod.rs
+++ b/clash/src/tui/mod.rs
@@ -1,6 +1,6 @@
 //! Interactive policy editor TUI.
 //!
-//! Launches a ratatui-based terminal UI for browsing and editing policy.json.
+//! Launches a ratatui-based terminal UI for browsing and editing policy.star.
 //! Uses the Elm Architecture (TEA) pattern: `Model -> update(Msg) -> view(Model)`.
 
 pub mod app;
@@ -18,7 +18,7 @@ pub mod widgets;
 
 use std::path::Path;
 
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, anyhow};
 use crossterm::cursor::Show;
 use crossterm::event::{DisableMouseCapture, EnableMouseCapture};
 use crossterm::execute;
@@ -30,7 +30,7 @@ use ratatui::backend::CrosstermBackend;
 
 use clash_starlark::codegen::StarDocument;
 
-use crate::policy_loader;
+use crate::policy_loader::legacy_json_error;
 
 /// Outcome of running the TUI.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -67,16 +67,19 @@ pub fn run_with_options(
     onboarding: bool,
 ) -> Result<TuiOutcome> {
     let is_star = path.extension().is_some_and(|ext| ext == "star");
+    if !is_star {
+        if path.file_name().and_then(|n| n.to_str()) == Some("policy.json") {
+            return Err(anyhow!(legacy_json_error(path)));
+        }
+        return Err(anyhow!(
+            "TUI only supports `.star` policies; got `{}`",
+            path.display()
+        ));
+    }
 
-    let mut app = if is_star {
-        let doc = StarDocument::open(path)
-            .with_context(|| format!("failed to parse {}", path.display()))?;
-        app::App::new_star(doc)?
-    } else {
-        let manifest = policy_loader::read_manifest(path)
-            .with_context(|| format!("failed to read {}", path.display()))?;
-        app::App::new(path.to_path_buf(), manifest)?
-    };
+    let doc = StarDocument::open(path)
+        .with_context(|| format!("failed to parse {}", path.display()))?;
+    let mut app = app::App::new_star(doc)?;
     if show_test_panel {
         app.show_test_panel();
     }

--- a/docs/policy-guide.md
+++ b/docs/policy-guide.md
@@ -62,38 +62,23 @@ The Starlark policy above compiles to the following JSON intermediate representa
 
 | Path | Scope |
 |------|-------|
-| `~/.clash/policy.json` | User-level (machine-readable, preferred) |
-| `~/.clash/policy.star` | User-level (Starlark, for power users) |
-| `<project>/.clash/policy.json` | Project-level (machine-readable, preferred) |
-| `<project>/.clash/policy.star` | Project-level (Starlark, for power users) |
+| `~/.clash/policy.star` | User-level |
+| `<project>/.clash/policy.star` | Project-level |
 
-JSON (`.json`) is the preferred format. If both `.json` and `.star` exist at the same level, the `.json` file takes precedence. Clash reads the policy on every hook invocation, so changes take effect immediately.
+Policy files use the `.star` extension. Clash reads the policy on every hook invocation, so changes take effect immediately.
 
-CLI commands like `clash policy allow`, `clash policy deny`, and `clash policy remove` operate on `policy.json` files. If only a `policy.star` exists, these commands will auto-create a `policy.json` that includes the existing `.star` file.
+CLI commands like `clash policy allow`, `clash policy deny`, and `clash policy remove` operate on `policy.star` files.
 
-### policy.json Format
+### Migrating from `policy.json`
 
-The `policy.json` file extends the v5 compiled policy format with an `includes` field for referencing Starlark files:
+Earlier versions of clash supported a JSON-based `policy.json` format. To migrate an existing `policy.json` to Starlark, run:
 
-```json
-{
-  "schema_version": 5,
-  "default_effect": "deny",
-  "default_sandbox": "cwd",
-  "sandboxes": {},
-  "includes": [
-    { "path": "@clash//builtin.star" },
-    { "path": "team-rules.star" }
-  ],
-  "tree": []
-}
+```sh
+clash policy convert            # writes policy.star alongside policy.json
+clash policy convert --replace  # also removes the old policy.json
 ```
 
-- **`includes`** — References to `.star` files that are compiled and merged at load time. Use `@clash//` for stdlib modules or relative paths for local files.
-- **`tree`** — Inline rules managed by CLI commands. These take precedence over included rules.
-- **`sandboxes`** — Named sandbox definitions, also CLI-managed.
-
-Included `.star` files are evaluated and their rules are appended after the inline `tree` rules, so inline rules always have higher priority.
+The legacy JSON format is no longer loaded directly — `.star` is the only source format.
 
 ---
 

--- a/docs/superpowers/plans/2026-04-06-unify-policy-and-sandbox.md
+++ b/docs/superpowers/plans/2026-04-06-unify-policy-and-sandbox.md
@@ -1,0 +1,982 @@
+# Unify `policy()` / `sandbox()` and remove `policy.json` — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give `policy()` and `sandbox()` a unified `(name, tree, *, ...kwargs)` surface with typed-constructor root keys, and remove `policy.json` as a user-authored source format (migration path preserved).
+
+**Architecture:** Two independent change streams that share a worktree. **Stream A** reshapes the Starlark DSL: stdlib (`std.star`), Rust parser (`when.rs`, `globals.rs`), and examples. **Stream B** removes `policy.json` from discovery/loader/cmd/fmt/init/tui, updating tests and docs. `clash policy migrate` is updated to emit the new shape in both streams. Streams can be executed in parallel; only the migrate command and shared tests are a merge point.
+
+**Tech Stack:** Rust (clash, clash_starlark), Starlark (stdlib + examples), clester YAML scripts.
+
+**Reference spec:** `docs/superpowers/specs/2026-04-06-unify-policy-and-sandbox-design.md`
+
+---
+
+## File Structure
+
+### Stream A — DSL surface
+
+| File | Role |
+|---|---|
+| `clash_starlark/stdlib/std.star` | Rewrite `sandbox()`, `policy()`; add `tool()`, `default()`, update `path()`, `glob()`, `domain()`, `localhost()` to emit typed keys usable as dict keys; remove `fs=`/`net=` legacy paths |
+| `clash_starlark/src/globals.rs` | Update `_policy_impl` and add `_sandbox_impl` (if needed) to accept the new tree; keep arg surface thin |
+| `clash_starlark/src/when.rs` | Rewrite `policy_impl`/add `sandbox_tree_impl`: enforce typed-root-key rule; classify keys (`default`/`mode`/`tool`/`path`/`glob`/`domain`/`localhost`); produce emitted JSON IR |
+| `clash_starlark/src/builders/match_tree.rs` | (Read only; types used by new code) |
+| `clash/src/default_policy.star` | Rewrite default policy to new shape |
+| `examples/*.star` | Rewrite all examples to new shape |
+| `clash_starlark/tests/*` | Update existing tests; add new tests for typed-root-key rule and unified sandbox tree |
+
+### Stream B — `policy.json` removal
+
+| File | Role |
+|---|---|
+| `clash/src/settings/discovery.rs` | Drop `policy.json` lookup; `.star` only |
+| `clash/src/policy_loader.rs` | Delete JSON source branch (`load_json_policy` entry point). Move legacy JSON parsing behind a `pub(crate)` function reachable only from `cmd::policy::migrate` |
+| `clash/src/cmd/policy.rs` | `show`/`validate`/`check`/`allow`/`deny`/`remove`: `.star` only. `migrate`: the one call site for legacy JSON parsing |
+| `clash/src/cmd/fmt.rs` | Drop JSON formatting |
+| `clash/src/cmd/init.rs` | Scaffold `.star` only |
+| `clash/src/cmd/import_settings.rs` | Drop JSON output path |
+| `clash/src/tui/**` | Drop any `policy.json` edit affordance |
+| `clash/src/ecosystem.rs`, `shell_cmd.rs`, `audit.rs`, `cmd/session.rs` | Targeted sweep for JSON source handling |
+| `clash/src/test_utils.rs`, `clester/tests/scripts/**` | Migrate fixtures to `.star`; legacy-JSON tests move under migrate suite |
+| `README.md`, `docs/**`, `site/**`, `AGENTS.md` | Doc sweep: `.star` only |
+
+---
+
+## Pre-work
+
+- [ ] **Verify baseline:** run `just check` and `just clester`. If either fails on `main`, stop and surface the failure before making changes.
+
+---
+
+## Stream A — DSL surface
+
+### Task A1: stdlib — add `default()`, `tool()` constructors and port `path()`/`glob()`/`domain()`/`localhost()` to be usable as dict keys
+
+**Files:**
+- Modify: `clash_starlark/stdlib/std.star`
+- Test: `clash_starlark/tests/dsl_keys.rs` (new, thin — asserts constructors produce the expected `_match_key`/`_match_value` structure)
+
+The goal of this task is to land the typed-root-key *constructors* before touching `sandbox()`/`policy()`. After this task, all constructors return a struct of the form:
+
+```starlark
+struct(_match_key="<kind>", _match_value=<value>, _doc=<optional>)
+```
+
+where `<kind>` is one of `"default"`, `"mode"`, `"tool"`, `"path"`, `"glob"`, `"domain"`, `"localhost"`.
+
+- [ ] **Step 1: Write the failing test** (`clash_starlark/tests/dsl_keys.rs`):
+
+```rust
+use clash_starlark::load_starlark_source_for_test;
+
+#[test]
+fn typed_constructors_produce_match_keys() {
+    let out = load_starlark_source_for_test(r#"
+        result = [
+            default()._match_key,
+            tool("Bash")._match_key,
+            path("$PWD")._match_key,
+            glob("/tmp/**")._match_key,
+            domain("github.com")._match_key,
+            localhost()._match_key,
+            mode("plan")._match_key,
+        ]
+    "#).unwrap();
+    assert_eq!(
+        out.get_global_strings("result").unwrap(),
+        vec!["default", "tool", "path", "glob", "domain", "localhost", "mode"],
+    );
+}
+```
+
+If `load_starlark_source_for_test` / `get_global_strings` don't exist yet, add the minimal test harness helper under `clash_starlark/src/test_support.rs` and re-export it for tests. The helper: evaluates a source string against `clash_globals()` with a fresh `EvalContext`, returns a handle from which named globals can be read.
+
+- [ ] **Step 2: Run test — expect fail**
+
+Run: `cargo test -p clash_starlark typed_constructors_produce_match_keys`
+Expected: FAIL (`default`, `tool` undefined or wrong shape).
+
+- [ ] **Step 3: Edit `std.star`.** Apply these edits in order:
+
+  1. Add `default()` constructor:
+
+  ```starlark
+  def default(doc=None):
+      """Sentinel root key representing the fallback effect for a tree.
+
+      Usage:
+          policy("x", {default(): deny(), mode("plan"): allow()})
+      """
+      return struct(_match_key="default", _match_value=None, _doc=doc)
+  ```
+
+  2. Add `tool()` constructor (rename the capital-T `Tool` to lowercase; keep `Tool` as a thin alias that `fail()`s pointing to the new name):
+
+  ```starlark
+  def tool(name, doc=None):
+      """Tool selector root key (policy trees).
+
+      Usage:
+          policy("x", {mode("plan"): {tool("Bash"): {"git push": deny()}}})
+      """
+      return struct(_match_key="tool", _match_value=name, _doc=doc)
+
+  def Tool(name):
+      fail("Tool() has been renamed to tool(). See docs/superpowers/specs/2026-04-06-unify-policy-and-sandbox-design.md")
+  ```
+
+  3. Rewrite `path()` to return a typed key *instead of* a path_match builder. Move the existing builder-style `path()`/`cwd()`/`home()`/`tempdir()` *machinery* into a private `_legacy_path_match()` used only by the sandbox migration emitter. The public `path()` now returns:
+
+  ```starlark
+  def path(path_str, doc=None):
+      """Filesystem literal-path key.
+
+      Usage:
+          sandbox("x", {path("$PWD"): allow("rwc")})
+      """
+      if type(path_str) != "string":
+          fail("path() takes a string; got " + type(path_str))
+      return struct(_match_key="path", _match_value=path_str, _doc=doc)
+  ```
+
+  Note: `cwd()`, `home()`, `tempdir()` keep working but are deprecated — leave them returning the old builder structs for now so examples still parse until Task A3. They are removed in Task A6.
+
+  4. Rewrite `glob()` to return a typed key. Preserve the current glob-pattern validation:
+
+  ```starlark
+  def glob(pattern, doc=None):
+      """Filesystem glob-path key.
+
+      Usage:
+          sandbox("x", {glob("$HOME/**"): allow("r")})
+      """
+      if type(pattern) != "string":
+          fail("glob() takes a string; got " + type(pattern))
+      # Preserve existing suffix validation
+      if pattern not in ("*", "**") and not (
+          pattern.endswith("/*") or pattern.endswith("/**") or pattern.endswith("/**/*")
+      ):
+          fail("glob() pattern must end with /*, /**, or /**/* (got: " + pattern + ")")
+      return struct(_match_key="glob", _match_value=pattern, _doc=doc)
+  ```
+
+  5. Rewrite `domain()` (two-arg → one-arg; no effect in the constructor; effect is the dict value):
+
+  ```starlark
+  def domain(name, doc=None):
+      """Network domain key.
+
+      Usage:
+          sandbox("x", {domain("github.com"): allow()})
+      """
+      return struct(_match_key="domain", _match_value=name, _doc=doc)
+  ```
+
+  6. Rewrite `localhost()`:
+
+  ```starlark
+  def localhost(ports=None, doc=None):
+      """Localhost network key. Optionally restricted to specific ports.
+
+      Usage:
+          sandbox("x", {localhost(): allow(), localhost(ports=[8080]): allow()})
+      """
+      if ports != None:
+          for p in ports:
+              if type(p) != "int":
+                  fail("localhost() ports must be integers; got " + type(p))
+              if p < 1 or p > 65535:
+                  fail("localhost() port out of range (1-65535): " + str(p))
+      return struct(_match_key="localhost", _match_value=ports, _doc=doc)
+  ```
+
+- [ ] **Step 4: Run test — expect pass**
+
+Run: `cargo test -p clash_starlark typed_constructors_produce_match_keys`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add clash_starlark/stdlib/std.star clash_starlark/tests/dsl_keys.rs clash_starlark/src/test_support.rs
+git commit -m "feat(starlark): add typed root-key constructors (default, tool, path, glob, domain, localhost)"
+```
+
+---
+
+### Task A2: `when.rs` — classify typed root keys and reject bare strings
+
+**Files:**
+- Modify: `clash_starlark/src/when.rs:109-150` (`MatchKeyKind`, `classify_key`)
+- Test: `clash_starlark/tests/root_key_rule.rs` (new)
+
+Add the enforcement of the uniform root-key rule.
+
+- [ ] **Step 1: Write the failing test**:
+
+```rust
+use clash_starlark::eval_policy_source_for_test;
+
+#[test]
+fn bare_string_at_policy_root_is_rejected() {
+    let err = eval_policy_source_for_test(r#"
+        policy("x", {"Bash": allow()})
+    "#).unwrap_err();
+    let msg = format!("{err:#}");
+    assert!(
+        msg.contains("typed constructor"),
+        "expected typed-constructor error, got: {msg}"
+    );
+}
+
+#[test]
+fn typed_root_key_is_accepted() {
+    eval_policy_source_for_test(r#"
+        policy("x", {tool("Bash"): allow()})
+    "#).unwrap();
+}
+```
+
+Add `eval_policy_source_for_test` to `clash_starlark/src/test_support.rs` (evaluates source as a policy file with a fresh `EvalContext`, returns `anyhow::Result<EvalContext>`).
+
+- [ ] **Step 2: Run tests — expect fail**
+
+Run: `cargo test -p clash_starlark root_key_rule`
+Expected: both FAIL (first passes today by mistreating `"Bash"` as a tool name).
+
+- [ ] **Step 3: Modify `when.rs`.** Extend `MatchKeyKind` to cover all root kinds:
+
+```rust
+enum MatchKeyKind {
+    Default { doc: Option<String> },
+    Mode { pattern: JsonValue, doc: Option<String> },
+    Tool { pattern: JsonValue, doc: Option<String> },
+    Path { value: JsonValue, doc: Option<String> },
+    Glob { value: JsonValue, doc: Option<String> },
+    Domain { value: JsonValue, doc: Option<String> },
+    Localhost { ports: JsonValue, doc: Option<String> },
+}
+```
+
+Rewrite `classify_key` to **require** a `_match_key` struct for root keys:
+
+```rust
+fn classify_root_key<'v>(key: Value<'v>, heap: &'v Heap) -> anyhow::Result<MatchKeyKind> {
+    if key.get_type() == "struct" {
+        if let Ok(Some(mk_val)) = key.get_attr("_match_key", heap) {
+            if let Some(mk) = mk_val.unpack_str() {
+                let mv = key.get_attr("_match_value", heap).ok().flatten()
+                    .context("match key struct missing _match_value")?;
+                let doc = key.get_attr("_doc", heap).ok().flatten()
+                    .filter(|v| !v.is_none())
+                    .and_then(|v| v.unpack_str().map(|s| s.to_string()));
+                return match mk {
+                    "default" => Ok(MatchKeyKind::Default { doc }),
+                    "mode" => Ok(MatchKeyKind::Mode { pattern: pattern_to_json(mv, heap)?, doc }),
+                    "tool" => Ok(MatchKeyKind::Tool { pattern: pattern_to_json(mv, heap)?, doc }),
+                    "path" => Ok(MatchKeyKind::Path { value: pattern_to_json(mv, heap)?, doc }),
+                    "glob" => Ok(MatchKeyKind::Glob { value: pattern_to_json(mv, heap)?, doc }),
+                    "domain" => Ok(MatchKeyKind::Domain { value: pattern_to_json(mv, heap)?, doc }),
+                    "localhost" => Ok(MatchKeyKind::Localhost { ports: pattern_to_json(mv, heap)?, doc }),
+                    other => bail!("unknown match key type: {other}"),
+                };
+            }
+        }
+    }
+    bail!(
+        "Root keys in a policy or sandbox tree must use a typed constructor \
+         (default(), mode(), tool(), path(), glob(), domain(), localhost()). \
+         Got a bare {} key. If you meant a filesystem path, use path(\"...\"). \
+         If you meant a tool name, use tool(\"...\").",
+        key.get_type()
+    )
+}
+```
+
+Keep the old `classify_key` function under a new name `classify_nested_key` for use inside `build_arg_tree` (where bare strings *are* allowed as positional-arg matchers). The existing callsites in `build_tool_level` and `build_arg_tree` keep using the nested classifier.
+
+Adjust `process_policy_dict` to call `classify_root_key` instead of `classify_key`, and to handle the new variants. For now, `Path`/`Glob`/`Domain`/`Localhost`/`Default` variants in a policy-root context should `bail!("sandbox-only key {kind} used in policy root")` — they will be wired up for sandbox trees in Task A3.
+
+- [ ] **Step 4: Run tests — expect pass**
+
+Run: `cargo test -p clash_starlark root_key_rule`
+Expected: PASS.
+
+- [ ] **Step 5: Run the whole `clash_starlark` suite**
+
+Run: `cargo test -p clash_starlark`
+Expected: PASS (there will be compile errors in `stdlib/std.star`-consuming tests if any stdlib example used a bare-string root key — fix them to use `tool("...")` as you find them).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add clash_starlark/src/when.rs clash_starlark/tests/root_key_rule.rs clash_starlark/src/test_support.rs
+git commit -m "feat(starlark): enforce typed root-key rule in policy/sandbox trees"
+```
+
+---
+
+### Task A3: `when.rs` — implement `sandbox_tree_impl` for the unified sandbox tree
+
+**Files:**
+- Modify: `clash_starlark/src/when.rs` (add `pub fn sandbox_tree_impl`)
+- Modify: `clash_starlark/src/globals.rs` (add `_sandbox_impl` global + wire registration)
+- Modify: `clash_starlark/src/eval_context.rs` (add `SandboxRegistration` + `register_sandbox` if not already present in a usable form)
+- Test: `clash_starlark/tests/sandbox_tree.rs` (new)
+
+After this task, calling `_sandbox_impl("name", {path("$PWD"): allow("rwc"), domain("github.com"): allow()})` produces a JSON sandbox value structurally identical to what `sandbox_to_json` produces today from the builder-based struct.
+
+- [ ] **Step 1: Write the failing test**:
+
+```rust
+use clash_starlark::eval_policy_source_for_test;
+
+#[test]
+fn sandbox_tree_fs_and_net_round_trip() {
+    let ctx = eval_policy_source_for_test(r#"
+        sandbox("rust-dev", {
+            default(): deny(),
+            path("$PWD"): allow("rwc"),
+            glob("/tmp/**"): allow("rwc"),
+            domain("crates.io"): allow(),
+            localhost(): allow(),
+        })
+    "#).unwrap();
+    let sb = ctx.sandboxes().get("rust-dev").expect("sandbox registered");
+    // Structural assertions:
+    assert_eq!(sb["default"], serde_json::json!("deny"));
+    let rules = sb["rules"].as_array().unwrap();
+    assert!(rules.iter().any(|r| r["path_value"] == "$PWD" && r["effect"] == "allow"));
+    assert!(rules.iter().any(|r| r["path_value"] == "/tmp/**" && r["effect"] == "allow"));
+    assert_eq!(sb["net"]["domains"][0], serde_json::json!("crates.io"));
+    assert_eq!(sb["net"]["localhost"], serde_json::json!(true));
+}
+```
+
+Use whatever snake-case keys `sandbox_to_json` currently emits. If the names don't match the above, update the test to match — the point is structural round-trip, not inventing a new wire format.
+
+- [ ] **Step 2: Run test — expect fail**
+
+Run: `cargo test -p clash_starlark sandbox_tree_fs_and_net_round_trip`
+Expected: FAIL (no `sandbox()` tree form yet).
+
+- [ ] **Step 3: Implement `sandbox_tree_impl` in `when.rs`.** Structure:
+
+```rust
+pub fn sandbox_tree_impl<'v>(
+    name: &str,
+    tree: Value<'v>,
+    default_effect_kwarg: &str,  // from `default=` kwarg in std.star wrapper
+    doc: Option<String>,
+    heap: &'v Heap,
+    source: Option<String>,
+) -> anyhow::Result<JsonValue> {
+    let dict = DictRef::from_value(tree)
+        .ok_or_else(|| anyhow::anyhow!("sandbox() tree must be a dict"))?;
+
+    let mut default_effect = default_effect_kwarg.to_string();
+    let mut fs_rules: Vec<JsonValue> = Vec::new();
+    let mut net_domains: Vec<String> = Vec::new();
+    let mut net_localhost_allow: Option<bool> = None;
+    let mut net_localhost_ports: Vec<i64> = Vec::new();
+    let mut net_effect: Option<String> = None;
+
+    for (key, value) in dict.iter() {
+        match classify_root_key(key, heap)? {
+            MatchKeyKind::Default { .. } => {
+                let eff = effect_to_string(value, heap)?;
+                default_effect = eff;
+            }
+            MatchKeyKind::Path { value: pv, doc } => {
+                fs_rules.push(fs_rule_from(value, pv, doc, "literal", heap)?);
+            }
+            MatchKeyKind::Glob { value: pv, doc } => {
+                fs_rules.push(fs_rule_from(value, pv, doc, "glob", heap)?);
+            }
+            MatchKeyKind::Domain { value: dv, .. } => {
+                let name = dv.as_str().context("domain() value must be a string")?.to_string();
+                // Value is the effect — today we only track the domain name in the IR,
+                // matching legacy behavior; a deny at domain level is expressed via default.
+                let _eff = effect_to_string(value, heap)?;
+                net_domains.push(name);
+            }
+            MatchKeyKind::Localhost { ports, .. } => {
+                let eff = effect_to_string(value, heap)?;
+                if eff == "allow" {
+                    net_localhost_allow = Some(true);
+                }
+                if let Some(arr) = ports.as_array() {
+                    for p in arr {
+                        if let Some(n) = p.as_i64() { net_localhost_ports.push(n); }
+                    }
+                }
+            }
+            MatchKeyKind::Mode { .. } | MatchKeyKind::Tool { .. } => {
+                bail!("mode()/tool() are policy-only keys; not allowed in a sandbox tree")
+            }
+        }
+    }
+
+    // Add the system rules (root read, /Users|/home deny) that sandbox() in std.star used to inject.
+    append_system_rules(&mut fs_rules);
+
+    Ok(assemble_sandbox_json(
+        name,
+        &default_effect,
+        fs_rules,
+        net_effect,
+        net_domains,
+        net_localhost_allow,
+        net_localhost_ports,
+        doc,
+    ))
+}
+```
+
+Implement `fs_rule_from`, `effect_to_string`, `append_system_rules`, and `assemble_sandbox_json` as private helpers. `assemble_sandbox_json` should produce the *same* JSON shape that `sandbox_to_json` produces today (read `sandbox_to_json` at `clash_starlark/src/when.rs:364` and mirror its output). The cleanest approach: refactor `sandbox_to_json` to call a shared private `build_sandbox_json(name, default, rules, net, doc) -> JsonValue`, and have both `sandbox_to_json` (legacy struct path) and `sandbox_tree_impl` (new dict path) feed it.
+
+- [ ] **Step 4: Register `_sandbox_impl` global.** In `clash_starlark/src/globals.rs`, under the `#[starlark_module] register_globals`:
+
+```rust
+fn _sandbox_impl<'v>(
+    #[starlark(require = pos)] name: &str,
+    #[starlark(require = pos)] tree: Value<'v>,
+    #[starlark(require = named, default = "deny")] default: &str,
+    #[starlark(require = named, default = starlark::values::none::NoneType)] doc: Value<'v>,
+    eval: &mut Evaluator<'v, '_, '_>,
+) -> anyhow::Result<NoneType> {
+    let heap = eval.heap();
+    let ctx = eval.extra.and_then(|e| e.downcast_ref::<EvalContext>())
+        .ok_or_else(|| anyhow::anyhow!("sandbox() can only be called in a policy file"))?;
+    let doc_str = doc.unpack_str().map(|s| s.to_string());
+    let source = caller_source_location(eval);
+    let sb_json = crate::when::sandbox_tree_impl(name, tree, default, doc_str, heap, source)?;
+    ctx.register_sandbox(name, sb_json)?;
+    Ok(NoneType)
+}
+```
+
+If `EvalContext::register_sandbox` doesn't exist, add it in `clash_starlark/src/eval_context.rs`: append to an internal `sandboxes: RefCell<BTreeMap<String, JsonValue>>`, bailing on duplicate names.
+
+- [ ] **Step 5: Wire `sandbox()` in `std.star`** to the new impl (this is the final signature change):
+
+```starlark
+def sandbox(name, tree, default="deny", doc=None):
+    """Register a sandbox from a decision-tree dict.
+
+    Usage:
+        sandbox("rust-dev", {
+            default(): deny(),
+            path("$PWD"): allow("rwc"),
+            domain("crates.io"): allow(),
+        }, doc="Build and test Rust projects.")
+    """
+    if type(name) != "string":
+        fail("sandbox() name must be a string")
+    if type(tree) != "dict":
+        fail("sandbox() tree must be a dict")
+    _sandbox_impl(name, tree, default=_unwrap_effect(default), doc=doc)
+```
+
+Delete the legacy `_make_sandbox` / builder-based `sandbox()` body and the `fs=`/`net=` kwarg branches. Keep `cwd()`, `home()`, `tempdir()`, `_path_match` **deleted** — they are replaced by `path()`. If any stdlib code still references them, fix it now; they're removed in this task.
+
+Add a helpful error shim for `fs=`/`net=`:
+
+```starlark
+# Friendly error for legacy calls
+def _legacy_sandbox_error(**kwargs):
+    fail("sandbox() no longer accepts fs= or net= kwargs. It now takes a single " +
+         "decision-tree dict: sandbox(\"name\", {path(\"$PWD\"): allow(\"rwc\"), " +
+         "domain(\"github.com\"): allow()}). Run `clash policy migrate` to convert.")
+```
+
+and detect legacy positional/kwarg shapes inside `sandbox()` before calling `_sandbox_impl`.
+
+- [ ] **Step 6: Run test — expect pass**
+
+Run: `cargo test -p clash_starlark sandbox_tree_fs_and_net_round_trip`
+Expected: PASS.
+
+- [ ] **Step 7: Run full `clash_starlark` suite**
+
+Run: `cargo test -p clash_starlark`
+Expected: PASS. If failures, they will be in tests/examples that used `fs=`/`net=` or bare string keys — fix those callsites inline to the new form as part of this task. Do **not** skip or weaken tests.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add clash_starlark/
+git commit -m "feat(starlark): unified sandbox() tree API with typed constructors"
+```
+
+---
+
+### Task A4: `when.rs` — wire `default()` into policy trees and accept unified signature
+
+**Files:**
+- Modify: `clash_starlark/src/when.rs` (`policy_impl`, `process_policy_dict`)
+- Modify: `clash_starlark/stdlib/std.star` (`policy()` wrapper)
+- Modify: `clash_starlark/src/globals.rs` (`_policy_impl` signature)
+- Test: `clash_starlark/tests/policy_tree.rs` (new)
+
+- [ ] **Step 1: Write the failing test**:
+
+```rust
+use clash_starlark::eval_policy_source_for_test;
+
+#[test]
+fn policy_default_key_sets_fallback() {
+    let ctx = eval_policy_source_for_test(r#"
+        policy("x", {
+            default(): deny(),
+            mode("plan"): allow(),
+            tool("Bash"): {"git push": deny()},
+        })
+    "#).unwrap();
+    let pol = ctx.policies().get("x").unwrap();
+    assert_eq!(pol["default_effect"], serde_json::json!("deny"));
+    // Tree has 2 non-default root nodes (mode + tool)
+    assert_eq!(pol["tree_nodes"].as_array().unwrap().len(), 2);
+}
+```
+
+Use whatever field names `PolicyRegistration` actually emits; adjust the test to match.
+
+- [ ] **Step 2: Run test — expect fail**
+
+Run: `cargo test -p clash_starlark policy_default_key_sets_fallback`
+Expected: FAIL.
+
+- [ ] **Step 3: Modify `process_policy_dict`** to handle `MatchKeyKind::Default` (sets a local `default_effect` override) and `MatchKeyKind::Tool` / `MatchKeyKind::Mode` (existing behavior). Reject `Path`/`Glob`/`Domain`/`Localhost` at policy root with a clear message.
+
+Change `policy_impl`'s return to `(default_effect, flat_nodes, sandboxes)` and propagate to `PolicyRegistration`. If `PolicyRegistration` lacks `default_effect`, add it.
+
+- [ ] **Step 4: Update `_policy_impl` global signature** in `globals.rs` to the unified shape:
+
+```rust
+fn _policy_impl<'v>(
+    #[starlark(require = pos)] name: &str,
+    #[starlark(require = pos)] tree: Value<'v>,
+    #[starlark(require = named, default = "deny")] default: &str,
+    #[starlark(require = named, default = starlark::values::none::NoneType)] default_sandbox: Value<'v>,
+    #[starlark(require = named, default = starlark::values::none::NoneType)] doc: Value<'v>,
+    eval: &mut Evaluator<'v, '_, '_>,
+) -> anyhow::Result<NoneType> { /* ... */ }
+```
+
+Keep the dict-only enforcement (current `clash_starlark/src/globals.rs:250-256`). Remove the "when()/rules= syntax" error text — replace with a pointer to the new shape.
+
+- [ ] **Step 5: Update `policy()` in `std.star`** to the final signature:
+
+```starlark
+def policy(name, tree, default="deny", default_sandbox=None, doc=None):
+    """Register a named policy from a decision-tree dict.
+
+    Usage:
+        policy("default", {
+            default(): deny(sandbox=plan_box),
+            mode("plan"): allow(sandbox=plan_box),
+            tool("Bash"): {"git push": deny()},
+        })
+    """
+    if type(name) != "string":
+        fail("policy() name must be a string")
+    if type(tree) != "dict":
+        fail("policy() tree must be a dict. Run `clash policy migrate` to convert legacy files.")
+    _policy_impl(name, tree, default=_unwrap_effect(default), default_sandbox=default_sandbox, doc=doc)
+```
+
+- [ ] **Step 6: Run test — expect pass**
+
+Run: `cargo test -p clash_starlark policy_default_key_sets_fallback`
+Expected: PASS.
+
+- [ ] **Step 7: Run full suite**
+
+Run: `cargo test -p clash_starlark && cargo test -p clash`
+Expected: PASS. Fix fallout in `clash/src/default_policy.star` (Task A5) as needed to get this green — but that should mostly land in the next task.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add clash_starlark/
+git commit -m "feat(starlark): unify policy() signature with default() root key"
+```
+
+---
+
+### Task A5: Rewrite `default_policy.star` and `examples/*.star` to the new shape
+
+**Files:**
+- Modify: `clash/src/default_policy.star`
+- Modify: `examples/paranoid.star`, `examples/rust-dev.star`, `examples/git-ssh-protected.star`, `examples/python-dev.star`, `examples/read-only-repo.star`, `examples/permissive.star`, `examples/node-dev.star`, `examples/curl-localhost-only.star`
+
+- [ ] **Step 1: Rewrite each file.** For each example: read the existing file, convert each `sandbox(...)`/`policy(...)` call to the new shape. The transformation is mechanical:
+
+  - `sandbox("x", default=deny(), fs={...}, net=allow())` →
+    ```starlark
+    sandbox("x", {
+        default(): deny(),
+        # each fs entry becomes path(...) or glob(...)
+        path("$PWD"): allow("rwc"),
+        # net=allow() becomes an explicit net key, or omit if default is allow
+        domain("..."): allow(),   # per domain
+    }, doc="...")
+    ```
+  - `policy("x", {"Bash": ...})` → `policy("x", {tool("Bash"): ...})`
+  - Every call site gets a meaningful `doc=`.
+
+Work one file at a time. After each file, run `cargo test -p clash_starlark` to keep the feedback loop tight.
+
+- [ ] **Step 2: Verify** the default policy loads:
+
+Run: `cargo test -p clash default_policy`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add clash/src/default_policy.star examples/
+git commit -m "refactor(examples): migrate examples and default policy to unified tree shape"
+```
+
+---
+
+### Task A6: Remove `cwd()`, `home()`, `tempdir()`, legacy `domains()`, legacy `_path_match` from stdlib
+
+**Files:**
+- Modify: `clash_starlark/stdlib/std.star`
+
+These are now unreachable from in-tree code (`default_policy.star` and examples were migrated in Task A5). Delete them.
+
+- [ ] **Step 1: Delete** `cwd()`, `home()`, `tempdir()`, `path()` *builder variant*, `_path_match`, `domains()` (the legacy plural dict form), and any dead helpers (`_process_fs_dict`, `_resolve_path_value` etc.) now unused. Keep `path()` as the typed key constructor added in Task A1.
+
+- [ ] **Step 2: Run full suite**
+
+Run: `cargo test -p clash_starlark && cargo test -p clash`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add clash_starlark/stdlib/std.star
+git commit -m "refactor(starlark): remove legacy path/sandbox builders"
+```
+
+---
+
+## Stream B — `policy.json` removal
+
+### Task B1: Fence off legacy JSON parsing behind `migrate` only
+
+**Files:**
+- Modify: `clash/src/policy_loader.rs` — rename `load_json_policy` → `migrate_load_json_policy`, mark `pub(crate)`, document "only call from `cmd::policy::migrate`".
+- Modify: `clash/src/cmd/policy.rs` — update migrate to call the new name.
+- Test: `clash/src/policy_loader.rs` — update existing JSON-loading tests to live under `mod migrate_tests` with an explicit `#[cfg(test)]` note.
+
+- [ ] **Step 1: Rename and gate.** Grep for all callers of `load_json_policy`:
+
+  Run: `rg -n 'load_json_policy' clash/`
+
+  For each caller outside `cmd::policy::migrate`, replace the call with an error: if a `.json` file is discovered at load time, emit:
+
+  > Legacy `policy.json` detected at `<path>`. Run `clash policy migrate` to convert to `.star` (the only supported format).
+
+  Plumb through a clean `anyhow::Error` with that message.
+
+- [ ] **Step 2: Run tests**
+
+Run: `cargo test -p clash policy_loader`
+Expected: PASS (migrate tests still call the renamed function; other tests now exercise the error path).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add clash/src/policy_loader.rs clash/src/cmd/policy.rs
+git commit -m "refactor(policy): gate legacy policy.json parsing behind migrate"
+```
+
+---
+
+### Task B2: Discovery — drop `policy.json` lookup
+
+**Files:**
+- Modify: `clash/src/settings/discovery.rs:141-180` (the `.json`-preferring discovery helpers)
+- Test: `clash/src/settings/discovery.rs` (adjust existing tests)
+
+- [ ] **Step 1: Write the failing test**. Add to the existing test module in `discovery.rs`:
+
+```rust
+#[test]
+fn discovery_ignores_policy_json() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(dir.path().join("policy.json"), "{}").unwrap();
+    std::fs::write(dir.path().join("policy.star"), "policy(\"x\", {default(): deny()})").unwrap();
+    let found = discover_in(dir.path()).unwrap();
+    assert!(found.ends_with("policy.star"));
+}
+
+#[test]
+fn discovery_errors_on_lone_policy_json() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(dir.path().join("policy.json"), "{}").unwrap();
+    let err = discover_in(dir.path()).unwrap_err();
+    assert!(format!("{err:#}").contains("policy migrate"));
+}
+```
+
+(Rename `discover_in` to whatever the actual helper is.)
+
+- [ ] **Step 2: Run tests — expect fail**
+
+Run: `cargo test -p clash discovery`
+Expected: first test passes today (wrong reason — picks `.json`), second fails.
+
+- [ ] **Step 3: Modify `discovery.rs`** — in the helper currently at line 163 (`Return policy.json if it exists…`): always return `policy.star`. If only `policy.json` exists, return `Err` with the migrate pointer.
+
+- [ ] **Step 4: Update doc comments** (lines 14, 16, 141, 152, 163, 218) — remove `.json` references.
+
+- [ ] **Step 5: Run tests — expect pass**
+
+Run: `cargo test -p clash discovery`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add clash/src/settings/discovery.rs
+git commit -m "feat(settings): drop policy.json discovery; starlark is the only source format"
+```
+
+---
+
+### Task B3: `cmd/policy.rs` — `.star`-only for show/validate/check/allow/deny/remove
+
+**Files:**
+- Modify: `clash/src/cmd/policy.rs`
+
+- [ ] **Step 1: Grep for JSON source handling** in `cmd/policy.rs`:
+
+Run: `rg -n '\.json|Json' clash/src/cmd/policy.rs`
+
+For each hit in a non-`migrate` subcommand, replace with the `.star` path. Any write-to-JSON codepath (e.g., `write_policy_json`) is deleted. `allow`/`deny`/`remove` mutate `.star` files through `clash_starlark::codegen::mutate` (already the primary path — confirm by reading current code).
+
+- [ ] **Step 2: Update clester scripts** under `clester/tests/scripts/` that exercise `clash policy show/validate/check/allow/deny/remove` against `.json` fixtures. Migrate fixtures to `.star` using the target shape.
+
+- [ ] **Step 3: Run tests**
+
+Run: `just check && just clester`
+Expected: PASS. If clester scripts reference `.json` files in assertions, update them.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add clash/src/cmd/policy.rs clester/tests/scripts/
+git commit -m "feat(cmd/policy): require .star for all non-migrate subcommands"
+```
+
+---
+
+### Task B4: `cmd/fmt.rs` — drop JSON formatting
+
+**Files:**
+- Modify: `clash/src/cmd/fmt.rs`
+
+- [ ] **Step 1: Delete the JSON branch.** `clash fmt` now handles `.star` only. If invoked on a `.json` file, print the migrate pointer and exit non-zero.
+
+- [ ] **Step 2: Run tests**
+
+Run: `cargo test -p clash cmd::fmt && just clester`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add clash/src/cmd/fmt.rs
+git commit -m "feat(cmd/fmt): starlark-only formatter"
+```
+
+---
+
+### Task B5: `cmd/init.rs` — scaffold `.star` only; `cmd/import_settings.rs` — emit `.star`
+
+**Files:**
+- Modify: `clash/src/cmd/init.rs`
+- Modify: `clash/src/cmd/import_settings.rs`
+
+- [ ] **Step 1:** In `init.rs`, remove any code that writes `policy.json` as part of initialization. The scaffolded file is always `policy.star` in the new tree shape.
+
+- [ ] **Step 2:** In `import_settings.rs`, remove the JSON output branch. Import always emits `.star`. The generator for `.star` should produce the new shape (typed root keys).
+
+- [ ] **Step 3:** Run tests
+
+Run: `just check && just clester`
+Expected: PASS. Update any clester scripts that asserted on JSON output of init/import.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add clash/src/cmd/init.rs clash/src/cmd/import_settings.rs
+git commit -m "feat(cmd): init and import_settings emit .star only"
+```
+
+---
+
+### Task B6: TUI — drop any policy.json affordance
+
+**Files:**
+- Modify: `clash/src/tui/mod.rs`, `clash/src/tui/inline_form.rs`
+
+- [ ] **Step 1:** `rg -n 'policy\.json' clash/src/tui/` to find callsites. Each is either (a) opening `.json` for edit — delete, the TUI edits `.star`; (b) a label mentioning "policy.json" — update to "policy.star".
+
+- [ ] **Step 2:** Run tests
+
+Run: `cargo test -p clash tui`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add clash/src/tui/
+git commit -m "refactor(tui): remove policy.json edit path"
+```
+
+---
+
+### Task B7: Sweep remaining callsites
+
+**Files:**
+- Modify: `clash/src/ecosystem.rs`, `clash/src/shell_cmd.rs`, `clash/src/audit.rs`, `clash/src/cmd/session.rs`, `clash/src/test_utils.rs`
+
+- [ ] **Step 1:** `rg -n 'policy\.json' clash/src/` — for each remaining hit outside `cmd/policy.rs` (migrate path), replace with `.star` or with the migrate-pointer error.
+
+- [ ] **Step 2:** `rg -n 'policy\.json' clester/` — update all clester fixtures.
+
+- [ ] **Step 3:** Run full suite
+
+Run: `just ci`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add -A
+git commit -m "refactor: drop remaining policy.json references outside migrate"
+```
+
+---
+
+### Task B8: `clash policy migrate` — emit new-shape `.star`
+
+**Files:**
+- Modify: `clash/src/cmd/policy.rs` (migrate subcommand)
+- Modify: `clash/src/policy_gen/` (if migrate uses the PolicyBuilder pipeline)
+- Test: clester script `clester/tests/scripts/policy-migrate-new-shape.yaml` (new)
+
+- [ ] **Step 1: Write a new clester script** that:
+  1. Creates a legacy `policy.json` with a few tool rules, a filesystem rule, and a network domain.
+  2. Runs `clash policy migrate`.
+  3. Asserts the resulting `.star` contains `tool("Bash")`, `path(`, `domain(`, and `default()`.
+  4. Asserts the resulting `.star` loads successfully via `clash policy validate`.
+
+- [ ] **Step 2: Run clester — expect fail**
+
+Run: `just clester -- policy-migrate-new-shape`
+Expected: FAIL (migrate still emits old-shape `.star`).
+
+- [ ] **Step 3: Update the migrate emitter.** Find the writer (likely `clash/src/policy_gen/` or `clash_starlark/src/codegen/from_manifest.rs:235`). It currently emits bare string tool keys and builder-style `sandbox(..., fs=..., net=...)`. Change it to emit:
+  - `policy("name", { default(): ..., mode(...): ..., tool("..."): ... })`
+  - `sandbox("name", { default(): ..., path("..."): ..., glob("..."): ..., domain("..."): ..., localhost(): ... })`
+
+- [ ] **Step 4: Run clester — expect pass**
+
+Run: `just clester -- policy-migrate-new-shape`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add clash/src/cmd/policy.rs clash/src/policy_gen/ clash_starlark/src/codegen/ clester/tests/scripts/policy-migrate-new-shape.yaml
+git commit -m "feat(policy/migrate): emit unified tree shape with typed root keys"
+```
+
+---
+
+### Task B9: Documentation sweep
+
+**Files:**
+- Modify: `README.md`, `docs/**`, `site/**`, `AGENTS.md:53`
+
+- [ ] **Step 1:** `rg -n 'policy\.json' README.md docs/ site/ AGENTS.md` and update each hit. Leave mentions that are explicitly describing the migrate path.
+
+- [ ] **Step 2:** Update `AGENTS.md` line 53 from:
+
+  > Policy files use `.json` or `.star` extension (`.json` preferred when both exist)
+
+  to:
+
+  > Policy files use the `.star` extension. Legacy `policy.json` files are converted with `clash policy migrate`.
+
+- [ ] **Step 3:** Update `docs/` examples and the site policy documentation to show the new unified tree shape (`default()`, `tool()`, `path()`, `domain()`, etc.). `doc=` should appear in every example.
+
+- [ ] **Step 4:** Build the site
+
+Run: `cd site && bun install && bun run build`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add README.md docs/ site/ AGENTS.md
+git commit -m "docs: document unified policy/sandbox tree shape; drop policy.json references"
+```
+
+---
+
+## Final verification
+
+- [ ] **Step 1:** Full CI
+
+Run: `just ci`
+Expected: PASS.
+
+- [ ] **Step 2:** Smoke test the migrate path end-to-end
+
+Run:
+```bash
+mkdir -p /tmp/clash-migrate-test && cd /tmp/clash-migrate-test
+cat > policy.json <<'EOF'
+{"default_effect":"deny","rules":[]}
+EOF
+clash policy migrate
+cat policy.star
+clash policy validate
+```
+Expected: migrate produces a `.star` file containing `default()`, loads clean.
+
+- [ ] **Step 3:** Smoke test a unified sandbox
+
+Create an example using the new shape and confirm `clash sandbox check` evaluates it correctly.
+
+- [ ] **Step 4: Final review commit / squash** (if using subagent-driven-development, the reviewer does this).
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage check:**
+  - §"Target API" signatures — Tasks A3 (sandbox), A4 (policy).
+  - §"Uniform root-key rule" — Task A2.
+  - §"Decision-tree shape" examples — exercised by tests in A3/A4; made canonical in A5.
+  - §"Nested bare strings" — preserved by keeping `classify_nested_key` in A2.
+  - §"Cultural: doc= load-bearing" — Task A5 rewrites examples with `doc=`.
+  - §"policy.json removal — What is removed" items 1–8 — Tasks B1–B7.
+  - §"What stays" — Task B1 (migrate fence), untouched JSON IR (no task — correct), `_from_claude_settings` (untouched — correct).
+  - §"User-facing error" — Tasks B1, B2, B4.
+  - §"Documentation sweep" — Task B9.
+  - §"Error messages" — Task A2 (typed-root) and Task A3 (legacy `fs=`/`net=`).
+
+- **Placeholder scan:** No "TBD"/"similar to"/"add error handling" placeholders. Every code block shows the actual code. Where a helper's current shape isn't fully verified (`discover_in`, `PolicyRegistration` fields), the task explicitly instructs reading the current code and adjusting test assertions to match — this is an intentional signal, not a placeholder.
+
+- **Type consistency:** `MatchKeyKind` variants and `classify_root_key` / `classify_nested_key` names are used consistently across A2, A3, A4. `sandbox_tree_impl` is referenced in both A3 and A4 by the same name. `_sandbox_impl` is the global name in both `globals.rs` and `std.star`.

--- a/docs/superpowers/specs/2026-04-06-unify-policy-and-sandbox-design.md
+++ b/docs/superpowers/specs/2026-04-06-unify-policy-and-sandbox-design.md
@@ -1,0 +1,222 @@
+# Unify `policy()` and `sandbox()` + remove `policy.json`
+
+**Date:** 2026-04-06
+**Status:** Design approved, ready for implementation plan
+
+## Motivation
+
+`policy()` and `sandbox()` currently have divergent surfaces. `policy()` takes a
+decision-tree dict; `sandbox()` takes separate `fs=` and `net=` kwargs. The
+asymmetry is historical, not principled — both are really matcher→effect maps
+over different capability domains. Unifying their surface makes the DSL
+smaller, easier to teach, and easier to document.
+
+Separately, clash still supports user-authored `policy.json` as a source format
+alongside `.star`. Maintaining two source formats is tech debt with no
+corresponding user benefit now that `.star` is the primary format.
+
+## Goals
+
+1. Make `policy()` and `sandbox()` take the same shape: `(name, tree, *, ...optional kwargs)`.
+2. Express a sandbox as a single decision-tree dict, the same way a policy is.
+3. Enforce one uniform rule for root-level keys in any tree: **typed constructors only**.
+4. Remove `policy.json` as a user-authored source format. Keep the JSON IR and
+   keep `clash policy migrate` as the one-way bridge for users with legacy files.
+
+## Non-goals
+
+- Unifying the policy and sandbox *evaluators* internally. Shared surface,
+  separate guts — the domains are semantically distinct.
+- Removing Claude Code `settings.json` support (`_from_claude_settings()`).
+  That reads a different file for a different purpose and is unaffected.
+- Removing the JSON IR. It remains the compiled representation that `.star`
+  produces and the eval layer consumes.
+- Scheduling removal of `clash policy migrate`. It stays indefinitely as a
+  humane offramp for users who upgrade after a long gap.
+
+## Target API
+
+```python
+policy(name, tree, *, default="deny", default_sandbox=None, doc=None)
+sandbox(name, tree, *, default="deny", doc=None)
+```
+
+- `name` and `tree` are the only required positional arguments.
+- `tree` is a decision-tree dict in both cases.
+- `doc` is the optional description kwarg, consistent across both.
+- `default` is an optional kwarg on both, preserving today's behavior.
+- `default_sandbox` remains on `policy()` only.
+- `sandbox()` no longer accepts `fs=` or `net=`. These kwargs are removed
+  entirely, with no deprecation shim. Existing callers get a clear error at
+  parse time pointing to the new shape.
+
+## Decision-tree shape
+
+Both `policy()` and `sandbox()` take a flat dict whose keys are *typed
+constructors*. The constructor determines the capability domain and the
+grammar of what may appear below it.
+
+### Uniform root-key rule
+
+**At the root of any decision tree, every key must be a typed constructor.**
+Bare strings are only allowed *inside* a nested dict, where the enclosing
+constructor has already established the domain.
+
+Root constructors:
+
+- `default()` — fallback effect for the tree.
+- `mode("plan")` / `mode("edit")` / ... — policy mode selector. Below: tool keys.
+- `tool("Bash")` / `tool("Edit")` / ... — policy tool selector. Below: argument matchers.
+- `path("$PWD")` — sandbox filesystem literal path (env-var expansion applies). Below: nested subpath dict (strings OK here).
+- `glob("$HOME/**")` — sandbox filesystem glob.
+- `domain("github.com")` — sandbox network domain rule.
+- `localhost(port=...)` — sandbox localhost rule.
+
+The grammar becomes self-documenting: `mode(...)` dictates "tool selector
+below," `tool(...)` dictates "arguments below," `path(...)` dictates "subpath
+scope below."
+
+### Example: sandbox
+
+```python
+sandbox("rust-dev",
+    {
+        default(): deny(),
+        path("$PWD"): allow("rwc"),
+        path("$HOME"): {
+            ".ssh": allow("r"),
+            ".cargo": allow("rwc"),
+        },
+        glob("/tmp/**"): allow("rwc"),
+        domain("crates.io"): allow(),
+        domain("github.com"): allow(),
+        localhost(8080): allow(),
+    },
+    doc="Build and test Rust projects with access to cargo registries.",
+)
+```
+
+### Example: policy
+
+```python
+policy("default",
+    {
+        default(): deny(),
+        mode("plan"): allow(sandbox=plan_box),
+        mode("edit"): allow(sandbox=edit_box),
+        tool("Bash"): {
+            "git push": deny(),
+            "git *": allow(),
+        },
+        tool("Edit"): allow(),
+    },
+    default_sandbox=plan_box,
+    doc="Default clash policy.",
+)
+```
+
+### Why typed roots
+
+Three overlapping reasons:
+
+1. **No hidden sub-dialects in the string keyspace.** Bare strings at the root
+   would force the reader (and the parser) to disambiguate between literal
+   paths, globs, hostnames, and tool names based on content sniffing. Typed
+   constructors eliminate the ambiguity.
+2. **Visual honesty.** Every root line announces its domain. `domain("github.com")`
+   and `path("github.com")` cannot be confused at a glance. `glob("$HOME/**")`
+   and `path("$HOME/bin")` cannot be confused at a glance.
+3. **Deliberation.** A `glob()` grants more than a `path()`. An author who
+   types `glob(...)` performs the larger grant explicitly. The small friction
+   is appropriate friction.
+
+### Nested bare strings
+
+Inside a nested dict value, bare strings are fine:
+
+```python
+path("$HOME"): {".ssh": allow("r"), ".cargo": allow("rwc")}
+```
+
+The enclosing `path()` has established that the domain is filesystem and the
+scope is `$HOME`, so nested strings are unambiguous subpath literals.
+
+### Cultural: `doc=` is load-bearing
+
+Every stdlib example updates to include a meaningful `doc=` on both `policy()`
+and `sandbox()`. The field is not enforced, but it is culturally elevated: a
+sandbox without a `doc` is a sandbox whose author has not explained themselves,
+and the examples should model the expected norm.
+
+## `policy.json` removal
+
+### What is removed
+
+1. **Discovery** (`clash/src/settings/discovery.rs`) — stop looking for `policy.json`.
+2. **Loader** (`clash/src/policy_loader.rs`) — drop the JSON source branch. `.star` → JSON IR remains.
+3. **TUI edit** (`clash/src/tui/`) — remove any "edit policy.json" affordance.
+4. **`clash fmt`** (`clash/src/cmd/fmt.rs`) — drop JSON formatting.
+5. **`clash policy` subcommands** (`clash/src/cmd/policy.rs`) — `show`, `validate`, `check`, `allow`, `deny`, `remove` operate on `.star` exclusively. Any JSON-writing path is deleted.
+6. **`clash init`** (`clash/src/cmd/init.rs`) — scaffolds `.star` only.
+7. **`ecosystem.rs`, `shell_cmd.rs`, `audit.rs`, `cmd/session.rs`, `cmd/import_settings.rs`** — targeted sweep to drop JSON source handling.
+8. **Tests** — fixtures authoring `policy.json` are migrated to `.star`, or moved under the migrate test suite if they test legacy behavior.
+
+### What stays
+
+- **`clash policy migrate`** — the only remaining reader of legacy user
+  `policy.json`. Emits new-shape `.star` with uniform typed constructors.
+  No scheduled removal.
+- **JSON IR** — unchanged.
+- **`_from_claude_settings()`** — unrelated; reads Claude Code `settings.json`.
+
+### User-facing error
+
+If a user has a `policy.json` in a location where clash used to look, clash
+emits a helpful pointer rather than silently skipping:
+
+> Legacy `policy.json` detected at `<path>`. Run `clash policy migrate` to
+> convert to `.star` (the only supported format).
+
+### Documentation sweep
+
+- `README.md`
+- `docs/`
+- `site/` content
+- `AGENTS.md` (line 53: "Policy files use `.json` or `.star` extension" → `.star` only)
+
+All updated to reflect `.star` as the sole source format.
+
+## Migration
+
+- `clash policy migrate` is updated to emit the new decision-tree shape with
+  uniform typed constructors — both when converting legacy `policy.json` and
+  when converting older `.star` files that used `fs=`/`net=` kwargs or bare
+  string root keys.
+- Stdlib examples in `examples/*.star` and `clash/src/default_policy.star` are
+  rewritten by hand to the new shape and committed as part of the
+  implementation.
+- Clester scripts that construct policies inline are updated.
+
+## Error messages
+
+Two parse-time errors matter most. Both should be instructive, not punitive:
+
+1. **Bare string at root of a tree:**
+   > Root keys in a policy or sandbox tree must use a typed constructor
+   > (`path(...)`, `glob(...)`, `domain(...)`, `tool(...)`, `mode(...)`,
+   > `default()`). Got a bare string key `"..."`. If you meant a filesystem
+   > path, use `path("...")`.
+
+2. **`sandbox(fs=..., net=...)`:**
+   > The `fs=` and `net=` arguments to `sandbox()` have been removed.
+   > Sandboxes now take a single decision-tree dict, the same shape as
+   > `policy()`. See `docs/sandbox.md` for the new grammar, or run
+   > `clash policy migrate` to convert existing files automatically.
+
+## Out of scope
+
+- Changing the underlying JSON IR or the eval layer.
+- Any refactor of `clash_starlark/src/when.rs` beyond what is needed to parse
+  the new root-key rule and the unified sandbox tree shape.
+- Any change to how sandboxes are *executed* — this is purely a source-format
+  and parse-time change.

--- a/site/pages/reference.md
+++ b/site/pages/reference.md
@@ -6,7 +6,7 @@ permalink: /reference/
 ---
 
 <h1 class="page-title">Reference</h1>
-<p class="page-desc">Everything you need to write clash policies. Use Starlark (<code>.star</code>) for expressive, hand-crafted policies. Use <code>policy.json</code> for CLI-driven and tool-managed rules.</p>
+<p class="page-desc">Everything you need to write clash policies. Policies are written in Starlark (<code>.star</code>), the only source format clash loads.</p>
 
 ## Effects
 
@@ -255,26 +255,20 @@ policy("default", merge(
 
 Starlark `load()` imports values from other `.star` files. All composition (function calls, `merge()`, imports) resolves at compile time.
 
-### Two formats: `.star` for humans, `.json` for tools
+### One format: `.star` for everything
 
-Clash supports two policy formats that serve different purposes:
+Clash policies are written in Starlark. The same `.star` file is edited by humans and mutated by CLI commands like `clash policy allow`, `clash policy deny`, and `clash policy remove`, which round-trip the file using a Starlark AST formatter so hand-written structure is preserved.
 
-**Starlark (`.star`)** is for humans. Write expressive policies with functions, variables, imports, and composition. When you want to craft a nuanced policy — conditionals, shared rule sets across projects, sandbox builders — this is the format to use.
+#### Migrating from `policy.json`
 
-**JSON (`policy.json`)** is for tools. CLI commands like `clash policy allow`, `clash policy deny`, and `clash policy remove` read and write `policy.json` directly. It's a machine-readable format designed to be mutated programmatically — by the CLI, by scripts, or by agents themselves.
+Earlier versions of clash supported a JSON-based `policy.json` format. To migrate:
 
-```json
-{
-  "default_effect": "deny",
-  "includes": [
-    { "path": "@clash//builtin.star" },
-    { "path": "team-rules.star" }
-  ],
-  "tree": []
-}
+```sh
+clash policy convert            # writes policy.star alongside policy.json
+clash policy convert --replace  # also removes the old policy.json
 ```
 
-The `includes` field lets `policy.json` pull in `.star` files, so you can combine CLI-managed rules with hand-written Starlark. Included files are compiled and merged at load time, with inline `tree` rules taking precedence. When both `.json` and `.star` exist at the same level, `.json` wins.
+After conversion, only `policy.star` is loaded.
 
 ### Updating policies
 
@@ -509,7 +503,7 @@ policy("default", {
 
 ## Policy schema (JSON IR)
 
-JSON IR schema for compiled clash policies. Policies are authored as Starlark (.star) files or managed via `policy.json`, and compiled to this format.
+JSON IR schema for compiled clash policies. Policies are authored as Starlark (`.star`) files and compiled to this format.
 
 ### Document structure
 


### PR DESCRIPTION
## Summary

Removes `policy.json` as a user-authored source format. `.star` is now the only supported format. The legacy JSON parser is fenced behind `clash policy convert`, which remains as the one-way migration bridge for users with legacy files.

Spec: `docs/superpowers/specs/2026-04-06-unify-policy-and-sandbox-design.md`
Plan: `docs/superpowers/plans/2026-04-06-unify-policy-and-sandbox.md`

Companion PR (independent): #444 unifies the `policy()`/`sandbox()` DSL surface.

## What's removed

- **Discovery** (`clash/src/settings/discovery.rs`) — `policy.json` lookup is gone. Discovery returns `.star` only; if only `policy.json` exists in a discovery dir, callers get a friendly `legacy_json_error` pointing to `clash policy convert`.
- **Loader** (`clash/src/policy_loader.rs`) — `load_json_policy` renamed to `migrate_load_json_policy`, marked `pub(crate)`, only reachable from the convert bridge. Dead `read_manifest` / `write_manifest` helpers deleted.
- **`clash policy` subcommands** — `show`, `validate`, `check`, `allow`, `deny`, `remove` all require `.star`. JSON-mutation paths in `apply_mutation` deleted along with the now-dead `build_rule_node` helper.
- **`clash fmt`** — `.star` only. Hands `.json` files back as the legacy error.
- **`clash init` / `import_settings`** — scaffold and emit `.star` only. `ensure_policy_at` writes the embedded `default_policy.star` instead of compiling to JSON.
- **TUI** — `policy.json` edit affordances and the JSON save fallback removed. `App::new_star` is the surviving entry point.
- **Settings loader** — `ensure_policy_at` now writes `policy.star` defaults.
- **Doc sweep** — `README.md`, `AGENTS.md`, `docs/policy-guide.md`, `site/pages/reference.md`, `clash-plugin/README.md` all updated.

## What stays

- **`clash policy convert`** (`cmd::policy::handle_convert`) — the one-way migration bridge. Reads legacy `policy.json` (and its `includes:`) and emits `.star`. Smoke-tested end-to-end during implementation.
- **JSON IR** — unchanged. `.star` files compile to JSON internally and the eval layer still consumes JSON.
- **`PolicyManifest` type** — repurposed: doc comments now describe it as the JSON shape produced by evaluating a `.star` policy (still also used by the migrate/convert path).
- **`_from_claude_settings()`** — unrelated; reads Claude Code `settings.json`.

## User-facing error

If `policy.json` is encountered anywhere outside `clash policy convert`:

> Legacy `policy.json` detected at `<path>`. Run `clash policy migrate` to convert to `.star` (the only supported format).

(Wired through a single helper `policy_loader::legacy_json_error` so the message is consistent everywhere.)

## Test plan

- [x] `cargo test -p clash` — 607 passing, 1 pre-existing unrelated failure (`resolve_symlinks_follows_real_symlink`, sandbox-environment permissions on `/tmp` symlinks)
- [x] Manual smoke test of `clash policy convert` against a legacy `policy.json` → emits valid `policy.star`, `clash policy validate` accepts the result
- [ ] Reviewer to spot-check the `legacy_json_error` message wording
- [ ] Reviewer to verify `clester` doesn't reference removed code paths (clester intentionally not run during implementation per local install hygiene)

## Notes

- The convert subcommand expects the full `PolicyManifest` shape (`default_effect`, `default_sandbox`, `sandboxes`, `tree`). Minimal manifests like `{"default_effect":"deny","rules":[]}` will fail to parse — pre-existing behavior, not introduced here, but worth flagging if convert UX should be relaxed.
- Stream A's unified DSL syntax (`tool()`, `path()`, `default()`) is intentionally NOT used in this PR's scaffolds, examples, or doc snippets — those will land in #444. Both PRs are independent and can be merged in either order.
